### PR TITLE
Reworked connections to 74*165s to put the sense pins

### DIFF
--- a/PCB_files/Eagle_v0.2/easy_bee_counter.brd
+++ b/PCB_files/Eagle_v0.2/easy_bee_counter.brd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="9.4.2">
+<eagle version="9.6.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="yes"/>
@@ -37,7 +37,7 @@
 <layer number="26" name="bNames" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="27" name="tValues" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="28" name="bValues" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="29" name="tStop" color="7" fill="3" visible="no" active="yes"/>
+<layer number="29" name="tStop" color="7" fill="3" visible="yes" active="yes"/>
 <layer number="30" name="bStop" color="7" fill="6" visible="no" active="yes"/>
 <layer number="31" name="tCream" color="7" fill="4" visible="no" active="yes"/>
 <layer number="32" name="bCream" color="7" fill="5" visible="no" active="yes"/>
@@ -173,13 +173,13 @@
 </layers>
 <board>
 <plain>
-<wire x1="446.786" y1="31.75" x2="73.396475" y2="31.75" width="0" layer="20"/>
-<wire x1="446.786" y1="31.75" x2="446.786" y2="-0.254" width="0" layer="20"/>
+<wire x1="446.786" y1="35.56" x2="73.396475" y2="35.56" width="0" layer="20"/>
+<wire x1="446.786" y1="35.56" x2="446.786" y2="-0.254" width="0" layer="20"/>
 <wire x1="446.786" y1="-0.254" x2="444.246" y2="-2.794" width="0" layer="20" curve="-90"/>
 <wire x1="444.246" y1="-2.794" x2="75.936475" y2="-2.794" width="0" layer="20"/>
 <wire x1="75.936475" y1="-2.794" x2="73.396475" y2="-0.254" width="0" layer="20" curve="-90"/>
-<wire x1="73.396475" y1="-0.254" x2="73.396475" y2="31.75" width="0" layer="20"/>
-<text x="143.8656" y="11.049" size="1.6764" layer="21" ratio="15">1</text>
+<wire x1="73.396475" y1="-0.254" x2="73.396475" y2="35.56" width="0" layer="20"/>
+<text x="143.8656" y="-1.016" size="1.6764" layer="21" ratio="15">1</text>
 <text x="157.099" y="-1.2192" size="1.6764" layer="21" ratio="15">2</text>
 <text x="170.6372" y="-1.27" size="1.6764" layer="21" ratio="15">3</text>
 <text x="182.626" y="-1.27" size="1.6764" layer="21" ratio="15">4</text>
@@ -237,24 +237,21 @@ REG</text>
 <text x="84.9884" y="26.162" size="1.27" layer="21" ratio="15" rot="R180">GND</text>
 <text x="83.9724" y="20.955" size="1.27" layer="21" ratio="15" rot="R180">5V</text>
 <text x="140.4874" y="11.049" size="1.27" layer="21" ratio="15" rot="R180">100K SIP</text>
-<text x="195.3514" y="9.906" size="1.27" layer="21" ratio="15" rot="R180">100K SIP</text>
-<text x="246.9134" y="9.271" size="1.27" layer="21" ratio="15" rot="R180">100K SIP</text>
-<text x="299.7454" y="9.271" size="1.27" layer="21" ratio="15" rot="R180">100K SIP</text>
-<text x="353.8474" y="9.271" size="1.27" layer="21" ratio="15" rot="R180">100K SIP</text>
+<text x="295.2496" y="18.034" size="1.27" layer="21" ratio="15">100K SIP</text>
+<text x="351.6376" y="18.034" size="1.27" layer="21" ratio="15">100K SIP</text>
 <text x="404.0124" y="9.144" size="1.27" layer="21" ratio="15" rot="R180">100K SIP</text>
 <text x="437.6674" y="6.858" size="1.27" layer="21" ratio="15" rot="R180">74HC165 Shift-IN</text>
 <text x="385.5974" y="6.858" size="1.27" layer="21" ratio="15" rot="R180">74HC165 Shift-IN</text>
 <text x="332.8924" y="6.858" size="1.27" layer="21" ratio="15" rot="R180">74HC165 Shift-IN</text>
-<text x="280.1874" y="6.858" size="1.27" layer="21" ratio="15" rot="R180">74HC165 Shift-IN</text>
+<text x="265.5824" y="6.858" size="1.27" layer="21" ratio="15" rot="R180">74HC165 Shift-IN</text>
 <text x="226.2124" y="6.858" size="1.27" layer="21" ratio="15" rot="R180">74HC165 Shift-IN</text>
 <text x="172.8724" y="6.858" size="1.27" layer="21" ratio="15" rot="R180">74HC165 Shift-IN</text>
-<text x="185.5724" y="28.829" size="1.27" layer="21" ratio="15" rot="R180">22R SIP</text>
-<text x="390.271" y="7.1374" size="1.27" layer="21" ratio="15" rot="R270">100nF</text>
+<text x="177.6476" y="18.796" size="1.27" layer="21" ratio="15">22R SIP</text>
 <text x="442.976" y="11.5824" size="1.27" layer="21" ratio="15" rot="R270">100nF</text>
-<text x="337.566" y="7.1374" size="1.27" layer="21" ratio="15" rot="R270">100nF</text>
-<text x="284.861" y="7.7724" size="1.27" layer="21" ratio="15" rot="R270">100nF</text>
-<text x="230.886" y="7.1374" size="1.27" layer="21" ratio="15" rot="R270">100nF</text>
-<text x="178.181" y="7.7724" size="1.27" layer="21" ratio="15" rot="R270">100nF</text>
+<text x="342.1126" y="7.366" size="1.27" layer="21" ratio="15">100nF</text>
+<text x="288.1376" y="7.366" size="1.27" layer="21" ratio="15">100nF</text>
+<text x="202.4126" y="7.366" size="1.27" layer="21" ratio="15">100nF</text>
+<text x="179.959" y="1.7526" size="1.27" layer="21" ratio="15" rot="R90">100nF</text>
 <text x="122.174" y="23.0886" size="1.27" layer="21" ratio="15" rot="R90" align="center">N-CH 
 Gates 1-12</text>
 <text x="136.271" y="23.5966" size="1.27" layer="21" ratio="15" rot="R90" align="center">Gates 13-24</text>
@@ -265,236 +262,215 @@ Gates 1-12</text>
 <text x="147.2946" y="-2.794" size="1.27" layer="21" ratio="15">SCL</text>
 <text x="134.5184" y="-1.524" size="1.27" layer="21" ratio="15" rot="R180">3V</text>
 <text x="129.0574" y="-1.524" size="1.27" layer="21" ratio="15" rot="R180">A4</text>
-<text x="261.7724" y="28.829" size="1.27" layer="21" ratio="15" rot="R180">22R SIP</text>
-<text x="312.5724" y="28.829" size="1.27" layer="21" ratio="15" rot="R180">22R SIP</text>
-<text x="414.1724" y="28.829" size="1.27" layer="21" ratio="15" rot="R180">22R SIP</text>
+<text x="272.2626" y="18.161" size="1.27" layer="21" ratio="15">22R SIP</text>
+<text x="312.5724" y="25.654" size="1.27" layer="21" ratio="15" rot="R180">22R SIP</text>
+<text x="414.1724" y="25.654" size="1.27" layer="21" ratio="15" rot="R180">22R SIP</text>
 <text x="98.7806" y="29.972" size="1.016" layer="21" ratio="15">I</text>
 <text x="101.3206" y="29.972" size="1.016" layer="21" ratio="15">G</text>
 <text x="103.8606" y="29.972" size="1.016" layer="21" ratio="15">O</text>
 <text x="130.175" y="25.6286" size="1.016" layer="21" ratio="15" rot="R90">G</text>
 <text x="130.175" y="23.0886" size="1.016" layer="21" ratio="15" rot="R90">D</text>
 <text x="130.175" y="20.5486" size="1.016" layer="21" ratio="15" rot="R90">S</text>
-<text x="141.351" y="22.733" size="1.143" layer="22" ratio="15" rot="MR0">A</text>
-<text x="154.686" y="23.241" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="167.386" y="22.479" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="180.086" y="23.114" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="192.786" y="22.987" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="204.978" y="22.987" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="218.313" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="230.378" y="23.368" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="243.205" y="23.368" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="255.778" y="23.241" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="268.478" y="23.241" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="281.178" y="23.114" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="293.878" y="23.114" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="306.578" y="22.987" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="319.278" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="331.978" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="344.678" y="22.733" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="357.378" y="23.368" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="370.078" y="23.368" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="382.778" y="23.241" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="395.478" y="23.114" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="408.178" y="22.987" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="420.878" y="22.987" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="433.578" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
-<text x="441.198" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="441.198" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="433.705" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="441.198" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="441.198" y="16.764" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="433.451" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="433.578" y="16.891" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="428.498" y="22.987" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="428.498" y="21.082" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="421.005" y="18.796" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="428.498" y="18.796" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="428.498" y="16.891" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="420.751" y="21.082" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="420.878" y="17.018" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="415.798" y="22.987" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="415.798" y="21.082" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="408.305" y="18.796" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="415.798" y="18.796" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="415.798" y="16.891" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="408.051" y="21.082" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="408.178" y="17.018" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="403.098" y="22.987" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="403.098" y="21.082" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="395.605" y="18.796" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="403.098" y="18.796" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="403.098" y="16.891" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="395.351" y="21.082" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="395.478" y="17.018" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="390.398" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="390.398" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="382.905" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="390.398" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="390.398" y="16.764" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="382.651" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="382.778" y="16.891" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="377.698" y="23.241" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="377.698" y="21.336" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="370.205" y="19.05" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="377.698" y="19.05" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="377.698" y="17.145" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="369.951" y="21.336" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="370.078" y="17.272" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="364.871" y="23.368" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="364.871" y="21.463" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="357.378" y="19.177" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="364.871" y="19.177" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="364.871" y="17.272" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="357.251" y="21.463" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="357.251" y="17.399" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="352.171" y="22.733" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="352.171" y="20.828" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="344.678" y="18.542" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="352.171" y="18.542" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="352.171" y="16.637" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="344.551" y="20.828" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="344.551" y="16.764" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="339.598" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="339.598" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="332.105" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="339.598" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="339.598" y="16.764" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="331.851" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="331.978" y="16.891" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="326.898" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="326.898" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="319.405" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="326.898" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="326.898" y="16.764" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="319.151" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="319.278" y="16.891" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="314.198" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="314.198" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="306.705" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="314.198" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="314.198" y="16.764" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="306.451" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="306.578" y="16.891" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="301.498" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="301.498" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="294.005" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="301.498" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="301.498" y="16.764" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="293.751" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="293.878" y="16.891" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="288.798" y="23.114" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="288.798" y="21.209" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="281.305" y="18.923" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="288.798" y="18.923" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="288.798" y="17.018" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="281.051" y="21.209" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="281.178" y="17.145" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="276.098" y="23.495" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="276.098" y="21.59" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="268.605" y="19.304" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="276.098" y="19.304" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="276.098" y="17.399" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="268.351" y="21.59" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="268.478" y="17.526" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="263.398" y="23.495" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="263.398" y="21.59" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="255.905" y="19.304" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="263.398" y="19.304" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="263.398" y="17.399" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="255.651" y="21.59" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="255.778" y="17.526" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="250.698" y="23.495" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="250.698" y="21.59" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="243.205" y="19.304" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="250.698" y="19.304" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="250.698" y="17.399" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="242.951" y="21.59" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="243.078" y="17.526" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="237.998" y="23.495" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="237.998" y="21.59" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="230.505" y="19.304" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="237.998" y="19.304" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="237.998" y="17.399" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="230.251" y="21.59" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="230.378" y="17.526" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="225.933" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="225.933" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="218.44" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="225.933" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="225.933" y="16.764" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="218.186" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="218.313" y="16.891" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="212.598" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="212.598" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="205.105" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="212.598" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="212.598" y="16.764" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="204.851" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="204.978" y="16.891" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="200.533" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="200.533" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="193.04" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="200.533" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="200.533" y="16.764" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="192.786" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="192.913" y="16.891" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="187.833" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="187.833" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="180.34" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="187.833" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="187.833" y="16.764" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="180.086" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="180.213" y="16.891" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="175.133" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="175.133" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="167.64" y="18.034" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="175.133" y="18.669" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="175.133" y="16.764" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="167.386" y="20.955" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="167.513" y="16.256" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="162.306" y="23.368" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="162.306" y="21.463" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="154.813" y="19.177" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="162.306" y="19.177" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="162.306" y="17.272" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="154.559" y="21.463" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="154.686" y="17.399" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="149.098" y="22.606" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="149.098" y="20.701" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="141.605" y="18.415" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="149.098" y="18.415" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
-<text x="149.098" y="16.51" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
-<text x="141.351" y="20.701" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
-<text x="141.478" y="16.637" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="141.351" y="28.321" size="1.143" layer="22" ratio="15" rot="MR0">A</text>
+<text x="154.686" y="28.829" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="167.386" y="28.067" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="180.086" y="28.702" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="192.786" y="28.575" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="204.978" y="28.575" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="218.313" y="28.448" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="230.378" y="28.956" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="243.205" y="28.956" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="255.778" y="28.829" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="268.478" y="28.829" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="281.178" y="28.702" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="293.878" y="28.702" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="306.578" y="28.575" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="319.278" y="28.448" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="331.978" y="28.448" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="344.678" y="28.321" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="357.378" y="28.956" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="370.078" y="28.956" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="382.778" y="28.829" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="395.478" y="28.702" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="408.178" y="28.575" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="420.878" y="28.575" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="433.578" y="28.448" size="1.143" layer="22" ratio="15" rot="MR0">AN</text>
+<text x="441.198" y="28.448" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="441.198" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="433.705" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="441.198" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="441.198" y="22.352" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="433.451" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="433.578" y="22.479" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="428.498" y="28.575" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="428.498" y="26.67" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="421.005" y="24.384" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="428.498" y="24.384" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="428.498" y="22.479" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="420.751" y="26.67" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="420.878" y="22.606" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="415.798" y="28.575" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="415.798" y="26.67" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="408.305" y="24.384" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="415.798" y="24.384" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="415.798" y="22.479" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="408.051" y="26.67" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="408.178" y="22.606" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="403.098" y="28.575" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="403.098" y="26.67" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="395.605" y="24.384" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="403.098" y="24.384" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="403.098" y="22.479" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="395.351" y="26.67" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="395.478" y="22.606" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="390.398" y="28.448" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="390.398" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="382.905" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="390.398" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="390.398" y="22.352" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="382.651" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="382.778" y="22.479" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="377.698" y="28.829" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="377.698" y="26.924" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="370.205" y="24.638" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="377.698" y="24.638" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="377.698" y="22.733" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="369.951" y="26.924" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="370.078" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="364.871" y="28.956" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="364.871" y="27.051" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="357.378" y="24.765" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="364.871" y="24.765" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="364.871" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="357.251" y="27.051" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="357.251" y="22.987" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="352.171" y="28.321" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="352.171" y="26.416" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="344.678" y="24.13" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="352.171" y="24.13" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="352.171" y="22.225" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="344.551" y="26.416" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="344.551" y="22.352" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="339.598" y="28.448" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="339.598" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="332.105" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="339.598" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="339.598" y="22.352" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="331.851" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="331.978" y="22.479" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="326.898" y="28.448" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="326.898" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="319.405" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="326.898" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="326.898" y="22.352" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="319.151" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="319.278" y="22.479" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="314.198" y="28.448" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="314.198" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="306.705" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="314.198" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="314.198" y="22.352" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="306.451" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="306.578" y="22.479" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="301.498" y="28.448" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="301.498" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="294.005" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="301.498" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="301.498" y="22.352" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="293.751" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="293.878" y="22.479" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="288.798" y="28.702" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="288.798" y="26.797" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="281.305" y="24.511" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="288.798" y="24.511" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="288.798" y="22.606" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="281.051" y="26.797" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="281.178" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="276.098" y="29.083" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="276.098" y="27.178" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="268.605" y="24.892" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="276.098" y="24.892" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="276.098" y="22.987" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="268.351" y="27.178" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="268.478" y="23.114" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="263.398" y="29.083" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="263.398" y="27.178" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="255.905" y="24.892" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="263.398" y="24.892" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="263.398" y="22.987" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="255.651" y="27.178" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="255.778" y="23.114" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="250.698" y="29.083" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="250.698" y="27.178" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="243.205" y="24.892" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="250.698" y="24.892" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="250.698" y="22.987" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="242.951" y="27.178" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="243.078" y="23.114" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="237.998" y="29.083" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="237.998" y="27.178" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="230.505" y="24.892" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="237.998" y="24.892" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="237.998" y="22.987" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="230.251" y="27.178" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="230.378" y="23.114" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="225.933" y="28.448" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="225.933" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="218.44" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="225.933" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="225.933" y="22.352" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="218.186" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="218.313" y="22.479" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="212.598" y="28.448" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="212.598" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="205.105" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="212.598" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="212.598" y="22.352" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="204.851" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="204.978" y="22.479" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="200.533" y="28.448" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="200.533" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="193.04" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="200.533" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="200.533" y="22.352" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="192.786" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="192.913" y="22.479" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="187.833" y="28.448" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="187.833" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="180.34" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="187.833" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="187.833" y="22.352" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="180.086" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="180.213" y="22.479" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="175.133" y="28.448" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="175.133" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="167.64" y="23.622" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="175.133" y="24.257" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="175.133" y="22.352" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="167.386" y="26.543" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="167.513" y="21.844" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="162.306" y="28.956" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="162.306" y="27.051" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="154.813" y="24.765" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="162.306" y="24.765" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="162.306" y="22.86" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="154.559" y="27.051" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="154.686" y="22.987" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="149.098" y="28.194" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="149.098" y="26.289" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="141.605" y="24.003" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="149.098" y="24.003" size="1.143" layer="22" ratio="15" rot="MR0">CA</text>
+<text x="149.098" y="22.098" size="1.143" layer="22" ratio="15" rot="MR0">3V</text>
+<text x="141.351" y="26.289" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
+<text x="141.478" y="22.225" size="1.143" layer="22" ratio="15" rot="MR0">EM</text>
 <text x="178.943" y="7.112" size="1.143" layer="22" ratio="15" rot="MR270">3V</text>
 <text x="156.083" y="9.144" size="1.143" layer="22" ratio="15" rot="MR270">3V</text>
-<text x="173.863" y="6.858" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
 <text x="179.07" y="4.445" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
-<text x="231.648" y="7.112" size="1.143" layer="22" ratio="15" rot="MR270">3V</text>
-<text x="208.788" y="9.144" size="1.143" layer="22" ratio="15" rot="MR270">3V</text>
-<text x="226.568" y="6.858" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
-<text x="231.775" y="4.445" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
-<text x="285.623" y="7.112" size="1.143" layer="22" ratio="15" rot="MR270">3V</text>
-<text x="262.763" y="9.144" size="1.143" layer="22" ratio="15" rot="MR270">3V</text>
-<text x="280.543" y="6.858" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
-<text x="285.75" y="4.445" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
-<text x="338.328" y="7.112" size="1.143" layer="22" ratio="15" rot="MR270">3V</text>
-<text x="315.468" y="9.144" size="1.143" layer="22" ratio="15" rot="MR270">3V</text>
-<text x="333.248" y="6.858" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
-<text x="338.455" y="4.445" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
-<text x="391.033" y="7.112" size="1.143" layer="22" ratio="15" rot="MR270">3V</text>
-<text x="368.173" y="9.144" size="1.143" layer="22" ratio="15" rot="MR270">3V</text>
-<text x="385.953" y="6.858" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
-<text x="391.16" y="4.445" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
 <text x="443.738" y="11.557" size="1.143" layer="22" ratio="15" rot="MR270">3V</text>
 <text x="420.243" y="8.509" size="1.143" layer="22" ratio="15" rot="MR270">3V</text>
 <text x="438.023" y="6.858" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
 <text x="443.865" y="8.89" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
 <text x="396.24" y="10.922" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
-<text x="343.408" y="10.668" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
-<text x="291.973" y="11.049" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
-<text x="239.268" y="10.795" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
-<text x="184.785" y="11.557" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
 <text x="132.461" y="12.573" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
 <text x="80.01" y="21.59" size="1.143" layer="22" ratio="15" rot="MR270">5V</text>
 <text x="79.375" y="15.367" size="1.143" layer="22" ratio="15" rot="MR270">GND</text>
@@ -508,52 +484,74 @@ Dual Footprint Compatible
 Adafruit Feather Socket
 Adafruit ItsyBitsy Socket</text>
 <text x="81.788" y="15.367" size="1.143" layer="22" ratio="15" rot="MR270">USB</text>
-<text x="154.94" y="12.319" size="1.016" layer="21" ratio="15">https://github.com/hydronics2/2019-easy-bee-counter</text>
+<text x="180.34" y="0.889" size="1.016" layer="21" ratio="15">https://github.com/hydronics2/2019-easy-bee-counter</text>
 <text x="97.155" y="4.826" size="1.143" layer="22" ratio="15" rot="MR270">A4</text>
 <text x="118.618" y="17.272" size="1.143" layer="22" ratio="15" rot="MR270">SDA</text>
 <text x="116.078" y="17.272" size="1.143" layer="22" ratio="15" rot="MR270">SCL</text>
 <text x="99.695" y="4.826" size="1.143" layer="22" ratio="15" rot="MR270">A5</text>
 <text x="132.334" y="0" size="1.143" layer="22" ratio="15" rot="MR180">3V</text>
 <text x="127.254" y="0" size="1.143" layer="22" ratio="15" rot="MR180">A4</text>
-<dimension x1="446.786" y1="31.75" x2="73.396475" y2="31.75" x3="260.0912375" y3="38.1" textsize="1.6764" layer="48" unit="inch"/>
-<dimension x1="446.786" y1="31.75" x2="446.786" y2="-2.794" x3="449.58" y3="14.478" textsize="1.6764" layer="48" unit="inch"/>
-<text x="190.881" y="27.051" size="1.016" layer="21">5</text>
-<text x="192.532" y="27.051" size="1.016" layer="21">6</text>
-<text x="194.31" y="27.051" size="1.016" layer="21">7</text>
-<text x="195.707" y="27.051" size="1.016" layer="21">8</text>
-<text x="184.277" y="26.797" size="1.016" layer="21">4</text>
-<text x="173.736" y="26.797" size="1.016" layer="21">3</text>
-<text x="160.909" y="26.797" size="1.016" layer="21">2</text>
-<text x="147.701" y="26.797" size="1.016" layer="21">1</text>
-<text x="249.809" y="26.797" size="1.016" layer="21">9</text>
-<text x="258.826" y="26.543" size="1.016" layer="21">10</text>
-<text x="270.383" y="26.67" size="1.016" layer="21">11</text>
-<text x="272.415" y="26.67" size="1.016" layer="21">12</text>
-<rectangle x1="272.415" y1="24.892" x2="273.685" y2="26.67" layer="39"/>
-<rectangle x1="270.51" y1="24.892" x2="271.78" y2="26.67" layer="39"/>
-<rectangle x1="259.08" y1="24.892" x2="260.35" y2="26.67" layer="39"/>
-<rectangle x1="249.555" y1="24.892" x2="250.825" y2="26.67" layer="39"/>
-<rectangle x1="195.326" y1="25.019" x2="196.596" y2="26.797" layer="39"/>
-<rectangle x1="193.802" y1="25.019" x2="195.072" y2="26.797" layer="39"/>
-<rectangle x1="192.151" y1="25.019" x2="193.421" y2="26.797" layer="39"/>
-<rectangle x1="190.5" y1="25.019" x2="191.77" y2="26.797" layer="39"/>
-<rectangle x1="183.896" y1="25.019" x2="185.166" y2="26.797" layer="39"/>
-<rectangle x1="173.355" y1="25.019" x2="174.625" y2="26.797" layer="39"/>
-<rectangle x1="160.655" y1="24.892" x2="161.925" y2="26.67" layer="39"/>
-<rectangle x1="147.32" y1="24.892" x2="148.59" y2="26.67" layer="39"/>
-<rectangle x1="300.355" y1="24.892" x2="301.625" y2="26.67" layer="39"/>
-<rectangle x1="157.861" y1="24.892" x2="159.131" y2="26.67" layer="39"/>
-<rectangle x1="310.896" y1="24.892" x2="312.166" y2="26.67" layer="39"/>
-<rectangle x1="321.437" y1="24.892" x2="322.707" y2="26.67" layer="39"/>
-<rectangle x1="325.501" y1="24.892" x2="326.771" y2="26.67" layer="39"/>
-<rectangle x1="348.996" y1="24.892" x2="350.266" y2="26.67" layer="39"/>
-<rectangle x1="361.696" y1="24.892" x2="362.966" y2="26.67" layer="39"/>
-<rectangle x1="376.682" y1="24.892" x2="377.952" y2="26.67" layer="39"/>
-<rectangle x1="389.001" y1="24.892" x2="390.271" y2="26.67" layer="39"/>
-<rectangle x1="407.67" y1="24.892" x2="408.94" y2="26.67" layer="39"/>
-<rectangle x1="412.496" y1="24.892" x2="413.766" y2="26.67" layer="39"/>
-<rectangle x1="419.227" y1="24.892" x2="420.497" y2="26.67" layer="39"/>
-<rectangle x1="422.148" y1="24.892" x2="423.418" y2="26.67" layer="39"/>
+<dimension x1="446.786" y1="32.385" x2="73.396475" y2="32.385" x3="260.0912375" y3="37.465" textsize="1.6764" layer="48" unit="inch"/>
+<dimension x1="446.786" y1="35.56" x2="446.786" y2="-2.794" x3="449.58" y3="16.383" textsize="1.6764" layer="48" unit="inch"/>
+<text x="199.136" y="20.32" size="1.016" layer="21">5</text>
+<text x="211.836" y="20.32" size="1.016" layer="21">6</text>
+<text x="224.536" y="20.32" size="1.016" layer="21">7</text>
+<text x="237.236" y="20.32" size="1.016" layer="21">8</text>
+<text x="186.436" y="20.32" size="1.016" layer="21">4</text>
+<text x="173.736" y="20.32" size="1.016" layer="21">3</text>
+<text x="161.036" y="20.32" size="1.016" layer="21">2</text>
+<text x="148.336" y="20.32" size="1.016" layer="21">1</text>
+<text x="249.936" y="20.32" size="1.016" layer="21">9</text>
+<text x="261.62" y="20.32" size="1.016" layer="21">10</text>
+<text x="274.32" y="20.32" size="1.016" layer="21">11</text>
+<text x="272.415" y="23.495" size="1.016" layer="21">12</text>
+<text x="299.72" y="20.32" size="1.016" layer="21">13</text>
+<text x="312.42" y="20.32" size="1.016" layer="21">14</text>
+<text x="325.12" y="20.32" size="1.016" layer="21">15</text>
+<text x="337.82" y="20.32" size="1.016" layer="21">16</text>
+<text x="349.25" y="23.495" size="1.016" layer="21">17</text>
+<text x="361.315" y="23.495" size="1.016" layer="21">18</text>
+<text x="375.92" y="20.32" size="1.016" layer="21">19</text>
+<text x="388.62" y="20.32" size="1.016" layer="21">20</text>
+<text x="401.32" y="20.32" size="1.016" layer="21">21</text>
+<text x="414.02" y="20.32" size="1.016" layer="21">22</text>
+<text x="426.72" y="20.32" size="1.016" layer="21">23</text>
+<text x="439.42" y="20.32" size="1.016" layer="21">24</text>
+<text x="283.845" y="-2.54" size="1.016" layer="21">This side towards Hive</text>
+<text x="267.335" y="33.655" size="1.016" layer="21">This side out</text>
+<hole x="140.97" y="33.909" drill="2.286"/>
+<hole x="287.655" y="34.163" drill="2.286"/>
+<hole x="363.855" y="34.163" drill="2.286"/>
+<hole x="407.67" y="34.163" drill="2.286"/>
+<hole x="427.355" y="34.163" drill="2.286"/>
+<hole x="445.389" y="34.163" drill="2.286"/>
+<rectangle x1="172.085" y1="13.335" x2="173.355" y2="15.875" layer="29"/>
+<rectangle x1="174.625" y1="13.335" x2="175.895" y2="15.875" layer="29"/>
+<rectangle x1="177.165" y1="13.335" x2="178.435" y2="15.875" layer="29"/>
+<rectangle x1="179.705" y1="13.335" x2="180.975" y2="15.875" layer="29"/>
+<rectangle x1="182.245" y1="13.335" x2="183.515" y2="15.875" layer="29"/>
+<rectangle x1="184.785" y1="13.335" x2="186.055" y2="15.875" layer="29"/>
+<rectangle x1="187.325" y1="13.335" x2="188.595" y2="15.875" layer="29"/>
+<rectangle x1="189.865" y1="13.335" x2="191.135" y2="15.875" layer="29"/>
+<text x="287.02" y="20.32" size="1.016" layer="21">12</text>
+<text x="350.52" y="20.32" size="1.016" layer="21">17</text>
+<text x="363.22" y="20.32" size="1.016" layer="21">18</text>
+<rectangle x1="265.938" y1="14.1478" x2="267.208" y2="16.6878" layer="29"/>
+<rectangle x1="268.478" y1="14.1478" x2="269.748" y2="16.6878" layer="29"/>
+<rectangle x1="273.558" y1="14.1478" x2="274.828" y2="16.6878" layer="29"/>
+<rectangle x1="271.018" y1="14.1478" x2="272.288" y2="16.6878" layer="29"/>
+<rectangle x1="368.173" y1="13.335" x2="369.443" y2="15.875" layer="29"/>
+<rectangle x1="370.713" y1="13.335" x2="371.983" y2="15.875" layer="29"/>
+<rectangle x1="373.253" y1="13.335" x2="374.523" y2="15.875" layer="29"/>
+<rectangle x1="375.793" y1="13.335" x2="377.063" y2="15.875" layer="29"/>
+<rectangle x1="378.333" y1="13.335" x2="379.603" y2="15.875" layer="29"/>
+<rectangle x1="380.873" y1="13.335" x2="382.143" y2="15.875" layer="29"/>
+<rectangle x1="383.413" y1="13.335" x2="384.683" y2="15.875" layer="29"/>
+<rectangle x1="385.953" y1="13.335" x2="387.223" y2="15.875" layer="29"/>
+<rectangle x1="325.247" y1="13.335" x2="326.517" y2="15.875" layer="29"/>
+<rectangle x1="327.787" y1="13.335" x2="329.057" y2="15.875" layer="29"/>
+<rectangle x1="330.327" y1="13.335" x2="331.597" y2="15.875" layer="29"/>
+<rectangle x1="332.867" y1="13.335" x2="334.137" y2="15.875" layer="29"/>
 </plain>
 <libraries>
 <library name="Bee Counter 3">
@@ -694,74 +692,6 @@ Warning: This is the KIT version of this package. This package has a smaller dia
 <description>made the hole size 0.038 or 38mill instead of the standard 40mill and the diamter 55mil in leiu of ~70mill standard</description>
 <pad name="1" x="0" y="0" drill="0.9652" diameter="1.397" rot="R90"/>
 <rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
-</package>
-</packages>
-</library>
-<library name="QRE1113">
-<packages>
-<package name="DIP400W50P180L360H200Q4">
-<wire x1="-1.8" y1="-1.45" x2="-1.8" y2="1.45" width="0.127" layer="51"/>
-<wire x1="-1.8" y1="1.45" x2="1.8" y2="1.45" width="0.127" layer="51"/>
-<wire x1="1.8" y1="1.45" x2="1.8" y2="-1.45" width="0.127" layer="51"/>
-<wire x1="1.8" y1="-1.45" x2="-1.8" y2="-1.45" width="0.127" layer="51"/>
-<text x="-2.07676875" y="3.075759375" size="1.271940625" layer="25">&gt;NAME</text>
-<text x="-2.08306875" y="-3.581009375" size="1.2732" layer="27" align="top-left">&gt;VALUE</text>
-<wire x1="1.8" y1="1.45" x2="1.8" y2="-1.45" width="0.0508" layer="21"/>
-<wire x1="-1.8" y1="-1.45" x2="-1.8" y2="0.6118" width="0.0508" layer="21"/>
-<wire x1="-2.05" y1="2.84" x2="-2.05" y2="-2.84" width="0.05" layer="39"/>
-<wire x1="-2.05" y1="-2.84" x2="2.05" y2="-2.84" width="0.05" layer="39"/>
-<wire x1="2.05" y1="-2.84" x2="2.05" y2="2.84" width="0.05" layer="39"/>
-<wire x1="2.05" y1="2.84" x2="-2.05" y2="2.84" width="0.05" layer="39"/>
-<circle x="-2.4" y="2.2" radius="0.0508" width="0.2" layer="21"/>
-<circle x="-2.4" y="2.2" radius="0.1" width="0.2" layer="51"/>
-<pad name="1" x="-0.9" y="2" drill="0.78" shape="square" rot="R270" stop="no"/>
-<pad name="4" x="0.9" y="2" drill="0.78" diameter="1.524" rot="R270" stop="no"/>
-<pad name="2" x="-0.9" y="-2" drill="0.78" diameter="1.524" rot="R270" stop="no"/>
-<pad name="3" x="0.9" y="-2" drill="0.78" diameter="1.524" rot="R270" stop="no"/>
-<polygon width="0.127" layer="29">
-<vertex x="-0.9271" y="1.6764" curve="-90.012891"/>
-<vertex x="-1.2319" y="2.0117" curve="-90"/>
-<vertex x="-0.9017" y="2.3266" curve="-90"/>
-<vertex x="-0.5741" y="1.9838" curve="-90.012967"/>
-</polygon>
-<rectangle x1="-1.5494" y1="1.3589" x2="-0.254" y2="2.6416" layer="30"/>
-<polygon width="0.127" layer="30">
-<vertex x="0.9677" y="1.2954" curve="-90"/>
-<vertex x="0.2033" y="1.9584" curve="-90.011749"/>
-<vertex x="0.8509" y="2.7052" curve="-90"/>
-<vertex x="1.5977" y="2.0447" curve="-90.024193"/>
-</polygon>
-<polygon width="0.127" layer="30">
-<vertex x="-0.8611" y="-2.7051" curve="-90"/>
-<vertex x="-1.6128" y="-2.0294" curve="-90.011749"/>
-<vertex x="-0.9017" y="-1.2953" curve="-90"/>
-<vertex x="-0.193" y="-1.9939" curve="-90.024193"/>
-</polygon>
-<polygon width="0.127" layer="30">
-<vertex x="0.9042" y="-2.7051" curve="-90"/>
-<vertex x="0.2033" y="-2.0421" curve="-90.011749"/>
-<vertex x="0.8636" y="-1.2953" curve="-90"/>
-<vertex x="1.6104" y="-1.9812" curve="-90.024193"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="0.8763" y="1.6764" curve="-90.012891"/>
-<vertex x="0.5715" y="2.0117" curve="-90"/>
-<vertex x="0.9017" y="2.3266" curve="-90"/>
-<vertex x="1.2293" y="1.9838" curve="-90.012967"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="-0.9144" y="-2.3241" curve="-90.012891"/>
-<vertex x="-1.2319" y="-1.9888" curve="-90"/>
-<vertex x="-0.889" y="-1.6739" curve="-90"/>
-<vertex x="-0.5614" y="-2.0167" curve="-90.012967"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="0.8763" y="-2.3241" curve="-90.012891"/>
-<vertex x="0.5715" y="-1.9888" curve="-90"/>
-<vertex x="0.9017" y="-1.6739" curve="-90"/>
-<vertex x="1.2293" y="-2.0167" curve="-90.012967"/>
-</polygon>
-<wire x1="-1.8034" y1="0.6096" x2="-1.27" y2="1.27" width="0.0508" layer="21"/>
 </package>
 </packages>
 </library>
@@ -2211,6 +2141,70 @@ by exp-lbrs.ulp</description>
 <text x="0.635" y="4.699" size="1.4224" layer="51" font="vector" ratio="15" rot="R90">Adafruit M0</text>
 <text x="4.064" y="-8.89" size="1.016" layer="51" font="vector" ratio="15">RX</text>
 <text x="-6.35" y="-9.017" size="1.016" layer="51" font="vector" ratio="15">2</text>
+</package>
+<package name="QRE1113_DIP400W50P180L360H200Q4">
+<circle x="-2.4" y="2.2" radius="0.0508" width="0.2" layer="21"/>
+<circle x="-2.4" y="2.2" radius="0.1" width="0.2" layer="51"/>
+<wire x1="-1.8" y1="-1.45" x2="-1.8" y2="1.45" width="0.127" layer="51"/>
+<wire x1="-1.8" y1="1.45" x2="1.8" y2="1.45" width="0.127" layer="51"/>
+<wire x1="1.8" y1="1.45" x2="1.8" y2="-1.45" width="0.127" layer="51"/>
+<wire x1="1.8" y1="-1.45" x2="-1.8" y2="-1.45" width="0.127" layer="51"/>
+<wire x1="1.8" y1="1.45" x2="1.8" y2="-1.45" width="0.0508" layer="21"/>
+<wire x1="-1.8" y1="-1.45" x2="-1.8" y2="0.6118" width="0.0508" layer="21"/>
+<wire x1="-2.05" y1="2.84" x2="-2.05" y2="-2.84" width="0.05" layer="39"/>
+<wire x1="-2.05" y1="-2.84" x2="2.05" y2="-2.84" width="0.05" layer="39"/>
+<wire x1="2.05" y1="-2.84" x2="2.05" y2="2.84" width="0.05" layer="39"/>
+<wire x1="2.05" y1="2.84" x2="-2.05" y2="2.84" width="0.05" layer="39"/>
+<wire x1="-1.8034" y1="0.6096" x2="-1.27" y2="1.27" width="0.0508" layer="21"/>
+<rectangle x1="-1.5494" y1="1.3589" x2="-0.254" y2="2.6416" layer="30"/>
+<pad name="1" x="-0.9" y="2" drill="0.78" shape="square" rot="R270" stop="no"/>
+<pad name="2" x="-0.9" y="-2" drill="0.78" diameter="1.524" rot="R270" stop="no"/>
+<pad name="3" x="0.9" y="-2" drill="0.78" diameter="1.524" rot="R270" stop="no"/>
+<pad name="4" x="0.9" y="2" drill="0.78" diameter="1.524" rot="R270" stop="no"/>
+<text x="-2.07676875" y="3.075759375" size="1.271940625" layer="25">&gt;NAME</text>
+<text x="-2.08306875" y="-3.581009375" size="1.2732" layer="27" align="top-left">&gt;VALUE</text>
+<polygon width="0.127" layer="29">
+<vertex x="-0.9271" y="1.6764" curve="-90.012891"/>
+<vertex x="-1.2319" y="2.0117" curve="-90"/>
+<vertex x="-0.9017" y="2.3266" curve="-90"/>
+<vertex x="-0.5741" y="1.9838" curve="-90.012967"/>
+</polygon>
+<polygon width="0.127" layer="30">
+<vertex x="0.9677" y="1.2954" curve="-90"/>
+<vertex x="0.2033" y="1.9584" curve="-90.011749"/>
+<vertex x="0.8509" y="2.7052" curve="-90"/>
+<vertex x="1.5977" y="2.0447" curve="-90.024193"/>
+</polygon>
+<polygon width="0.127" layer="30">
+<vertex x="-0.8611" y="-2.7051" curve="-90"/>
+<vertex x="-1.6128" y="-2.0294" curve="-90.011749"/>
+<vertex x="-0.9017" y="-1.2953" curve="-90"/>
+<vertex x="-0.193" y="-1.9939" curve="-90.024193"/>
+</polygon>
+<polygon width="0.127" layer="30">
+<vertex x="0.9042" y="-2.7051" curve="-90"/>
+<vertex x="0.2033" y="-2.0421" curve="-90.011749"/>
+<vertex x="0.8636" y="-1.2953" curve="-90"/>
+<vertex x="1.6104" y="-1.9812" curve="-90.024193"/>
+</polygon>
+<polygon width="0.127" layer="29">
+<vertex x="0.8763" y="1.6764" curve="-90.012891"/>
+<vertex x="0.5715" y="2.0117" curve="-90"/>
+<vertex x="0.9017" y="2.3266" curve="-90"/>
+<vertex x="1.2293" y="1.9838" curve="-90.012967"/>
+</polygon>
+<polygon width="0.127" layer="29">
+<vertex x="-0.9144" y="-2.3241" curve="-90.012891"/>
+<vertex x="-1.2319" y="-1.9888" curve="-90"/>
+<vertex x="-0.889" y="-1.6739" curve="-90"/>
+<vertex x="-0.5614" y="-2.0167" curve="-90.012967"/>
+</polygon>
+<polygon width="0.127" layer="29">
+<vertex x="0.8763" y="-2.3241" curve="-90.012891"/>
+<vertex x="0.5715" y="-1.9888" curve="-90"/>
+<vertex x="0.9017" y="-1.6739" curve="-90"/>
+<vertex x="1.2293" y="-2.0167" curve="-90.012967"/>
+</polygon>
 </package>
 </packages>
 </library>
@@ -17668,6 +17662,53 @@ by exp-lbrs.ulp</description>
 </package>
 </packages>
 </library>
+<library name="pinhead" urn="urn:adsk.eagle:library:325">
+<description>&lt;b&gt;Pin Header Connectors&lt;/b&gt;&lt;p&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
+<packages>
+<package name="1X03" urn="urn:adsk.eagle:footprint:22340/1" library_version="4">
+<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
+<wire x1="-3.175" y1="1.27" x2="-1.905" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-1.905" y1="1.27" x2="-1.27" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="0.635" x2="-1.27" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="-0.635" x2="-1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="0.635" x2="-0.635" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="0.635" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="1.27" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="0.635" x2="1.27" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="-0.635" x2="0.635" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="0.635" y1="-1.27" x2="-0.635" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-0.635" y1="-1.27" x2="-1.27" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-3.81" y1="0.635" x2="-3.81" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="1.27" x2="-3.81" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-3.81" y1="-0.635" x2="-3.175" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-1.905" y1="-1.27" x2="-3.175" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="0.635" x2="1.905" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="3.175" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="3.175" y1="1.27" x2="3.81" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="3.81" y1="0.635" x2="3.81" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="3.81" y1="-0.635" x2="3.175" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="3.175" y1="-1.27" x2="1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="1.905" y1="-1.27" x2="1.27" y2="-0.635" width="0.1524" layer="21"/>
+<pad name="1" x="-2.54" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="0" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="3" x="2.54" y="0" drill="1.016" shape="long" rot="R90"/>
+<text x="-3.8862" y="1.8288" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-3.81" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<rectangle x1="-2.794" y1="-0.254" x2="-2.286" y2="0.254" layer="51"/>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+</package>
+</packages>
+<packages3d>
+<package3d name="1X03" urn="urn:adsk.eagle:package:22458/2" type="model" library_version="4">
+<description>PIN HEADER</description>
+<packageinstances>
+<packageinstance name="1X03"/>
+</packageinstances>
+</package3d>
+</packages3d>
+</library>
 </libraries>
 <attributes>
 </attributes>
@@ -17864,129 +17905,218 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 </pass>
 </autorouter>
 <elements>
-<element name="U$1" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="150.749" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$2" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="163.449" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$3" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="138.049" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$4" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="176.149" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$5" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="188.849" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$6" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="201.549" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$7" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="214.249" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$8" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="226.949" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$9" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="239.649" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$10" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="252.349" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$11" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="265.049" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$12" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="277.749" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$13" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="290.449" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$14" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="135.509" y="30.353" smashed="yes" rot="MR0"/>
-<element name="U$15" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="120.269" y="30.353" smashed="yes" rot="MR0"/>
-<element name="U$16" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="445.389" y="20.193" smashed="yes" rot="MR90"/>
-<element name="U$17" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="105.029" y="30.353" smashed="yes" rot="MR0"/>
-<element name="U$18" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="303.149" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$19" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="315.849" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$20" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="328.549" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$21" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="341.249" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$22" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="353.949" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$23" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="366.649" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$24" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="379.349" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$25" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="392.049" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$26" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="404.749" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$27" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="417.449" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$28" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="430.149" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$29" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="442.849" y="25.273" smashed="yes" rot="MR270"/>
-<element name="U$30" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="138.049" y="2.413" smashed="yes" rot="MR90"/>
-<element name="U$59" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="89.8144" y="30.353" smashed="yes" rot="MR0"/>
-<element name="U$60" library="th_libraries3" package="1X01-40MILL" value="CONN_0138MILL" x="77.1144" y="30.353" smashed="yes"/>
-<element name="U$61" library="th_libraries3" package="1X01-40MILL" value="CONN_0138MILL" x="74.5744" y="30.3276" smashed="yes"/>
-<element name="U$68" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="436.499" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$69" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="436.499" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$70" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="423.799" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$71" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="423.799" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$72" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="411.099" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$73" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="411.099" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$74" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="398.399" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$75" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="398.399" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$76" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="385.699" y="18.6182" smashed="yes" rot="MR270"/>
-<element name="U$77" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="385.699" y="22.7838" smashed="yes" rot="MR270"/>
-<element name="U$78" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="372.999" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$79" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="372.999" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$80" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="360.299" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$81" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="360.299" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$82" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="347.599" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$83" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="347.599" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$84" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="334.899" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$85" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="334.899" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$86" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="322.199" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$87" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="322.199" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$88" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="309.499" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$89" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="309.499" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$90" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="296.799" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$91" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="296.799" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$92" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="284.099" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$93" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="284.099" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$94" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="271.399" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$95" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="271.399" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$96" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="258.699" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$97" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="258.699" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$98" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="245.999" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$99" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="245.999" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$100" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="233.299" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$101" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="233.299" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$102" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="220.599" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$103" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="220.599" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$104" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="207.899" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$105" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="207.899" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$106" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="195.199" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$107" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="195.199" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$108" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="182.499" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$109" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="182.499" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$110" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="169.799" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$111" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="169.799" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$112" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="157.099" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$113" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="157.099" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$114" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="144.399" y="18.161" smashed="yes" rot="MR270"/>
-<element name="U$115" library="QRE1113" package="DIP400W50P180L360H200Q4" value="QRE1113_" x="144.399" y="22.3266" smashed="yes" rot="MR270"/>
-<element name="U$34" library="th_libraries" package="RPACK-SIP-PTH-9" value="22Ω" x="412.115" y="30.48" smashed="yes" rot="R270"/>
-<element name="U$35" library="th_libraries" package="RPACK-SIP-PTH-9" value="22Ω" x="311.15" y="30.48" smashed="yes" rot="R270"/>
-<element name="U$36" library="th_libraries" package="RPACK-SIP-PTH-9" value="22Ω" x="186.69" y="30.48" smashed="yes" rot="R270"/>
-<element name="R2" library="th_libraries" package="RPACK-SIP-PTH-8" value="100KΩ" x="395.605" y="6.35" smashed="yes" rot="R90">
-<attribute name="VALUE" x="395.605" y="3.302" size="1.27" layer="27"/>
+<element name="U$1" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="150.749" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$2" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="163.449" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$3" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="138.049" y="28.956" smashed="yes" rot="MR270"/>
+<element name="U$4" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="176.149" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$5" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="188.849" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$6" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="201.549" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$7" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="214.249" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$8" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="226.949" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$9" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="239.649" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$10" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="252.349" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$11" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="265.049" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$12" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="277.749" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$13" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="290.449" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$14" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="135.509" y="34.036" smashed="yes" rot="MR0"/>
+<element name="U$15" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="120.269" y="34.036" smashed="yes" rot="MR0"/>
+<element name="U$16" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="445.389" y="11.176" smashed="yes" rot="MR90"/>
+<element name="U$17" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="105.029" y="34.036" smashed="yes" rot="MR0"/>
+<element name="U$18" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="303.149" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$19" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="315.849" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$20" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="328.549" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$21" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="341.249" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$22" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="353.949" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$23" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="366.649" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$24" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="379.349" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$25" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="392.049" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$26" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="404.749" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$27" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="417.449" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$28" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="430.149" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$29" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="442.849" y="31.496" smashed="yes" rot="MR270"/>
+<element name="U$30" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="138.049" y="6.096" smashed="yes" rot="MR90"/>
+<element name="U$59" library="Bee Counter 3" package="1X06_BEE" value="M06_BEE" x="89.8144" y="34.036" smashed="yes" rot="MR0"/>
+<element name="U$60" library="th_libraries3" package="1X01-40MILL" value="CONN_0138MILL" x="77.1144" y="34.036" smashed="yes"/>
+<element name="U$61" library="th_libraries3" package="1X01-40MILL" value="CONN_0138MILL" x="74.5744" y="34.036" smashed="yes"/>
+<element name="U24I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="436.499" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="438.6834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
 </element>
-<element name="R5" library="th_libraries" package="RPACK-SIP-PTH-8" value="100KΩ" x="342.9" y="6.35" smashed="yes" rot="R90">
-<attribute name="VALUE" x="342.9" y="3.302" size="1.27" layer="27"/>
+<element name="U24O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="436.499" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="438.6834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
 </element>
-<element name="R6" library="th_libraries" package="RPACK-SIP-PTH-8" value="100KΩ" x="291.465" y="6.35" smashed="yes" rot="R90">
-<attribute name="VALUE" x="291.465" y="3.302" size="1.27" layer="27"/>
+<element name="U23I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="423.799" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="425.9834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
 </element>
-<element name="R7" library="th_libraries" package="RPACK-SIP-PTH-8" value="100KΩ" x="238.76" y="6.35" smashed="yes" rot="R90">
-<attribute name="VALUE" x="238.76" y="3.302" size="1.27" layer="27"/>
+<element name="U23O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="423.799" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="425.9834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
 </element>
-<element name="R11" library="th_libraries" package="RPACK-SIP-PTH-8" value="100KΩ" x="184.15" y="6.985" smashed="yes" rot="R90">
-<attribute name="VALUE" x="184.15" y="3.937" size="1.27" layer="27"/>
+<element name="U22I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="411.099" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="413.2834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
 </element>
-<element name="R12" library="th_libraries" package="RPACK-SIP-PTH-8" value="100KΩ" x="132.08" y="8.255" smashed="yes" rot="R90">
-<attribute name="VALUE" x="132.08" y="5.207" size="1.27" layer="27"/>
+<element name="U22O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="411.099" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="413.2834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U21I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="398.399" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="400.5834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U21O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="398.399" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="400.5834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U20I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="385.699" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="387.8834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U20O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="385.699" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="387.8834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U19I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="372.999" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="375.1834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U19O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="372.999" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="375.1834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U18I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="360.299" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="362.4834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U18O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="360.299" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="362.4834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U17I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="347.599" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="349.7834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U17O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="347.599" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="349.7834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U16I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="334.899" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="337.0834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U16O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="334.899" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="337.0834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U15I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="322.199" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="324.3834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U15O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="322.199" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="324.3834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U14I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="309.499" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="311.6834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U14O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="309.499" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="311.6834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U13I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="296.799" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="298.9834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U13O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="296.799" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="298.9834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U12I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="284.099" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="286.2834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U12O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="284.099" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="286.2834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U11I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="271.399" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="273.5834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U11O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="271.399" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="273.5834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U10I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="258.699" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="260.8834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U10O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="258.699" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="260.8834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U09O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="245.999" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="248.1834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U08I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="233.299" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="235.4834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U08O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="233.299" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="235.4834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U07I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="220.599" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="222.7834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U07O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="220.599" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="222.7834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U06I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="207.899" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="210.0834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U06O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="207.899" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="210.0834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U05I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="195.199" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="197.3834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U05O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="195.199" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="197.3834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U04I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="182.499" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="184.6834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U04O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="182.499" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="184.6834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U03I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="169.799" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="171.9834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U03O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="169.799" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="171.9834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U02I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="157.099" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="159.2834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U02O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="157.099" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="159.2834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U01I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="144.399" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="146.5834" y="20.32" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U01O" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="144.399" y="28.321" smashed="yes" rot="MR270">
+<attribute name="NAME" x="146.5834" y="31.115" size="1.271940625" layer="26" rot="MR0"/>
+</element>
+<element name="U$34" library="th_libraries" package="RPACK-SIP-PTH-9" value="22Ω" x="377.698" y="17.78" smashed="yes" rot="R270"/>
+<element name="U$35" library="th_libraries" package="RPACK-SIP-PTH-9" value="22Ω" x="324.485" y="17.145" smashed="yes" rot="R270"/>
+<element name="U$36" library="th_libraries" package="RPACK-SIP-PTH-9" value="22Ω" x="181.61" y="17.145" smashed="yes" rot="R270"/>
+<element name="R2" library="th_libraries" package="RPACK-SIP-PTH-8" value="100KΩ" x="392.43" y="18.415" smashed="yes" rot="R90">
+<attribute name="VALUE" x="392.43" y="15.367" size="1.27" layer="27"/>
+</element>
+<element name="R5" library="th_libraries" package="RPACK-SIP-PTH-8" value="100KΩ" x="343.535" y="16.51" smashed="yes" rot="R90"/>
+<element name="R6" library="th_libraries" package="RPACK-SIP-PTH-8" value="100KΩ" x="289.56" y="16.51" smashed="yes" rot="R90"/>
+<element name="R7" library="th_libraries" package="RPACK-SIP-PTH-8" value="100KΩ" x="226.695" y="17.78" smashed="yes" rot="R90">
+<attribute name="VALUE" x="226.695" y="14.732" size="1.27" layer="27"/>
+</element>
+<element name="R11" library="th_libraries" package="RPACK-SIP-PTH-8" value="100KΩ" x="203.2" y="16.51" smashed="yes" rot="R90">
+<attribute name="VALUE" x="203.2" y="13.462" size="1.27" layer="27"/>
+</element>
+<element name="R12" library="th_libraries" package="RPACK-SIP-PTH-8" value="100KΩ" x="144.78" y="16.51" smashed="yes" rot="R90">
+<attribute name="VALUE" x="144.78" y="13.462" size="1.27" layer="27"/>
 </element>
 <element name="Q6" library="th_libraries" package="TO220V" value="60V/32A/35mΩ" x="132.08" y="23.495" smashed="yes" rot="R270">
 <attribute name="PROD_ID" value="TRANS-10060" x="132.08" y="23.495" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
 <element name="R13" library="SparkFun-Passives" package="AXIAL-0.3" value="10k" x="107.95" y="10.795" smashed="yes" rot="R180"/>
-<element name="U1" library="th_libraries" package="DIP16" value="74*165" x="428.625" y="6.35" smashed="yes">
-<attribute name="VALUE" x="440.055" y="6.35" size="0.6096" layer="27" font="vector" ratio="20" rot="R90" align="bottom-center"/>
+<element name="U1" library="th_libraries" package="DIP16" value="74*165" x="395.605" y="6.35" smashed="yes">
+<attribute name="VALUE" x="407.035" y="6.35" size="0.6096" layer="27" font="vector" ratio="20" rot="R90" align="bottom-center"/>
 </element>
-<element name="U2" library="th_libraries" package="DIP16" value="74*165" x="376.555" y="6.35" smashed="yes">
-<attribute name="VALUE" x="387.985" y="6.35" size="0.6096" layer="27" font="vector" ratio="20" rot="R90" align="bottom-center"/>
+<element name="U2" library="th_libraries" package="DIP16" value="74*165" x="358.14" y="6.35" smashed="yes">
+<attribute name="VALUE" x="369.57" y="6.35" size="0.6096" layer="27" font="vector" ratio="20" rot="R90" align="bottom-center"/>
 </element>
-<element name="U3" library="th_libraries" package="DIP16" value="74*165" x="323.85" y="6.35" smashed="yes">
-<attribute name="NAME" x="313.055" y="6.35" size="0.6096" layer="25" font="vector" ratio="20" rot="R90" align="bottom-center"/>
-<attribute name="VALUE" x="335.28" y="6.35" size="0.6096" layer="27" font="vector" ratio="20" rot="R90" align="bottom-center"/>
+<element name="U3" library="th_libraries" package="DIP16" value="74*165" x="304.165" y="6.35" smashed="yes">
+<attribute name="NAME" x="293.37" y="6.35" size="0.6096" layer="25" font="vector" ratio="20" rot="R90" align="bottom-center"/>
+<attribute name="VALUE" x="315.595" y="6.35" size="0.6096" layer="27" font="vector" ratio="20" rot="R90" align="bottom-center"/>
 </element>
-<element name="U4" library="th_libraries" package="DIP16" value="74*165" x="271.145" y="6.35" smashed="yes">
-<attribute name="NAME" x="260.35" y="6.35" size="0.6096" layer="25" font="vector" ratio="20" rot="R90" align="bottom-center"/>
-<attribute name="VALUE" x="282.575" y="6.35" size="0.6096" layer="27" font="vector" ratio="20" rot="R90" align="bottom-center"/>
+<element name="U4" library="th_libraries" package="DIP16" value="74*165" x="258.445" y="6.35" smashed="yes">
+<attribute name="NAME" x="247.65" y="6.35" size="0.6096" layer="25" font="vector" ratio="20" rot="R90" align="bottom-center"/>
+<attribute name="VALUE" x="269.875" y="6.35" size="0.6096" layer="27" font="vector" ratio="20" rot="R90" align="bottom-center"/>
 </element>
-<element name="U5" library="th_libraries" package="DIP16" value="74*165" x="217.17" y="6.35" smashed="yes">
-<attribute name="NAME" x="207.01" y="6.35" size="0.6096" layer="25" font="vector" ratio="20" rot="R90" align="bottom-center"/>
-<attribute name="VALUE" x="228.6" y="6.35" size="0.6096" layer="27" font="vector" ratio="20" rot="R90" align="bottom-center"/>
+<element name="U5" library="th_libraries" package="DIP16" value="74*165" x="219.71" y="6.35" smashed="yes">
+<attribute name="NAME" x="209.55" y="6.35" size="0.6096" layer="25" font="vector" ratio="20" rot="R90" align="bottom-center"/>
+<attribute name="VALUE" x="231.14" y="6.35" size="0.6096" layer="27" font="vector" ratio="20" rot="R90" align="bottom-center"/>
 </element>
 <element name="U6" library="th_libraries" package="DIP16" value="74*165" x="164.465" y="6.35" smashed="yes">
 <attribute name="VALUE" x="175.895" y="6.35" size="0.6096" layer="27" font="vector" ratio="20" rot="R90" align="bottom-center"/>
@@ -17995,27 +18125,27 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <attribute name="PROD_ID" value="TRANS-10060" x="126.365" y="23.495" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
 <element name="R15" library="SparkFun-Passives" package="AXIAL-0.3" value="10k" x="107.95" y="13.335" smashed="yes" rot="R180"/>
-<element name="U$37" library="th_libraries" package="RPACK-SIP-PTH-9" value="22Ω" x="263.525" y="30.48" smashed="yes" rot="R270"/>
+<element name="U$37" library="th_libraries" package="RPACK-SIP-PTH-9" value="22Ω" x="275.463" y="18.415" smashed="yes" rot="R270"/>
 <element name="U7" library="SparkFun-IC-Power" library_urn="urn:adsk.eagle:library:526" package="DC-DC_CONVERTER_78XX" package3d_urn="urn:adsk.eagle:package:39086/1" value="R78E3.3-1.0" x="101.6" y="27.305" smashed="yes">
 <attribute name="PROD_ID" value="COM-13655" x="101.6" y="27.305" size="1.778" layer="27" display="off"/>
 </element>
-<element name="C1" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" package="CAP-PTH-SMALL-KIT" package3d_urn="urn:adsk.eagle:package:37428/1" value="0.1uF" x="441.325" y="8.89" smashed="yes" rot="R270">
-<attribute name="PROD_ID" value="CAP-08370" x="441.325" y="8.89" size="1.778" layer="27" rot="R270" display="off"/>
+<element name="C1" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" package="CAP-PTH-SMALL-KIT" package3d_urn="urn:adsk.eagle:package:37428/1" value="0.1uF" x="381.635" y="10.16" smashed="yes" rot="R180">
+<attribute name="PROD_ID" value="CAP-08370" x="381.635" y="10.16" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="C2" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" package="CAP-PTH-SMALL-KIT" package3d_urn="urn:adsk.eagle:package:37428/1" value="0.1uF" x="388.62" y="3.81" smashed="yes" rot="R270">
-<attribute name="PROD_ID" value="CAP-08370" x="388.62" y="3.81" size="1.778" layer="27" rot="R270" display="off"/>
+<element name="C2" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" package="CAP-PTH-SMALL-KIT" package3d_urn="urn:adsk.eagle:package:37428/1" value="0.1uF" x="344.805" y="10.16" smashed="yes" rot="R180">
+<attribute name="PROD_ID" value="CAP-08370" x="344.805" y="10.16" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="C3" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" package="CAP-PTH-SMALL-KIT" package3d_urn="urn:adsk.eagle:package:37428/1" value="0.1uF" x="335.915" y="3.81" smashed="yes" rot="R270">
-<attribute name="PROD_ID" value="CAP-08370" x="335.915" y="3.81" size="1.778" layer="27" rot="R270" display="off"/>
+<element name="C3" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" package="CAP-PTH-SMALL-KIT" package3d_urn="urn:adsk.eagle:package:37428/1" value="0.1uF" x="290.83" y="10.16" smashed="yes" rot="R180">
+<attribute name="PROD_ID" value="CAP-08370" x="290.83" y="10.16" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="C4" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" package="CAP-PTH-SMALL-KIT" package3d_urn="urn:adsk.eagle:package:37428/1" value="0.1uF" x="283.21" y="4.445" smashed="yes" rot="R270">
-<attribute name="PROD_ID" value="CAP-08370" x="283.21" y="4.445" size="1.778" layer="27" rot="R270" display="off"/>
+<element name="C4" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" package="CAP-PTH-SMALL-KIT" package3d_urn="urn:adsk.eagle:package:37428/1" value="0.1uF" x="245.11" y="10.16" smashed="yes" rot="R180">
+<attribute name="PROD_ID" value="CAP-08370" x="245.11" y="10.16" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="C5" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" package="CAP-PTH-SMALL-KIT" package3d_urn="urn:adsk.eagle:package:37428/1" value="0.1uF" x="229.235" y="4.445" smashed="yes" rot="R270">
-<attribute name="PROD_ID" value="CAP-08370" x="229.235" y="4.445" size="1.778" layer="27" rot="R270" display="off"/>
+<element name="C5" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" package="CAP-PTH-SMALL-KIT" package3d_urn="urn:adsk.eagle:package:37428/1" value="0.1uF" x="206.375" y="10.16" smashed="yes" rot="R180">
+<attribute name="PROD_ID" value="CAP-08370" x="206.375" y="10.16" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="C6" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" package="CAP-PTH-SMALL-KIT" package3d_urn="urn:adsk.eagle:package:37428/1" value="0.1uF" x="176.53" y="4.445" smashed="yes" rot="R270">
-<attribute name="PROD_ID" value="CAP-08370" x="176.53" y="4.445" size="1.778" layer="27" rot="R270" display="off"/>
+<element name="C6" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" package="CAP-PTH-SMALL-KIT" package3d_urn="urn:adsk.eagle:package:37428/1" value="0.1uF" x="151.13" y="9.525" smashed="yes" rot="R180">
+<attribute name="PROD_ID" value="CAP-08370" x="151.13" y="9.525" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
 <element name="C8" library="rcl" library_urn="urn:adsk.eagle:library:334" package="E3,5-8" package3d_urn="urn:adsk.eagle:package:23360/2" value="560uF" x="116.205" y="25.4" smashed="yes" rot="R270">
 <attribute name="SPICEPREFIX" value="C" x="116.205" y="25.4" size="1.778" layer="27" rot="R270" display="off"/>
@@ -18050,6 +18180,35 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 </element>
 <element name="U$45" library="easy_bee_counter" package="ADAFRUIT_ITS_MO_28" value="ADAFRUIT_ITSY_M0_28" x="100.33" y="8.89" smashed="yes" rot="R90"/>
 <element name="U$44" library="owen_desktop" package="BEE_LOGO" value="BEE_LOGO" x="103.505" y="-3.81" smashed="yes"/>
+<element name="SERVO5" library="pinhead" library_urn="urn:adsk.eagle:library:325" package="1X03" package3d_urn="urn:adsk.eagle:package:22458/2" value="" x="197.104" y="12.446" smashed="yes" rot="R270">
+<attribute name="NAME" x="198.9328" y="16.3322" size="1.27" layer="25" ratio="10" rot="R270"/>
+<attribute name="POPULARITY" value="92" x="197.104" y="12.446" size="1.016" layer="27" rot="R270" display="off"/>
+<attribute name="VALUE" x="193.929" y="16.256" size="1.27" layer="27" rot="R270"/>
+</element>
+<element name="SERVO4" library="pinhead" library_urn="urn:adsk.eagle:library:325" package="1X03" package3d_urn="urn:adsk.eagle:package:22458/2" value="" x="339.725" y="12.7" smashed="yes" rot="R90">
+<attribute name="NAME" x="337.8962" y="8.8138" size="1.27" layer="25" ratio="10" rot="R90"/>
+<attribute name="POPULARITY" value="92" x="339.725" y="12.7" size="1.016" layer="27" rot="R90" display="off"/>
+<attribute name="VALUE" x="342.9" y="8.89" size="1.27" layer="27" rot="R90"/>
+</element>
+<element name="SERVO3" library="pinhead" library_urn="urn:adsk.eagle:library:325" package="1X03" package3d_urn="urn:adsk.eagle:package:22458/2" value="" x="409.194" y="12.7" smashed="yes" rot="R90">
+<attribute name="NAME" x="407.3652" y="8.8138" size="1.27" layer="25" ratio="10" rot="R90"/>
+<attribute name="POPULARITY" value="92" x="409.194" y="12.7" size="1.016" layer="27" rot="R90" display="off"/>
+<attribute name="VALUE" x="412.369" y="8.89" size="1.27" layer="27" rot="R90"/>
+</element>
+<element name="SERVO2" library="pinhead" library_urn="urn:adsk.eagle:library:325" package="1X03" package3d_urn="urn:adsk.eagle:package:22458/2" value="" x="420.37" y="12.7" smashed="yes" rot="R90">
+<attribute name="NAME" x="418.5412" y="8.8138" size="1.27" layer="25" ratio="10" rot="R90"/>
+<attribute name="POPULARITY" value="92" x="420.37" y="12.7" size="1.016" layer="27" rot="R90" display="off"/>
+<attribute name="VALUE" x="423.545" y="8.89" size="1.27" layer="27" rot="R90"/>
+</element>
+<element name="SERVO1" library="pinhead" library_urn="urn:adsk.eagle:library:325" package="1X03" package3d_urn="urn:adsk.eagle:package:22458/2" value="" x="436.88" y="12.7" smashed="yes" rot="R90">
+<attribute name="NAME" x="435.0512" y="8.8138" size="1.27" layer="25" ratio="10" rot="R90"/>
+<attribute name="POPULARITY" value="92" x="436.88" y="12.7" size="1.016" layer="27" rot="R90" display="off"/>
+<attribute name="VALUE" x="440.055" y="8.89" size="1.27" layer="27" rot="R90"/>
+</element>
+<element name="U09I" library="easy_bee_counter" package="QRE1113_DIP400W50P180L360H200Q4" value="QRE1113_QRE1113_" x="245.999" y="24.003" smashed="yes" rot="MR270">
+<attribute name="NAME" x="242.923240625" y="26.07976875" size="1.271940625" layer="26" rot="MR270"/>
+<attribute name="VALUE" x="249.580009375" y="26.08606875" size="1.2732" layer="28" rot="MR270" align="top-left"/>
+</element>
 </elements>
 <signals>
 <signal name="GND">
@@ -18102,76 +18261,6 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <vertex x="81.28" y="12.7"/>
 <vertex x="88.9" y="5.08"/>
 </polygon>
-<wire x1="76.835" y1="25.4" x2="89.535" y2="25.4" width="0.6096" layer="1"/>
-<wire x1="99.187" y1="23.495" x2="101.6" y2="25.908" width="0.6096" layer="1"/>
-<wire x1="101.6" y1="25.908" x2="101.6" y2="27.305" width="0.6096" layer="1"/>
-<wire x1="101.6" y1="27.305" x2="101.6" y2="27.94" width="0.6096" layer="1"/>
-<wire x1="101.6" y1="27.94" x2="100.33" y2="29.21" width="0.6096" layer="1"/>
-<wire x1="100.33" y1="29.21" x2="97.155" y2="29.21" width="0.6096" layer="1"/>
-<wire x1="97.155" y1="29.21" x2="93.345" y2="25.4" width="0.6096" layer="1"/>
-<wire x1="93.345" y1="25.4" x2="89.535" y2="25.4" width="0.6096" layer="1"/>
-<wire x1="116.205" y1="23.622" x2="99.314" y2="23.622" width="0.6096" layer="1"/>
-<wire x1="99.314" y1="23.622" x2="99.187" y2="23.495" width="0.6096" layer="1"/>
-<wire x1="116.205" y1="23.622" x2="118.618" y2="23.622" width="0.6096" layer="16"/>
-<wire x1="118.618" y1="23.622" x2="121.285" y2="20.955" width="0.6096" layer="16"/>
-<wire x1="121.92" y1="20.955" x2="125.73" y2="20.955" width="0.6096" layer="16"/>
-<wire x1="125.73" y1="20.955" x2="132.08" y2="20.955" width="0.6096" layer="16"/>
-<wire x1="111.76" y1="13.335" x2="111.76" y2="10.795" width="0.6096" layer="1"/>
-<wire x1="126.365" y1="16.51" x2="121.92" y2="20.955" width="0.6096" layer="16"/>
-<wire x1="121.92" y1="20.955" x2="121.285" y2="20.955" width="0.6096" layer="16"/>
-<wire x1="111.76" y1="13.335" x2="114.935" y2="16.51" width="0.6096" layer="1"/>
-<wire x1="114.935" y1="16.51" x2="126.365" y2="16.51" width="0.6096" layer="1"/>
-<wire x1="126.365" y1="16.51" x2="127" y2="16.51" width="0.6096" layer="1"/>
-<wire x1="127" y1="16.51" x2="132.08" y2="11.43" width="0.6096" layer="1"/>
-<wire x1="132.08" y1="11.43" x2="132.08" y2="8.255" width="0.6096" layer="1"/>
-<wire x1="132.08" y1="8.255" x2="133.985" y2="6.35" width="0.6096" layer="16"/>
-<wire x1="154.305" y1="6.35" x2="158.115" y2="10.16" width="0.6096" layer="16"/>
-<wire x1="133.985" y1="6.35" x2="148.59" y2="6.35" width="0.6096" layer="16"/>
-<wire x1="148.59" y1="6.35" x2="154.305" y2="6.35" width="0.6096" layer="16"/>
-<wire x1="176.53" y1="3.048" x2="176.022" y2="2.54" width="0.6096" layer="16"/>
-<wire x1="176.022" y1="2.54" x2="173.355" y2="2.54" width="0.6096" layer="16"/>
-<wire x1="173.355" y1="2.54" x2="173.355" y2="1.905" width="0.6096" layer="16"/>
-<wire x1="173.355" y1="1.905" x2="169.545" y2="-1.905" width="0.6096" layer="16"/>
-<wire x1="169.545" y1="-1.905" x2="156.845" y2="-1.905" width="0.6096" layer="16"/>
-<wire x1="156.845" y1="-1.905" x2="148.59" y2="6.35" width="0.6096" layer="16"/>
-<wire x1="176.53" y1="3.048" x2="180.467" y2="6.985" width="0.6096" layer="16"/>
-<wire x1="180.467" y1="6.985" x2="184.15" y2="6.985" width="0.6096" layer="16"/>
-<wire x1="184.15" y1="6.985" x2="189.865" y2="1.27" width="0.6096" layer="16"/>
-<wire x1="189.865" y1="1.27" x2="203.2" y2="1.27" width="0.6096" layer="16"/>
-<wire x1="203.073" y1="1.143" x2="203.2" y2="1.27" width="0.6096" layer="16"/>
-<wire x1="203.2" y1="1.27" x2="210.82" y2="8.89" width="0.6096" layer="16"/>
-<wire x1="210.82" y1="8.89" x2="210.82" y2="10.16" width="0.6096" layer="16"/>
-<wire x1="229.235" y1="3.048" x2="228.727" y2="2.54" width="0.6096" layer="16"/>
-<wire x1="228.727" y1="2.54" x2="226.06" y2="2.54" width="0.6096" layer="16"/>
-<wire x1="226.06" y1="2.54" x2="224.663" y2="1.143" width="0.6096" layer="16"/>
-<wire x1="224.663" y1="1.143" x2="203.073" y2="1.143" width="0.6096" layer="16"/>
-<wire x1="229.235" y1="3.048" x2="232.537" y2="6.35" width="0.6096" layer="16"/>
-<wire x1="232.537" y1="6.35" x2="238.76" y2="6.35" width="0.6096" layer="16"/>
-<wire x1="238.76" y1="6.35" x2="244.475" y2="0.635" width="0.6096" layer="16"/>
-<wire x1="280.035" y1="2.54" x2="278.13" y2="0.635" width="0.6096" layer="16"/>
-<wire x1="278.13" y1="0.635" x2="244.475" y2="0.635" width="0.6096" layer="16"/>
-<wire x1="280.035" y1="2.54" x2="282.702" y2="2.54" width="0.6096" layer="16"/>
-<wire x1="282.702" y1="2.54" x2="283.21" y2="3.048" width="0.6096" layer="16"/>
-<wire x1="283.21" y1="3.048" x2="288.163" y2="3.048" width="0.6096" layer="16"/>
-<wire x1="288.163" y1="3.048" x2="291.465" y2="6.35" width="0.6096" layer="16"/>
-<wire x1="291.465" y1="6.35" x2="297.18" y2="0.635" width="0.6096" layer="16"/>
-<wire x1="332.74" y1="2.54" x2="330.835" y2="0.635" width="0.6096" layer="16"/>
-<wire x1="330.835" y1="0.635" x2="297.18" y2="0.635" width="0.6096" layer="16"/>
-<wire x1="332.74" y1="2.54" x2="335.788" y2="2.54" width="0.6096" layer="16"/>
-<wire x1="335.788" y1="2.54" x2="335.915" y2="2.413" width="0.6096" layer="16"/>
-<wire x1="335.915" y1="2.413" x2="338.963" y2="2.413" width="0.6096" layer="16"/>
-<wire x1="338.963" y1="2.413" x2="342.9" y2="6.35" width="0.6096" layer="16"/>
-<wire x1="384.048" y1="1.143" x2="385.445" y2="2.54" width="0.6096" layer="16"/>
-<wire x1="385.445" y1="2.54" x2="388.493" y2="2.54" width="0.6096" layer="16"/>
-<wire x1="388.493" y1="2.54" x2="388.62" y2="2.413" width="0.6096" layer="16"/>
-<wire x1="388.62" y1="2.413" x2="391.668" y2="2.413" width="0.6096" layer="16"/>
-<wire x1="391.668" y1="2.413" x2="395.605" y2="6.35" width="0.6096" layer="16"/>
-<wire x1="395.605" y1="6.35" x2="403.86" y2="-1.905" width="0.6096" layer="16"/>
-<wire x1="422.275" y1="10.16" x2="422.275" y2="6.985" width="0.6096" layer="16"/>
-<wire x1="422.275" y1="6.985" x2="413.385" y2="-1.905" width="0.6096" layer="16"/>
-<wire x1="403.86" y1="-1.905" x2="413.385" y2="-1.905" width="0.6096" layer="16"/>
-<wire x1="437.515" y1="2.54" x2="433.07" y2="-1.905" width="0.6096" layer="16"/>
-<wire x1="433.07" y1="-1.905" x2="413.385" y2="-1.905" width="0.6096" layer="16"/>
 <polygon width="0.6096" layer="16">
 <vertex x="436.245" y="2.54"/>
 <vertex x="436.245" y="0"/>
@@ -18187,300 +18276,376 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <vertex x="436.245" y="5.715"/>
 <vertex x="436.245" y="3.175"/>
 </polygon>
-<wire x1="348.107" y1="1.143" x2="384.048" y2="1.143" width="0.6096" layer="16"/>
-<wire x1="342.9" y1="6.35" x2="348.107" y2="1.143" width="0.6096" layer="16"/>
-<wire x1="395.605" y1="6.35" x2="393.7" y2="8.255" width="0.6096" layer="1"/>
-<wire x1="372.11" y1="8.255" x2="370.205" y2="10.16" width="0.6096" layer="1"/>
-<wire x1="393.7" y1="8.255" x2="372.11" y2="8.255" width="0.6096" layer="1"/>
-<wire x1="264.795" y1="10.16" x2="262.89" y2="12.065" width="0.6096" layer="16"/>
-<wire x1="260.985" y1="12.065" x2="259.08" y2="10.16" width="0.6096" layer="16"/>
-<wire x1="259.08" y1="10.16" x2="257.81" y2="10.16" width="0.6096" layer="16"/>
-<via x="257.81" y="10.16" extent="1-16" drill="0.3302"/>
-<wire x1="257.81" y1="10.16" x2="242.57" y2="10.16" width="0.6096" layer="1"/>
-<wire x1="242.57" y1="10.16" x2="238.76" y2="6.35" width="0.6096" layer="1"/>
-<wire x1="262.89" y1="12.065" x2="260.985" y2="12.065" width="0.6096" layer="16"/>
-<wire x1="317.5" y1="10.16" x2="319.405" y2="8.255" width="0.6096" layer="16"/>
-<wire x1="340.995" y1="8.255" x2="342.9" y2="6.35" width="0.6096" layer="16"/>
-<wire x1="319.405" y1="8.255" x2="340.995" y2="8.255" width="0.6096" layer="16"/>
+<contactref element="SERVO5" pad="1"/>
+<contactref element="SERVO4" pad="1"/>
+<contactref element="SERVO3" pad="1"/>
+<contactref element="SERVO2" pad="1"/>
+<contactref element="SERVO1" pad="1"/>
+<wire x1="76.835" y1="25.4" x2="89.535" y2="25.4" width="0.6096" layer="1"/>
+<wire x1="89.535" y1="25.4" x2="93.345" y2="29.21" width="0.6096" layer="1"/>
+<wire x1="93.345" y1="29.21" x2="100.33" y2="29.21" width="0.6096" layer="1"/>
+<wire x1="100.33" y1="29.21" x2="101.6" y2="27.94" width="0.6096" layer="1"/>
+<wire x1="101.6" y1="27.94" x2="101.6" y2="27.305" width="0.6096" layer="1"/>
+<wire x1="101.6" y1="27.305" x2="105.283" y2="23.622" width="0.6096" layer="1"/>
+<wire x1="105.283" y1="23.622" x2="116.205" y2="23.622" width="0.6096" layer="1"/>
+<wire x1="116.205" y1="23.622" x2="120.523" y2="23.622" width="0.6096" layer="16"/>
+<wire x1="120.523" y1="23.622" x2="123.19" y2="20.955" width="0.6096" layer="16"/>
+<wire x1="123.19" y1="20.955" x2="125.73" y2="20.955" width="0.6096" layer="16"/>
+<wire x1="125.73" y1="20.955" x2="132.08" y2="20.955" width="0.6096" layer="1"/>
+<wire x1="125.73" y1="20.955" x2="126.365" y2="20.32" width="0.6096" layer="1"/>
+<wire x1="126.365" y1="20.32" x2="126.365" y2="16.51" width="0.6096" layer="1"/>
+<wire x1="101.6" y1="27.305" x2="101.6" y2="25.908" width="0.6096" layer="1"/>
+<wire x1="101.6" y1="25.908" x2="99.187" y2="23.495" width="0.6096" layer="1"/>
+<wire x1="111.76" y1="10.795" x2="111.76" y2="13.335" width="0.6096" layer="16"/>
+<wire x1="111.76" y1="13.335" x2="114.935" y2="16.51" width="0.6096" layer="16"/>
+<wire x1="114.935" y1="16.51" x2="126.365" y2="16.51" width="0.6096" layer="16"/>
+<wire x1="144.78" y1="16.51" x2="142.875" y2="14.605" width="0.2032" layer="16"/>
+<wire x1="142.875" y1="14.605" x2="137.16" y2="14.605" width="0.2032" layer="16"/>
+<wire x1="137.16" y1="14.605" x2="135.255" y2="16.51" width="0.2032" layer="16"/>
+<wire x1="135.255" y1="17.78" x2="132.08" y2="20.955" width="0.2032" layer="16"/>
+<wire x1="135.255" y1="17.78" x2="135.255" y2="16.51" width="0.2032" layer="16"/>
+<wire x1="173.355" y1="2.54" x2="171.45" y2="4.445" width="0.2032" layer="1"/>
+<wire x1="171.45" y1="4.445" x2="168.91" y2="4.445" width="0.2032" layer="1"/>
+<wire x1="168.91" y1="4.445" x2="165.735" y2="7.62" width="0.2032" layer="1"/>
+<wire x1="165.735" y1="7.62" x2="165.735" y2="7.6327" width="0.2032" layer="1"/>
+<via x="165.735" y="7.6327" extent="1-16" drill="0.3302"/>
+<wire x1="165.735" y1="7.6327" x2="160.6423" y2="7.6327" width="0.2032" layer="16"/>
+<wire x1="160.6423" y1="7.6327" x2="158.115" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="157.48" y1="10.16" x2="158.115" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="144.78" y1="16.51" x2="144.78" y2="14.478" width="0.2032" layer="1"/>
+<wire x1="144.78" y1="14.478" x2="149.733" y2="9.525" width="0.2032" layer="1"/>
+<wire x1="149.733" y1="9.525" x2="149.733" y2="9.017" width="0.2032" layer="16"/>
+<wire x1="153.07409375" y1="8.2042" x2="153.12489375" y2="8.255" width="0.2032" layer="16"/>
+<wire x1="155.575" y1="8.255" x2="157.48" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="149.733" y1="9.017" x2="150.5458" y2="8.2042" width="0.2032" layer="16"/>
+<wire x1="150.5458" y1="8.2042" x2="153.07409375" y2="8.2042" width="0.2032" layer="16"/>
+<wire x1="153.12489375" y1="8.255" x2="155.575" y2="8.255" width="0.2032" layer="16"/>
+<wire x1="173.355" y1="2.54" x2="186.055" y2="2.54" width="0.2032" layer="16"/>
+<via x="186.055" y="2.54" extent="1-16" drill="0.3302"/>
+<wire x1="186.055" y1="2.54" x2="194.945" y2="11.43" width="0.2032" layer="1"/>
+<wire x1="194.945" y1="11.43" x2="194.945" y2="12.827" width="0.2032" layer="1"/>
+<wire x1="194.945" y1="12.827" x2="197.104" y2="14.986" width="0.2032" layer="1"/>
+<wire x1="203.2" y1="16.51" x2="198.628" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="198.628" y1="16.51" x2="197.104" y2="14.986" width="0.2032" layer="1"/>
+<wire x1="203.2" y1="16.51" x2="204.978" y2="14.732" width="0.2032" layer="1"/>
+<wire x1="204.978" y1="14.732" x2="204.978" y2="10.16" width="0.2032" layer="1"/>
+<wire x1="204.978" y1="10.16" x2="206.883" y2="8.255" width="0.2032" layer="16"/>
+<wire x1="211.455" y1="8.255" x2="213.36" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="206.883" y1="8.255" x2="211.455" y2="8.255" width="0.2032" layer="16"/>
+<wire x1="213.36" y1="10.16" x2="215.2424" y2="8.2776" width="0.2032" layer="16"/>
+<wire x1="215.2424" y1="8.2776" x2="222.25" y2="8.2776" width="0.2032" layer="16"/>
+<via x="222.25" y="8.2776" extent="1-16" drill="0.35"/>
+<wire x1="222.25" y1="8.2776" x2="222.2726" y2="8.255" width="0.2032" layer="1"/>
+<wire x1="222.2726" y1="8.255" x2="222.885" y2="8.255" width="0.2032" layer="1"/>
+<wire x1="222.885" y1="8.255" x2="228.6" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="228.6" y1="2.54" x2="229.235" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="229.235" y1="2.54" x2="233.553" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="241.173" y1="10.16" x2="233.553" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="241.173" y1="10.16" x2="243.713" y2="10.16" width="0.2032" layer="1"/>
+<wire x1="243.713" y1="10.16" x2="245.618" y2="8.255" width="0.2032" layer="16"/>
+<wire x1="250.19" y1="8.255" x2="252.095" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="245.618" y1="8.255" x2="250.19" y2="8.255" width="0.2032" layer="16"/>
+<wire x1="226.695" y1="17.78" x2="231.775" y2="12.7" width="0.2032" layer="1"/>
+<wire x1="231.775" y1="5.08" x2="229.235" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="231.775" y1="12.7" x2="231.775" y2="5.08" width="0.2032" layer="1"/>
+<wire x1="409.194" y1="10.16" x2="420.37" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="420.37" y1="10.16" x2="436.88" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="267.335" y1="2.54" x2="262.2324" y2="7.6426" width="0.2032" layer="1"/>
+<wire x1="262.2324" y1="7.6426" x2="260.985" y2="7.6426" width="0.2032" layer="1"/>
+<via x="260.985" y="7.6426" extent="1-16" drill="0.35"/>
+<wire x1="260.985" y1="7.6426" x2="255.2474" y2="7.6426" width="0.2032" layer="16"/>
+<wire x1="255.2474" y1="7.6426" x2="252.73" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="252.73" y1="10.16" x2="252.095" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="281.813" y1="2.54" x2="289.433" y2="10.16" width="0.2032" layer="1"/>
+<wire x1="267.335" y1="2.54" x2="281.813" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="289.433" y1="10.16" x2="289.56" y2="10.287" width="0.2032" layer="1"/>
+<wire x1="289.56" y1="10.287" x2="289.56" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="289.433" y1="10.16" x2="290.9316" y2="8.6614" width="0.2032" layer="16"/>
+<wire x1="290.9316" y1="8.6614" x2="296.545" y2="8.6614" width="0.2032" layer="16"/>
+<wire x1="296.545" y1="8.6614" x2="297.815" y2="9.9314" width="0.2032" layer="16"/>
+<wire x1="297.815" y1="9.9314" x2="297.815" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="297.815" y1="10.16" x2="297.815" y2="9.779" width="0.2032" layer="16"/>
+<wire x1="299.0596" y1="8.5344" x2="297.815" y2="9.779" width="0.2032" layer="16"/>
+<wire x1="307.7182" y1="8.5344" x2="307.975" y2="8.2776" width="0.2032" layer="16"/>
+<via x="307.975" y="8.2776" extent="1-16" drill="0.35"/>
+<wire x1="307.975" y1="8.2776" x2="313.055" y2="3.1976" width="0.2032" layer="1"/>
+<wire x1="313.055" y1="3.1976" x2="313.055" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="299.0596" y1="8.5344" x2="307.7182" y2="8.5344" width="0.2032" layer="16"/>
+<wire x1="314.325" y1="1.27" x2="330.835" y2="1.27" width="0.2032" layer="1"/>
+<wire x1="330.835" y1="1.27" x2="339.725" y2="10.16" width="0.2032" layer="1"/>
+<wire x1="313.055" y1="2.54" x2="314.325" y2="1.27" width="0.2032" layer="1"/>
+<wire x1="339.725" y1="10.16" x2="343.408" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="343.408" y1="10.16" x2="343.408" y2="16.383" width="0.2032" layer="1"/>
+<wire x1="343.408" y1="16.383" x2="343.535" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="351.79" y1="10.16" x2="351.155" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="351.155" y1="10.16" x2="349.25" y2="8.255" width="0.2032" layer="16"/>
+<wire x1="345.313" y1="8.255" x2="343.408" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="349.25" y1="8.255" x2="345.313" y2="8.255" width="0.2032" layer="16"/>
+<wire x1="351.79" y1="10.16" x2="352.425" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="352.425" y1="10.16" x2="355.6" y2="6.985" width="0.2032" layer="16"/>
+<wire x1="355.6" y1="6.985" x2="362.5624" y2="6.985" width="0.2032" layer="16"/>
+<wire x1="362.5624" y1="6.985" x2="362.585" y2="7.0076" width="0.2032" layer="16"/>
+<via x="362.585" y="7.0076" extent="1-16" drill="0.35"/>
+<wire x1="367.03" y1="2.5626" x2="362.585" y2="7.0076" width="0.2032" layer="1"/>
+<wire x1="367.03" y1="2.5626" x2="367.03" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="367.03" y1="2.54" x2="372.618" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="372.618" y1="2.54" x2="380.238" y2="10.16" width="0.2032" layer="1"/>
+<wire x1="380.238" y1="10.16" x2="381" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="381" y1="10.16" x2="382.397" y2="8.763" width="0.2032" layer="16"/>
+<wire x1="382.397" y1="8.763" x2="387.858" y2="8.763" width="0.2032" layer="16"/>
+<wire x1="387.858" y1="8.763" x2="389.255" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="389.255" y1="10.16" x2="389.255" y2="10.795" width="0.2032" layer="1"/>
+<wire x1="392.43" y1="13.97" x2="389.255" y2="10.795" width="0.2032" layer="1"/>
+<wire x1="392.43" y1="13.97" x2="392.43" y2="18.415" width="0.2032" layer="16"/>
+<wire x1="404.495" y1="2.54" x2="404.495" y2="5.461" width="0.2032" layer="1"/>
+<wire x1="404.495" y1="5.461" x2="409.194" y2="10.16" width="0.2032" layer="1"/>
+<wire x1="389.255" y1="10.16" x2="390.525" y2="11.43" width="0.2032" layer="16"/>
+<wire x1="390.525" y1="11.43" x2="407.924" y2="11.43" width="0.2032" layer="16"/>
+<wire x1="407.924" y1="11.43" x2="409.194" y2="10.16" width="0.2032" layer="16"/>
+<via x="392.43" y="13.97" extent="1-16" drill="0.35"/>
+<wire x1="436.88" y1="10.16" x2="442.595" y2="4.445" width="0.2032" layer="16"/>
+<wire x1="442.595" y1="4.445" x2="442.595" y2="1.397" width="0.2032" layer="16"/>
 </signal>
-<signal name="N$30">
-<contactref element="U$114" pad="4"/>
+<signal name="SNS01I">
+<contactref element="U01I" pad="4"/>
 <contactref element="R12" pad="P$3"/>
-<contactref element="U6" pad="11"/>
-<wire x1="137.16" y1="8.255" x2="141.097" y2="12.192" width="0.2032" layer="16"/>
-<wire x1="141.097" y1="12.192" x2="141.097" y2="16.002" width="0.2032" layer="16"/>
-<wire x1="141.097" y1="16.002" x2="142.356" y2="17.261" width="0.2032" layer="16"/>
-<wire x1="142.356" y1="17.261" x2="142.399" y2="17.261" width="0.2032" layer="16"/>
-<wire x1="142.399" y1="17.261" x2="143.394" y2="17.261" width="0.2032" layer="16"/>
-<wire x1="143.394" y1="17.261" x2="144.145" y2="16.51" width="0.2032" layer="16"/>
-<wire x1="144.145" y1="12.7" x2="144.78" y2="12.065" width="0.2032" layer="16"/>
-<via x="144.78" y="12.065" extent="1-16" drill="0.55"/>
-<wire x1="144.78" y1="12.065" x2="147.32" y2="9.525" width="0.2032" layer="1"/>
-<wire x1="147.32" y1="9.525" x2="153.035" y2="9.525" width="0.2032" layer="1"/>
-<wire x1="153.035" y1="9.525" x2="154.305" y2="8.255" width="0.2032" layer="1"/>
-<wire x1="154.305" y1="8.255" x2="166.37" y2="8.255" width="0.2032" layer="1"/>
-<wire x1="166.37" y1="8.255" x2="168.275" y2="10.16" width="0.2032" layer="1"/>
-<wire x1="144.145" y1="16.51" x2="144.145" y2="12.7" width="0.2032" layer="16"/>
-</signal>
-<signal name="N$101">
-<contactref element="U$112" pad="4"/>
-<contactref element="R12" pad="P$4"/>
-<contactref element="U6" pad="13"/>
-<wire x1="139.7" y1="8.255" x2="142.24" y2="10.795" width="0.2032" layer="16"/>
-<wire x1="142.24" y1="10.795" x2="150.495" y2="10.795" width="0.2032" layer="16"/>
-<wire x1="150.495" y1="10.795" x2="153.67" y2="13.97" width="0.2032" layer="16"/>
-<wire x1="153.67" y1="15.875" x2="153.67" y2="13.97" width="0.2032" layer="16"/>
-<wire x1="153.67" y1="15.875" x2="155.056" y2="17.261" width="0.2032" layer="16"/>
-<wire x1="155.056" y1="17.261" x2="155.099" y2="17.261" width="0.2032" layer="16"/>
-<wire x1="153.67" y1="13.97" x2="157.48" y2="13.97" width="0.2032" layer="16"/>
-<via x="157.48" y="13.97" extent="1-16" drill="0.55"/>
-<wire x1="157.48" y1="13.97" x2="159.385" y2="13.97" width="0.2032" layer="1"/>
-<wire x1="159.385" y1="13.97" x2="163.195" y2="10.16" width="0.2032" layer="1"/>
-</signal>
-<signal name="N$102">
-<contactref element="U$113" pad="4"/>
-<contactref element="R12" pad="P$5"/>
-<contactref element="U6" pad="14"/>
-<wire x1="155.099" y1="21.4266" x2="155.1034" y2="21.4266" width="0.2032" layer="16"/>
-<wire x1="155.1034" y1="21.4266" x2="156.845" y2="19.685" width="0.2032" layer="16"/>
-<wire x1="156.845" y1="19.685" x2="156.845" y2="16.51" width="0.2032" layer="16"/>
-<wire x1="156.845" y1="16.51" x2="158.75" y2="14.605" width="0.2032" layer="16"/>
-<wire x1="158.75" y1="14.605" x2="158.75" y2="12.065" width="0.2032" layer="16"/>
-<wire x1="158.75" y1="12.065" x2="160.655" y2="10.16" width="0.2032" layer="16"/>
-<wire x1="142.24" y1="8.255" x2="144.145" y2="10.16" width="0.2032" layer="16"/>
-<wire x1="152.4" y1="10.16" x2="154.305" y2="12.065" width="0.2032" layer="16"/>
-<wire x1="154.305" y1="12.065" x2="158.75" y2="12.065" width="0.2032" layer="16"/>
-<wire x1="144.145" y1="10.16" x2="152.4" y2="10.16" width="0.2032" layer="16"/>
-</signal>
-<signal name="N$108">
-<contactref element="U$108" pad="4"/>
-<contactref element="R12" pad="P$8"/>
-<contactref element="U6" pad="5"/>
-<wire x1="149.86" y1="8.255" x2="152.4" y2="5.715" width="0.2032" layer="1"/>
-<wire x1="162.56" y1="5.715" x2="165.735" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="152.4" y1="5.715" x2="162.56" y2="5.715" width="0.2032" layer="1"/>
-<wire x1="165.735" y1="2.54" x2="172.085" y2="8.89" width="0.2032" layer="16"/>
-<wire x1="172.085" y1="8.89" x2="174.625" y2="8.89" width="0.2032" layer="16"/>
-<wire x1="174.625" y1="8.89" x2="180.499" y2="14.764" width="0.2032" layer="16"/>
-<wire x1="180.499" y1="14.764" x2="180.499" y2="17.261" width="0.2032" layer="16"/>
-</signal>
-<signal name="N$109">
-<contactref element="U$109" pad="4"/>
-<contactref element="R12" pad="P$9"/>
-<contactref element="U6" pad="6"/>
-<wire x1="152.4" y1="8.255" x2="154.305" y2="6.35" width="0.2032" layer="1"/>
-<wire x1="164.465" y1="6.35" x2="168.275" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="154.305" y1="6.35" x2="164.465" y2="6.35" width="0.2032" layer="1"/>
-<wire x1="168.275" y1="2.54" x2="173.355" y2="7.62" width="0.2032" layer="16"/>
-<wire x1="175.26" y1="7.62" x2="182.245" y2="14.605" width="0.2032" layer="16"/>
-<wire x1="182.245" y1="14.605" x2="182.245" y2="19.6806" width="0.2032" layer="16"/>
-<wire x1="182.245" y1="19.6806" x2="180.499" y2="21.4266" width="0.2032" layer="16"/>
-<wire x1="173.355" y1="7.62" x2="175.26" y2="7.62" width="0.2032" layer="16"/>
-</signal>
-<signal name="N$18">
-<contactref element="U$110" pad="4"/>
-<contactref element="R12" pad="P$6"/>
-<contactref element="U6" pad="3"/>
-<wire x1="144.78" y1="8.255" x2="148.59" y2="4.445" width="0.2032" layer="1"/>
-<wire x1="160.655" y1="3.175" x2="159.385" y2="4.445" width="0.2032" layer="1"/>
-<wire x1="160.655" y1="3.175" x2="160.655" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="148.59" y1="4.445" x2="159.385" y2="4.445" width="0.2032" layer="1"/>
-<wire x1="167.799" y1="17.261" x2="167.64" y2="17.102" width="0.2032" layer="16"/>
-<wire x1="167.64" y1="12.065" x2="167.005" y2="11.43" width="0.2032" layer="16"/>
-<wire x1="167.005" y1="11.43" x2="167.005" y2="8.89" width="0.2032" layer="16"/>
-<wire x1="167.005" y1="8.89" x2="160.655" y2="2.54" width="0.2032" layer="16"/>
-<wire x1="167.64" y1="17.102" x2="167.64" y2="12.065" width="0.2032" layer="16"/>
-</signal>
-<signal name="N$58">
-<contactref element="U$111" pad="4"/>
-<contactref element="R12" pad="P$7"/>
 <contactref element="U6" pad="4"/>
-<wire x1="147.32" y1="8.255" x2="150.495" y2="5.08" width="0.2032" layer="1"/>
-<wire x1="160.655" y1="5.08" x2="163.195" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="150.495" y1="5.08" x2="160.655" y2="5.08" width="0.2032" layer="1"/>
-<wire x1="167.799" y1="21.4266" x2="167.799" y2="20.796" width="0.2032" layer="16"/>
-<wire x1="167.799" y1="20.796" x2="169.545" y2="19.05" width="0.2032" layer="16"/>
-<wire x1="169.545" y1="8.89" x2="163.195" y2="2.54" width="0.2032" layer="16"/>
-<wire x1="169.545" y1="19.05" x2="169.545" y2="8.89" width="0.2032" layer="16"/>
+<wire x1="149.86" y1="16.51" x2="149.86" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="154.305" y1="10.795" x2="149.86" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="154.305" y1="10.795" x2="154.305" y2="8.89" width="0.2032" layer="1"/>
+<wire x1="154.305" y1="8.89" x2="156.21" y2="6.985" width="0.2032" layer="1"/>
+<wire x1="158.75" y1="6.985" x2="163.195" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="156.21" y1="6.985" x2="158.75" y2="6.985" width="0.2032" layer="1"/>
+<wire x1="149.86" y1="16.51" x2="143.51" y2="22.86" width="0.2032" layer="1"/>
+<wire x1="143.51" y1="22.86" x2="142.399" y2="22.86" width="0.2032" layer="1"/>
+<wire x1="142.399" y1="22.86" x2="142.399" y2="23.103" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$105">
-<contactref element="U$105" pad="4"/>
-<contactref element="R11" pad="P$5"/>
-<contactref element="U5" pad="14"/>
-<wire x1="213.36" y1="10.16" x2="213.36" y2="12.065" width="0.2032" layer="1"/>
-<wire x1="213.36" y1="12.065" x2="210.82" y2="14.605" width="0.2032" layer="1"/>
-<wire x1="210.82" y1="14.605" x2="208.28" y2="14.605" width="0.2032" layer="1"/>
-<wire x1="208.28" y1="14.605" x2="207.645" y2="15.24" width="0.2032" layer="16"/>
-<wire x1="207.645" y1="15.24" x2="207.645" y2="19.685" width="0.2032" layer="16"/>
-<wire x1="207.645" y1="19.685" x2="205.9034" y2="21.4266" width="0.2032" layer="16"/>
-<wire x1="205.9034" y1="21.4266" x2="205.899" y2="21.4266" width="0.2032" layer="16"/>
-<wire x1="194.31" y1="6.985" x2="200.025" y2="12.7" width="0.2032" layer="16"/>
-<wire x1="208.28" y1="14.605" x2="206.375" y2="12.7" width="0.2032" layer="1"/>
-<wire x1="205.105" y1="12.7" x2="206.375" y2="12.7" width="0.2032" layer="1"/>
-<wire x1="200.025" y1="12.7" x2="205.105" y2="12.7" width="0.2032" layer="16"/>
-<via x="208.28" y="14.605" extent="1-16" drill="0.3302"/>
-<via x="205.105" y="12.7" extent="1-16" drill="0.3302"/>
+<signal name="SNS02I">
+<contactref element="U02I" pad="4"/>
+<contactref element="R12" pad="P$5"/>
+<contactref element="U6" pad="6"/>
+<wire x1="154.94" y1="16.51" x2="159.385" y2="12.065" width="0.2032" layer="1"/>
+<wire x1="159.385" y1="12.065" x2="159.385" y2="8.89" width="0.2032" layer="1"/>
+<wire x1="159.385" y1="8.89" x2="160.02" y2="8.255" width="0.2032" layer="1"/>
+<wire x1="160.02" y1="8.255" x2="162.56" y2="8.255" width="0.2032" layer="1"/>
+<wire x1="162.56" y1="8.255" x2="168.275" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="154.94" y1="16.51" x2="155.099" y2="16.669" width="0.2032" layer="1"/>
+<wire x1="155.099" y1="16.669" x2="155.099" y2="23.103" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$112">
-<contactref element="U$101" pad="4"/>
+<signal name="SNS02O">
+<contactref element="R12" pad="P$4"/>
+<contactref element="U02O" pad="4"/>
+<contactref element="U6" pad="5"/>
+<wire x1="152.4" y1="16.51" x2="156.845" y2="12.065" width="0.2032" layer="1"/>
+<wire x1="156.845" y1="12.065" x2="156.845" y2="8.89" width="0.2032" layer="1"/>
+<wire x1="156.845" y1="8.89" x2="158.115" y2="7.62" width="0.2032" layer="1"/>
+<wire x1="160.655" y1="7.62" x2="165.735" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="158.115" y1="7.62" x2="160.655" y2="7.62" width="0.2032" layer="1"/>
+<wire x1="152.4" y1="16.51" x2="152.4" y2="26.035" width="0.2032" layer="1"/>
+<wire x1="152.4" y1="26.035" x2="153.786" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="153.786" y1="27.421" x2="155.099" y2="27.421" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS04I">
+<contactref element="U04I" pad="4"/>
+<contactref element="U6" pad="11"/>
+<contactref element="R12" pad="P$9"/>
+<wire x1="165.1" y1="16.51" x2="165.1" y2="13.335" width="0.2032" layer="1"/>
+<wire x1="165.1" y1="13.335" x2="168.275" y2="10.16" width="0.2032" layer="1"/>
+<wire x1="176.446" y1="19.05" x2="180.499" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="176.446" y1="19.05" x2="167.64" y2="19.05" width="0.2032" layer="1"/>
+<wire x1="165.1" y1="16.51" x2="167.64" y2="19.05" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS04O">
+<contactref element="U04O" pad="4"/>
+<contactref element="U6" pad="12"/>
+<contactref element="R12" pad="P$8"/>
+<wire x1="162.56" y1="16.51" x2="162.56" y2="13.335" width="0.2032" layer="1"/>
+<wire x1="162.56" y1="13.335" x2="165.735" y2="10.16" width="0.2032" layer="1"/>
+<wire x1="170.815" y1="19.685" x2="165.735" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="162.56" y1="16.51" x2="165.735" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="173.99" y1="22.86" x2="174.625" y2="22.86" width="0.2032" layer="1"/>
+<wire x1="179.186" y1="27.421" x2="180.499" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="170.815" y1="19.685" x2="173.99" y2="22.86" width="0.2032" layer="1"/>
+<wire x1="174.625" y1="22.86" x2="179.186" y2="27.421" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS03I">
+<contactref element="U03I" pad="4"/>
+<contactref element="U6" pad="13"/>
+<contactref element="R12" pad="P$7"/>
+<wire x1="160.02" y1="16.51" x2="160.02" y2="13.97" width="0.2032" layer="1"/>
+<wire x1="163.195" y1="10.795" x2="163.195" y2="10.16" width="0.2032" layer="1"/>
+<wire x1="163.195" y1="10.795" x2="160.02" y2="13.97" width="0.2032" layer="1"/>
+<wire x1="163.19499375" y1="17.77999375" x2="161.289996875" y2="17.779996875" width="0.2032" layer="1"/>
+<wire x1="160.02" y1="16.51" x2="161.289996875" y2="17.779996875" width="0.2032" layer="1"/>
+<wire x1="167.799" y1="22.384" x2="167.799" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="163.19499375" y1="17.77999375" x2="167.799" y2="22.384" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS03O">
+<contactref element="U03O" pad="4"/>
+<contactref element="U6" pad="14"/>
+<contactref element="R12" pad="P$6"/>
+<wire x1="157.48" y1="16.51" x2="157.48" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="160.655" y1="12.065" x2="157.48" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="160.655" y1="12.065" x2="160.655" y2="10.16" width="0.2032" layer="1"/>
+<wire x1="157.48" y1="16.51" x2="159.385" y2="18.415" width="0.2032" layer="1"/>
+<wire x1="163.195" y1="18.415" x2="159.385" y2="18.415" width="0.2032" layer="1"/>
+<wire x1="163.195" y1="18.415" x2="165.1" y2="20.32" width="0.2032" layer="1"/>
+<wire x1="165.1" y1="20.32" x2="165.1" y2="24.765" width="0.2032" layer="1"/>
+<wire x1="165.1" y1="24.765" x2="167.756" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="167.756" y1="27.421" x2="167.799" y2="27.421" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS08I">
+<contactref element="U08I" pad="4"/>
 <contactref element="R11" pad="P$9"/>
-<contactref element="U5" pad="6"/>
-<wire x1="204.47" y1="6.985" x2="205.105" y2="6.35" width="0.2032" layer="1"/>
-<wire x1="217.17" y1="6.35" x2="205.105" y2="6.35" width="0.2032" layer="1"/>
-<wire x1="217.17" y1="6.35" x2="220.98" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="231.299" y1="21.4266" x2="231.9384" y2="21.4266" width="0.2032" layer="16"/>
-<wire x1="231.9384" y1="21.4266" x2="233.045" y2="20.32" width="0.2032" layer="16"/>
-<wire x1="233.045" y1="20.32" x2="233.045" y2="14.605" width="0.2032" layer="16"/>
-<wire x1="233.045" y1="14.605" x2="220.98" y2="2.54" width="0.2032" layer="16"/>
+<contactref element="U5" pad="11"/>
+<wire x1="223.52" y1="10.16" x2="223.52" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="223.52" y1="16.51" x2="223.52" y2="17.145" width="0.2032" layer="1"/>
+<wire x1="225.933" y1="19.558" x2="223.52" y2="17.145" width="0.2032" layer="1"/>
+<wire x1="225.933" y1="19.558" x2="228.473" y2="19.558" width="0.2032" layer="1"/>
+<wire x1="228.473" y1="19.558" x2="231.299" y2="22.384" width="0.2032" layer="1"/>
+<wire x1="231.299" y1="22.384" x2="231.299" y2="23.103" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$117">
-<contactref element="U$103" pad="4"/>
-<contactref element="R11" pad="P$7"/>
-<contactref element="U5" pad="4"/>
-<wire x1="199.39" y1="6.985" x2="201.295" y2="5.08" width="0.2032" layer="1"/>
-<wire x1="213.36" y1="5.08" x2="215.9" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="201.295" y1="5.08" x2="213.36" y2="5.08" width="0.2032" layer="1"/>
-<wire x1="218.599" y1="21.4266" x2="218.6034" y2="21.4266" width="0.2032" layer="16"/>
-<wire x1="220.345" y1="11.43" x2="219.71" y2="10.795" width="0.2032" layer="16"/>
-<wire x1="219.71" y1="6.35" x2="215.9" y2="2.54" width="0.2032" layer="16"/>
-<wire x1="218.6034" y1="21.4266" x2="220.345" y2="19.685" width="0.2032" layer="16"/>
-<wire x1="220.345" y1="19.685" x2="220.345" y2="11.43" width="0.2032" layer="16"/>
-<wire x1="219.71" y1="10.795" x2="219.71" y2="6.35" width="0.2032" layer="16"/>
-</signal>
-<signal name="N$131">
-<contactref element="U$97" pad="4"/>
+<signal name="SNS10I">
 <contactref element="R7" pad="P$5"/>
-<contactref element="U4" pad="14"/>
-<wire x1="248.92" y1="6.35" x2="252.095" y2="9.525" width="0.2032" layer="16"/>
-<wire x1="253.365" y1="9.525" x2="252.095" y2="9.525" width="0.2032" layer="16"/>
-<wire x1="258.445" y1="14.605" x2="253.365" y2="9.525" width="0.2032" layer="16"/>
-<wire x1="258.445" y1="14.605" x2="258.445" y2="19.6806" width="0.2032" layer="16"/>
-<wire x1="258.445" y1="19.6806" x2="256.699" y2="21.4266" width="0.2032" layer="16"/>
-<wire x1="267.335" y1="10.16" x2="262.89" y2="14.605" width="0.2032" layer="16"/>
-<wire x1="262.89" y1="14.605" x2="258.445" y2="14.605" width="0.2032" layer="16"/>
-</signal>
-<signal name="N$135">
-<contactref element="U$93" pad="4"/>
-<contactref element="R7" pad="P$9"/>
+<contactref element="U10I" pad="4"/>
 <contactref element="U4" pad="6"/>
-<wire x1="259.08" y1="6.35" x2="271.145" y2="6.35" width="0.2032" layer="1"/>
-<wire x1="271.145" y1="6.35" x2="274.955" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="282.099" y1="21.4266" x2="280.035" y2="19.3626" width="0.2032" layer="16"/>
-<wire x1="280.035" y1="12.7" x2="278.765" y2="11.43" width="0.2032" layer="16"/>
-<wire x1="278.765" y1="11.43" x2="278.765" y2="7.62" width="0.2032" layer="16"/>
-<via x="278.765" y="7.62" extent="1-16" drill="0.3302"/>
-<wire x1="278.765" y1="7.62" x2="278.765" y2="6.35" width="0.2032" layer="1"/>
-<wire x1="278.765" y1="6.35" x2="274.955" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="280.035" y1="19.3626" x2="280.035" y2="12.7" width="0.2032" layer="16"/>
+<wire x1="262.255" y1="2.54" x2="258.445" y2="6.35" width="0.2032" layer="1"/>
+<wire x1="258.445" y1="6.35" x2="254.635" y2="6.35" width="0.2032" layer="1"/>
+<wire x1="254.635" y1="6.35" x2="253.365" y2="7.62" width="0.2032" layer="1"/>
+<wire x1="253.365" y1="7.62" x2="253.365" y2="11.43" width="0.2032" layer="1"/>
+<wire x1="253.365" y1="11.43" x2="250.19" y2="14.605" width="0.2032" layer="1"/>
+<wire x1="250.19" y1="14.605" x2="240.03" y2="14.605" width="0.2032" layer="1"/>
+<wire x1="240.03" y1="14.605" x2="236.855" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="238.3536" y1="19.2786" x2="240.1983375" y2="19.2786" width="0.2032" layer="1"/>
+<wire x1="240.1983375" y1="19.2786" x2="241.7477375" y2="20.828" width="0.2032" layer="1"/>
+<wire x1="251.703" y1="23.103" x2="256.699" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="236.855" y1="17.78" x2="238.3536" y2="19.2786" width="0.2032" layer="1"/>
+<wire x1="241.7477375" y1="20.828" x2="249.428" y2="20.828" width="0.2032" layer="1"/>
+<wire x1="249.428" y1="20.828" x2="251.703" y2="23.103" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$140">
-<contactref element="U$95" pad="4"/>
+<signal name="SNS12I">
+<contactref element="R7" pad="P$9"/>
+<contactref element="U12I" pad="4"/>
+<contactref element="U4" pad="11"/>
+<wire x1="262.255" y1="10.16" x2="262.255" y2="13.97" width="0.2032" layer="1"/>
+<wire x1="262.255" y1="13.97" x2="259.08" y2="17.145" width="0.2032" layer="1"/>
+<wire x1="247.65" y1="17.145" x2="247.015" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="259.08" y1="17.145" x2="247.65" y2="17.145" width="0.2032" layer="1"/>
+<wire x1="262.255" y1="20.7916" x2="264.16" y2="22.6966" width="0.2032" layer="1"/>
+<wire x1="264.16" y1="22.6966" x2="265.5934" y2="22.6966" width="0.2032" layer="1"/>
+<wire x1="262.255" y1="13.97" x2="262.255" y2="20.7916" width="0.2032" layer="1"/>
+<wire x1="267.1064" y1="21.1836" x2="275.1836" y2="21.1836" width="0.2032" layer="1"/>
+<wire x1="265.5934" y1="22.6966" x2="267.1064" y2="21.1836" width="0.2032" layer="1"/>
+<wire x1="277.103" y1="23.103" x2="282.099" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="275.1836" y1="21.1836" x2="277.103" y2="23.103" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS11I">
 <contactref element="R7" pad="P$7"/>
-<contactref element="U4" pad="4"/>
-<wire x1="254" y1="6.35" x2="255.651" y2="4.699" width="0.2032" layer="1"/>
-<wire x1="267.716" y1="4.699" x2="269.875" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="255.651" y1="4.699" x2="267.716" y2="4.699" width="0.2032" layer="1"/>
-<wire x1="269.399" y1="21.4266" x2="270.0384" y2="21.4266" width="0.2032" layer="16"/>
-<wire x1="272.3322" y1="16.8191125" x2="272.415" y2="16.7363125" width="0.2032" layer="16"/>
-<wire x1="272.415" y1="16.7363125" x2="272.415" y2="12.7" width="0.2032" layer="16"/>
-<wire x1="272.3322" y1="19.1328" x2="272.3322" y2="16.8191125" width="0.2032" layer="16"/>
-<wire x1="272.415" y1="12.7" x2="273.685" y2="11.43" width="0.2032" layer="16"/>
-<wire x1="273.685" y1="11.43" x2="273.685" y2="9.525" width="0.2032" layer="16"/>
-<wire x1="273.685" y1="9.525" x2="271.78" y2="7.62" width="0.2032" layer="1"/>
-<wire x1="255.27" y1="7.62" x2="254" y2="6.35" width="0.2032" layer="1"/>
-<wire x1="270.0384" y1="21.4266" x2="272.3322" y2="19.1328" width="0.2032" layer="16"/>
-<wire x1="271.78" y1="7.62" x2="255.27" y2="7.62" width="0.2032" layer="1"/>
-<via x="273.685" y="9.525" extent="1-16" drill="0.3302"/>
+<contactref element="U11I" pad="4"/>
+<contactref element="U4" pad="13"/>
+<wire x1="257.175" y1="10.16" x2="257.175" y2="12.7" width="0.2032" layer="1"/>
+<wire x1="257.175" y1="12.7" x2="254" y2="15.875" width="0.2032" layer="1"/>
+<wire x1="243.205" y1="15.875" x2="241.935" y2="17.145" width="0.2032" layer="1"/>
+<wire x1="241.935" y1="17.145" x2="241.935" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="254" y1="15.875" x2="243.205" y2="15.875" width="0.2032" layer="1"/>
+<wire x1="242.824" y1="19.558" x2="241.935" y2="18.669" width="0.2032" layer="1"/>
+<wire x1="241.935" y1="17.78" x2="241.935" y2="18.669" width="0.2032" layer="1"/>
+<wire x1="266.605" y1="23.103" x2="269.399" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="266.605" y1="23.103" x2="265.716" y2="23.992" width="0.2032" layer="1"/>
+<wire x1="265.716" y1="23.992" x2="264.022" y2="23.992" width="0.2032" layer="1"/>
+<wire x1="242.824" y1="19.558" x2="259.588" y2="19.558" width="0.2032" layer="1"/>
+<wire x1="259.588" y1="19.558" x2="264.022" y2="23.992" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$141">
-<contactref element="U$99" pad="4"/>
-<contactref element="R7" pad="P$3"/>
-<contactref element="U4" pad="12"/>
-<wire x1="243.84" y1="6.35" x2="243.84" y2="13.335" width="0.2032" layer="16"/>
-<wire x1="243.84" y1="13.335" x2="243.84" y2="13.97" width="0.2032" layer="16"/>
-<wire x1="243.84" y1="13.97" x2="245.745" y2="15.875" width="0.2032" layer="16"/>
-<wire x1="245.745" y1="15.875" x2="245.745" y2="19.6806" width="0.2032" layer="16"/>
-<wire x1="245.745" y1="19.6806" x2="243.999" y2="21.4266" width="0.2032" layer="16"/>
-<wire x1="272.415" y1="10.16" x2="272.415" y2="11.43" width="0.2032" layer="16"/>
-<wire x1="272.415" y1="11.43" x2="271.145" y2="12.7" width="0.2032" layer="16"/>
-<via x="271.145" y="12.7" extent="1-16" drill="0.3302"/>
-<wire x1="271.145" y1="12.7" x2="270.51" y2="13.335" width="0.2032" layer="1"/>
-<via x="243.84" y="13.335" extent="1-16" drill="0.3302"/>
-<wire x1="270.51" y1="13.335" x2="243.84" y2="13.335" width="0.2032" layer="1"/>
+<signal name="SNS09O">
+<contactref element="U4" pad="3"/>
+<wire x1="247.015" y1="4.445" x2="245.11" y2="6.35" width="0.2032" layer="1"/>
+<wire x1="245.11" y1="6.35" x2="245.11" y2="10.795" width="0.2032" layer="1"/>
+<wire x1="245.11" y1="10.795" x2="244.348" y2="11.557" width="0.2032" layer="1"/>
+<wire x1="252.73" y1="4.445" x2="247.015" y2="4.445" width="0.2032" layer="1"/>
+<contactref element="R7" pad="P$2"/>
+<contactref element="U09O" pad="4"/>
+<wire x1="234.188" y1="11.557" x2="229.235" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="229.235" y1="16.51" x2="229.235" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="244.348" y1="11.557" x2="234.188" y2="11.557" width="0.2032" layer="1"/>
+<wire x1="254.635" y1="2.54" x2="252.73" y2="4.445" width="0.2032" layer="1"/>
+<wire x1="229.235" y1="17.78" x2="233.045" y2="21.59" width="0.2032" layer="1"/>
+<wire x1="233.045" y1="21.59" x2="235.585" y2="21.59" width="0.2032" layer="1"/>
+<wire x1="235.585" y1="21.59" x2="237.49" y2="23.495" width="0.2032" layer="1"/>
+<wire x1="240.146" y1="27.421" x2="243.999" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="237.49" y1="23.495" x2="237.49" y2="24.765" width="0.2032" layer="1"/>
+<wire x1="237.49" y1="24.765" x2="240.146" y2="27.421" width="0.2032" layer="1"/>
 </signal>
 <signal name="3.3V">
-<contactref element="U$68" pad="1"/>
-<contactref element="U$68" pad="3"/>
-<contactref element="U$69" pad="3"/>
-<contactref element="U$70" pad="1"/>
-<contactref element="U$70" pad="3"/>
-<contactref element="U$71" pad="3"/>
-<contactref element="U$72" pad="1"/>
-<contactref element="U$72" pad="3"/>
-<contactref element="U$73" pad="3"/>
-<contactref element="U$74" pad="1"/>
-<contactref element="U$74" pad="3"/>
-<contactref element="U$75" pad="3"/>
-<contactref element="U$76" pad="1"/>
-<contactref element="U$76" pad="3"/>
-<contactref element="U$78" pad="1"/>
-<contactref element="U$78" pad="3"/>
-<contactref element="U$79" pad="3"/>
-<contactref element="U$77" pad="3"/>
-<contactref element="U$80" pad="1"/>
-<contactref element="U$80" pad="3"/>
-<contactref element="U$81" pad="3"/>
-<contactref element="U$82" pad="1"/>
-<contactref element="U$82" pad="3"/>
-<contactref element="U$83" pad="3"/>
-<contactref element="U$84" pad="1"/>
-<contactref element="U$84" pad="3"/>
-<contactref element="U$85" pad="3"/>
-<contactref element="U$86" pad="1"/>
-<contactref element="U$86" pad="3"/>
-<contactref element="U$87" pad="3"/>
-<contactref element="U$88" pad="1"/>
-<contactref element="U$88" pad="3"/>
-<contactref element="U$89" pad="3"/>
-<contactref element="U$90" pad="1"/>
-<contactref element="U$90" pad="3"/>
-<contactref element="U$91" pad="3"/>
-<contactref element="U$92" pad="1"/>
-<contactref element="U$92" pad="3"/>
-<contactref element="U$93" pad="3"/>
-<contactref element="U$94" pad="1"/>
-<contactref element="U$94" pad="3"/>
-<contactref element="U$95" pad="3"/>
-<contactref element="U$96" pad="1"/>
-<contactref element="U$96" pad="3"/>
-<contactref element="U$97" pad="3"/>
-<contactref element="U$98" pad="1"/>
-<contactref element="U$98" pad="3"/>
-<contactref element="U$99" pad="3"/>
-<contactref element="U$100" pad="1"/>
-<contactref element="U$100" pad="3"/>
-<contactref element="U$101" pad="3"/>
-<contactref element="U$102" pad="1"/>
-<contactref element="U$102" pad="3"/>
-<contactref element="U$103" pad="3"/>
-<contactref element="U$104" pad="1"/>
-<contactref element="U$104" pad="3"/>
-<contactref element="U$105" pad="3"/>
-<contactref element="U$106" pad="1"/>
-<contactref element="U$106" pad="3"/>
-<contactref element="U$107" pad="3"/>
-<contactref element="U$108" pad="1"/>
-<contactref element="U$108" pad="3"/>
-<contactref element="U$109" pad="3"/>
-<contactref element="U$110" pad="1"/>
-<contactref element="U$110" pad="3"/>
-<contactref element="U$111" pad="3"/>
-<contactref element="U$112" pad="1"/>
-<contactref element="U$112" pad="3"/>
-<contactref element="U$113" pad="3"/>
-<contactref element="U$114" pad="1"/>
-<contactref element="U$114" pad="3"/>
-<contactref element="U$115" pad="3"/>
+<contactref element="U24I" pad="1"/>
+<contactref element="U24I" pad="3"/>
+<contactref element="U24O" pad="3"/>
+<contactref element="U23I" pad="1"/>
+<contactref element="U23I" pad="3"/>
+<contactref element="U23O" pad="3"/>
+<contactref element="U22I" pad="1"/>
+<contactref element="U22I" pad="3"/>
+<contactref element="U22O" pad="3"/>
+<contactref element="U21I" pad="1"/>
+<contactref element="U21I" pad="3"/>
+<contactref element="U21O" pad="3"/>
+<contactref element="U20I" pad="1"/>
+<contactref element="U20I" pad="3"/>
+<contactref element="U19I" pad="1"/>
+<contactref element="U19I" pad="3"/>
+<contactref element="U19O" pad="3"/>
+<contactref element="U20O" pad="3"/>
+<contactref element="U18I" pad="1"/>
+<contactref element="U18I" pad="3"/>
+<contactref element="U18O" pad="3"/>
+<contactref element="U17I" pad="1"/>
+<contactref element="U17I" pad="3"/>
+<contactref element="U17O" pad="3"/>
+<contactref element="U16I" pad="1"/>
+<contactref element="U16I" pad="3"/>
+<contactref element="U16O" pad="3"/>
+<contactref element="U15I" pad="1"/>
+<contactref element="U15I" pad="3"/>
+<contactref element="U15O" pad="3"/>
+<contactref element="U14I" pad="1"/>
+<contactref element="U14I" pad="3"/>
+<contactref element="U14O" pad="3"/>
+<contactref element="U13I" pad="1"/>
+<contactref element="U13I" pad="3"/>
+<contactref element="U13O" pad="3"/>
+<contactref element="U12I" pad="1"/>
+<contactref element="U12I" pad="3"/>
+<contactref element="U12O" pad="3"/>
+<contactref element="U11I" pad="1"/>
+<contactref element="U11I" pad="3"/>
+<contactref element="U11O" pad="3"/>
+<contactref element="U10I" pad="1"/>
+<contactref element="U10I" pad="3"/>
+<contactref element="U10O" pad="3"/>
+<contactref element="U09O" pad="3"/>
+<contactref element="U08I" pad="1"/>
+<contactref element="U08I" pad="3"/>
+<contactref element="U08O" pad="3"/>
+<contactref element="U07I" pad="1"/>
+<contactref element="U07I" pad="3"/>
+<contactref element="U07O" pad="3"/>
+<contactref element="U06I" pad="1"/>
+<contactref element="U06I" pad="3"/>
+<contactref element="U06O" pad="3"/>
+<contactref element="U05I" pad="1"/>
+<contactref element="U05I" pad="3"/>
+<contactref element="U05O" pad="3"/>
+<contactref element="U04I" pad="1"/>
+<contactref element="U04I" pad="3"/>
+<contactref element="U04O" pad="3"/>
+<contactref element="U03I" pad="1"/>
+<contactref element="U03I" pad="3"/>
+<contactref element="U03O" pad="3"/>
+<contactref element="U02I" pad="1"/>
+<contactref element="U02I" pad="3"/>
+<contactref element="U02O" pad="3"/>
+<contactref element="U01I" pad="1"/>
+<contactref element="U01I" pad="3"/>
+<contactref element="U01O" pad="3"/>
 <contactref element="U1" pad="16"/>
 <contactref element="U2" pad="16"/>
 <contactref element="U3" pad="16"/>
@@ -18501,1291 +18666,1239 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <contactref element="R3" pad="P$2"/>
 <wire x1="104.14" y1="27.305" x2="116.078" y2="27.305" width="0.6096" layer="1"/>
 <wire x1="116.078" y1="27.305" x2="116.205" y2="27.178" width="0.6096" layer="1"/>
-<wire x1="126.365" y1="14.605" x2="127" y2="14.605" width="0.6096" layer="1"/>
-<wire x1="128.905" y1="12.7" x2="128.905" y2="10.795" width="0.6096" layer="1"/>
-<wire x1="128.905" y1="10.795" x2="130.175" y2="9.525" width="0.6096" layer="1"/>
-<wire x1="130.175" y1="9.525" x2="130.175" y2="4.445" width="0.6096" layer="1"/>
-<wire x1="130.175" y1="4.445" x2="132.715" y2="1.905" width="0.6096" layer="1"/>
-<wire x1="132.715" y1="1.905" x2="133.27" y2="1.905" width="0.6096" layer="1"/>
-<wire x1="127" y1="14.605" x2="128.905" y2="12.7" width="0.6096" layer="1"/>
-<wire x1="111.76" y1="5.715" x2="111.76" y2="8.255" width="0.6096" layer="1"/>
-<wire x1="111.76" y1="5.715" x2="112.395" y2="5.08" width="0.6096" layer="1"/>
-<wire x1="123.19" y1="5.08" x2="128.905" y2="10.795" width="0.6096" layer="1"/>
-<wire x1="112.395" y1="5.08" x2="123.19" y2="5.08" width="0.6096" layer="1"/>
-<wire x1="126.365" y1="14.605" x2="135.255" y2="14.605" width="0.6096" layer="16"/>
-<wire x1="142.399" y1="19.061" x2="139.711" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="135.255" y1="14.605" x2="139.711" y2="19.061" width="0.6096" layer="16"/>
-<wire x1="139.711" y1="19.061" x2="137.16" y2="21.612" width="0.6096" layer="1"/>
-<wire x1="137.16" y1="24.765" x2="133.985" y2="27.94" width="0.6096" layer="1"/>
-<wire x1="133.985" y1="27.94" x2="116.967" y2="27.94" width="0.6096" layer="1"/>
-<wire x1="116.967" y1="27.94" x2="116.205" y2="27.178" width="0.6096" layer="1"/>
-<wire x1="137.16" y1="21.612" x2="137.16" y2="24.765" width="0.6096" layer="1"/>
-<wire x1="142.399" y1="19.061" x2="143.9064" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="143.9064" y1="19.061" x2="146.399" y2="21.4266" width="0.6096" layer="1"/>
-<wire x1="143.9064" y1="19.061" x2="144.472" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="144.472" y1="19.061" x2="146.399" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="146.399" y1="17.261" x2="149.976" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="151.776" y1="19.061" x2="155.099" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="149.976" y1="17.261" x2="151.776" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="155.099" y1="19.061" x2="157.172" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="158.464" y1="17.261" x2="159.099" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="159.099" y1="17.261" x2="163.967" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="165.259" y1="19.061" x2="163.967" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="165.259" y1="19.061" x2="167.799" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="169.78084375" y1="19.061" x2="167.799" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="171.799" y1="17.261" x2="176.2112125" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="177.5032125" y1="19.061" x2="176.2112125" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="177.5032125" y1="19.061" x2="180.499" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="180.499" y1="19.061" x2="182.48084375" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="184.499" y1="17.261" x2="189.367" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="190.659" y1="19.061" x2="189.367" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="190.659" y1="19.061" x2="193.199" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="195.30784375" y1="19.061" x2="193.199" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="197.199" y1="17.261" x2="200.797" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="202.724" y1="19.061" x2="205.899" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="202.724" y1="19.061" x2="200.797" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="205.899" y1="19.061" x2="207.4064" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="209.899" y1="21.4266" x2="207.4064" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="207.4064" y1="19.061" x2="209.2064" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="209.2064" y1="17.261" x2="209.899" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="209.899" y1="17.261" x2="214.767" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="216.059" y1="19.061" x2="214.767" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="216.059" y1="19.061" x2="218.599" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="230.073803125" y1="19.061" x2="231.299" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="235.299" y1="17.261" x2="238.897" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="240.824" y1="19.061" x2="238.897" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="240.824" y1="19.061" x2="243.999" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="247.999" y1="17.261" x2="251.597" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="253.524" y1="19.061" x2="251.597" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="253.524" y1="19.061" x2="256.699" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="260.699" y1="17.261" x2="264.297" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="266.224" y1="19.061" x2="264.297" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="266.224" y1="19.061" x2="269.399" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="273.399" y1="17.261" x2="276.362" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="278.289" y1="19.061" x2="276.362" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="278.289" y1="19.061" x2="282.099" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="286.099" y1="17.261" x2="289.062" y2="17.261" width="0.6096" layer="16"/>
-<wire x1="290.989" y1="19.061" x2="289.062" y2="17.261" width="0.6096" layer="16"/>
-<wire x1="290.989" y1="19.061" x2="294.799" y2="19.061" width="0.6096" layer="16"/>
-<wire x1="298.799" y1="17.261" x2="302.397" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="304.324" y1="19.061" x2="302.397" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="304.324" y1="19.061" x2="307.499" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="311.499" y1="17.261" x2="315.097" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="317.024" y1="19.061" x2="315.097" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="317.024" y1="19.061" x2="320.199" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="324.199" y1="17.261" x2="327.797" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="329.724" y1="19.061" x2="327.797" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="329.724" y1="19.061" x2="332.899" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="336.899" y1="17.261" x2="339.817196875" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="341.744196875" y1="19.061" x2="345.599" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="341.744196875" y1="19.061" x2="339.817196875" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="349.599" y1="17.261" x2="352.517196875" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="354.444196875" y1="19.061" x2="352.517196875" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="354.444196875" y1="19.061" x2="358.299" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="362.299" y1="17.261" x2="369.072" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="369.072" y1="17.261" x2="370.999" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="374.999" y1="17.261" x2="378.7748" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="381.159" y1="19.5182" x2="383.699" y2="19.5182" width="0.6096" layer="1"/>
-<wire x1="381.159" y1="19.5182" x2="378.7748" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="387.699" y1="17.7182" x2="391.05914375" y2="17.7182" width="0.6096" layer="1"/>
-<wire x1="392.52894375" y1="19.061" x2="391.05914375" y2="17.7182" width="0.6096" layer="1"/>
-<wire x1="392.52894375" y1="19.061" x2="396.399" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="400.399" y1="17.261" x2="403.317196875" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="405.244196875" y1="19.061" x2="403.317196875" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="405.244196875" y1="19.061" x2="409.099" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="413.099" y1="17.261" x2="416.652196875" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="418.579196875" y1="19.061" x2="416.652196875" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="418.579196875" y1="19.061" x2="421.799" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="425.799" y1="17.261" x2="429.352196875" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="431.279196875" y1="19.061" x2="429.352196875" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="431.279196875" y1="19.061" x2="434.499" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="438.499" y1="21.4266" x2="438.372" y2="21.41" width="0.6096" layer="1"/>
-<wire x1="434.499" y1="19.061" x2="436.023" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="438.372" y1="21.41" x2="436.023" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="436.023" y1="19.061" x2="436.572" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="436.572" y1="19.061" x2="438.499" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="421.799" y1="19.061" x2="423.3064" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="423.3064" y1="19.061" x2="425.799" y2="21.4266" width="0.6096" layer="1"/>
-<wire x1="423.3064" y1="19.061" x2="423.872" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="423.872" y1="19.061" x2="425.799" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="409.099" y1="19.061" x2="410.6064" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="410.6064" y1="19.061" x2="413.099" y2="21.4266" width="0.6096" layer="1"/>
-<wire x1="410.6064" y1="19.061" x2="411.172" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="411.172" y1="19.061" x2="413.099" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="396.399" y1="19.061" x2="397.9064" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="397.9064" y1="19.061" x2="400.399" y2="21.4266" width="0.6096" layer="1"/>
-<wire x1="397.9064" y1="19.061" x2="398.472" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="398.472" y1="19.061" x2="400.399" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="383.699" y1="19.5182" x2="385.2064" y2="19.5182" width="0.6096" layer="1"/>
-<wire x1="385.2064" y1="19.5182" x2="387.699" y2="21.8838" width="0.6096" layer="1"/>
-<wire x1="385.2064" y1="19.5182" x2="385.772" y2="19.5182" width="0.6096" layer="1"/>
-<wire x1="385.772" y1="19.5182" x2="387.699" y2="17.7182" width="0.6096" layer="1"/>
-<wire x1="370.999" y1="19.061" x2="372.5064" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="372.5064" y1="19.061" x2="374.999" y2="21.4266" width="0.6096" layer="1"/>
-<wire x1="372.5064" y1="19.061" x2="373.072" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="373.072" y1="19.061" x2="374.999" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="358.299" y1="19.061" x2="359.8064" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="359.8064" y1="19.061" x2="362.299" y2="21.4266" width="0.6096" layer="1"/>
-<wire x1="359.8064" y1="19.061" x2="360.372" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="360.372" y1="19.061" x2="362.299" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="345.599" y1="19.061" x2="347.1064" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="347.1064" y1="19.061" x2="349.599" y2="21.4266" width="0.6096" layer="1"/>
-<wire x1="347.1064" y1="19.061" x2="347.672" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="347.672" y1="19.061" x2="349.599" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="332.899" y1="19.061" x2="334.4064" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="334.4064" y1="19.061" x2="336.899" y2="21.4266" width="0.6096" layer="1"/>
-<wire x1="334.4064" y1="19.061" x2="334.972" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="334.972" y1="19.061" x2="336.899" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="320.199" y1="19.061" x2="321.7064" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="321.7064" y1="19.061" x2="324.199" y2="21.4266" width="0.6096" layer="1"/>
-<wire x1="321.7064" y1="19.061" x2="322.272" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="322.272" y1="19.061" x2="324.199" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="307.499" y1="19.061" x2="309.0064" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="309.0064" y1="19.061" x2="311.499" y2="21.4266" width="0.6096" layer="1"/>
-<wire x1="309.0064" y1="19.061" x2="309.572" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="309.572" y1="19.061" x2="311.499" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="294.799" y1="19.061" x2="296.3064" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="296.3064" y1="19.061" x2="298.799" y2="21.4266" width="0.6096" layer="1"/>
-<wire x1="296.3064" y1="19.061" x2="296.872" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="296.872" y1="19.061" x2="298.799" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="282.099" y1="19.061" x2="283.6064" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="283.6064" y1="19.061" x2="286.099" y2="21.4266" width="0.6096" layer="1"/>
-<wire x1="283.6064" y1="19.061" x2="284.172" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="284.172" y1="19.061" x2="286.099" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="269.399" y1="19.061" x2="270.9064" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="270.9064" y1="19.061" x2="273.399" y2="21.4266" width="0.6096" layer="1"/>
-<wire x1="270.9064" y1="19.061" x2="271.472" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="271.472" y1="19.061" x2="273.399" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="256.699" y1="19.061" x2="258.2064" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="258.2064" y1="19.061" x2="260.699" y2="21.4266" width="0.6096" layer="1"/>
-<wire x1="258.2064" y1="19.061" x2="258.772" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="258.772" y1="19.061" x2="260.699" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="243.999" y1="19.061" x2="245.5064" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="245.5064" y1="19.061" x2="247.999" y2="21.4266" width="0.6096" layer="1"/>
-<wire x1="245.5064" y1="19.061" x2="246.072" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="246.072" y1="19.061" x2="247.999" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="231.299" y1="19.061" x2="232.8064" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="232.8064" y1="19.061" x2="235.299" y2="21.4266" width="0.6096" layer="1"/>
-<wire x1="232.8064" y1="19.061" x2="233.372" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="233.372" y1="19.061" x2="235.299" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="222.599" y1="21.4266" x2="220.7414" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="222.599" y1="17.261" x2="221.72636875" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="176.53" y1="5.842" x2="176.53" y2="10.414" width="0.6096" layer="1"/>
-<wire x1="176.53" y1="10.414" x2="174.625" y2="12.319" width="0.6096" layer="1"/>
-<wire x1="174.625" y1="12.319" x2="174.625" y2="14.986" width="0.6096" layer="1"/>
-<wire x1="174.625" y1="14.986" x2="172.35" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="172.35" y1="17.261" x2="171.799" y2="17.261" width="0.6096" layer="1"/>
-<via x="139.711" y="19.061" extent="1-16" drill="0.55"/>
-<wire x1="155.575" y1="10.16" x2="155.575" y2="14.372" width="0.6096" layer="1"/>
-<wire x1="155.575" y1="14.372" x2="158.464" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="208.28" y1="10.16" x2="208.28" y2="8.89" width="0.6096" layer="1"/>
-<wire x1="208.28" y1="8.89" x2="209.3341" y2="7.8359" width="0.6096" layer="1"/>
-<wire x1="209.3341" y1="7.8359" x2="223.23745625" y2="7.8359" width="0.6096" layer="1"/>
-<wire x1="225.23135625" y1="5.842" x2="229.235" y2="5.842" width="0.6096" layer="1"/>
-<wire x1="223.23745625" y1="7.8359" x2="225.23135625" y2="5.842" width="0.6096" layer="1"/>
-<wire x1="229.235" y1="5.842" x2="232.537" y2="2.54" width="0.6096" layer="1"/>
-<wire x1="283.21" y1="5.842" x2="281.94" y2="4.572" width="0.6096" layer="16"/>
-<wire x1="232.537" y1="2.54" x2="258.8006125" y2="2.54" width="0.6096" layer="1"/>
-<wire x1="283.21" y1="5.842" x2="286.512" y2="2.54" width="0.6096" layer="1"/>
-<wire x1="286.512" y1="2.54" x2="311.15" y2="2.54" width="0.6096" layer="1"/>
-<wire x1="334.01" y1="7.112" x2="315.722" y2="7.112" width="0.6096" layer="16"/>
-<wire x1="334.01" y1="7.112" x2="335.915" y2="5.207" width="0.6096" layer="16"/>
-<wire x1="311.15" y1="2.54" x2="315.722" y2="7.112" width="0.6096" layer="1"/>
-<wire x1="335.915" y1="5.207" x2="338.582" y2="2.54" width="0.6096" layer="1"/>
-<wire x1="363.855" y1="2.54" x2="367.665" y2="6.35" width="0.6096" layer="1"/>
-<wire x1="367.665" y1="6.35" x2="387.477" y2="6.35" width="0.6096" layer="1"/>
-<wire x1="387.477" y1="6.35" x2="388.62" y2="5.207" width="0.6096" layer="1"/>
-<wire x1="338.582" y1="2.54" x2="363.855" y2="2.54" width="0.6096" layer="1"/>
-<wire x1="388.62" y1="5.207" x2="389.382" y2="4.445" width="0.6096" layer="1"/>
-<wire x1="435.61" y1="4.445" x2="441.325" y2="10.16" width="0.6096" layer="1"/>
-<wire x1="441.325" y1="10.16" x2="441.325" y2="10.287" width="0.6096" layer="1"/>
-<wire x1="389.382" y1="4.445" x2="435.61" y2="4.445" width="0.6096" layer="1"/>
-<wire x1="441.325" y1="14.435" x2="438.499" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="441.325" y1="10.287" x2="441.325" y2="14.435" width="0.6096" layer="1"/>
-<wire x1="367.665" y1="10.16" x2="367.665" y2="6.35" width="0.6096" layer="1"/>
-<wire x1="262.255" y1="10.16" x2="260.858" y2="8.763" width="0.6096" layer="16"/>
-<via x="258.8006125" y="2.54" extent="1-16" drill="0.3302"/>
-<wire x1="258.8006125" y1="2.54" x2="260.858" y2="4.5973875" width="0.6096" layer="16"/>
-<wire x1="260.858" y1="8.763" x2="260.858" y2="4.5973875" width="0.6096" layer="16"/>
-<wire x1="281.94" y1="4.572" x2="260.8833875" y2="4.572" width="0.6096" layer="16"/>
-<wire x1="260.8833875" y1="4.572" x2="260.858" y2="4.5973875" width="0.6096" layer="16"/>
-<via x="315.722" y="7.112" extent="1-16" drill="0.3302"/>
-<wire x1="314.96" y1="10.16" x2="314.96" y2="7.874" width="0.6096" layer="16"/>
-<wire x1="314.96" y1="7.874" x2="315.722" y2="7.112" width="0.6096" layer="16"/>
-<wire x1="419.735" y1="10.16" x2="413.099" y2="16.796" width="0.6096" layer="16"/>
-<wire x1="413.099" y1="16.796" x2="413.099" y2="17.261" width="0.6096" layer="16"/>
-<wire x1="218.599" y1="19.061" x2="220.7414" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="221.72636875" y1="17.261" x2="220.7414" y2="18.24596875" width="0.6096" layer="1"/>
-<wire x1="220.7414" y1="18.24596875" x2="220.7414" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="159.099" y1="17.261" x2="158.972" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="158.972" y1="17.261" x2="157.172" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="157.172" y1="19.061" x2="159.099" y2="20.988" width="0.6096" layer="1"/>
-<wire x1="159.099" y1="20.988" x2="159.099" y2="21.4266" width="0.6096" layer="1"/>
-<wire x1="184.499" y1="21.07915625" x2="182.48084375" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="184.499" y1="21.07915625" x2="184.499" y2="21.4266" width="0.6096" layer="1"/>
-<wire x1="184.499" y1="17.261" x2="184.28084375" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="184.28084375" y1="17.261" x2="182.48084375" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="171.799" y1="21.4266" x2="171.799" y2="21.07915625" width="0.6096" layer="1"/>
-<wire x1="171.799" y1="21.07915625" x2="169.78084375" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="169.78084375" y1="19.061" x2="171.58084375" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="171.58084375" y1="17.261" x2="171.799" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="228.273803125" y1="17.261" x2="230.073803125" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="222.599" y1="17.261" x2="228.273803125" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="197.199" y1="17.261" x2="197.10784375" y2="17.261" width="0.6096" layer="1"/>
-<wire x1="197.10784375" y1="17.261" x2="195.30784375" y2="19.061" width="0.6096" layer="1"/>
-<wire x1="197.199" y1="21.4266" x2="197.199" y2="20.95215625" width="0.6096" layer="1"/>
-<wire x1="197.199" y1="20.95215625" x2="195.30784375" y2="19.061" width="0.6096" layer="1"/>
+<wire x1="116.205" y1="27.178" x2="124.46" y2="18.923" width="0.6096" layer="1"/>
+<wire x1="124.46" y1="18.923" x2="124.46" y2="15.875" width="0.6096" layer="1"/>
+<wire x1="124.46" y1="15.875" x2="125.73" y2="14.605" width="0.6096" layer="1"/>
+<wire x1="125.73" y1="14.605" x2="126.365" y2="14.605" width="0.6096" layer="1"/>
+<wire x1="111.76" y1="8.255" x2="116.205" y2="8.255" width="0.2032" layer="16"/>
+<wire x1="116.205" y1="8.255" x2="122.555" y2="14.605" width="0.2032" layer="16"/>
+<wire x1="122.555" y1="14.605" x2="126.365" y2="14.605" width="0.2032" layer="16"/>
+<wire x1="111.76" y1="5.715" x2="111.76" y2="8.255" width="0.2032" layer="16"/>
+<wire x1="155.575" y1="10.16" x2="155.575" y2="11.43" width="0.2032" layer="1"/>
+<wire x1="155.575" y1="11.43" x2="151.13" y2="15.875" width="0.2032" layer="1"/>
+<wire x1="151.13" y1="15.875" x2="151.13" y2="17.145" width="0.2032" layer="1"/>
+<wire x1="146.399" y1="21.876" x2="146.399" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="151.13" y1="17.145" x2="146.399" y2="21.876" width="0.2032" layer="1"/>
+<wire x1="126.365" y1="14.605" x2="128.905" y2="17.145" width="0.6096" layer="1"/>
+<wire x1="128.905" y1="17.145" x2="133.985" y2="17.145" width="0.6096" layer="1"/>
+<wire x1="133.985" y1="17.145" x2="137.298" y2="20.458" width="0.6096" layer="1"/>
+<wire x1="137.954" y1="20.458" x2="137.298" y2="20.458" width="0.6096" layer="16"/>
+<wire x1="137.954" y1="20.458" x2="142.399" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="142.399" y1="24.903" x2="143.88" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="145.68" y1="23.103" x2="146.399" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="143.88" y1="24.903" x2="145.68" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="143.88" y1="24.903" x2="143.881" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="143.881" y1="24.903" x2="146.399" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="146.399" y1="23.103" x2="151.373" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="153.173" y1="24.903" x2="155.099" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="151.373" y1="23.103" x2="153.173" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="155.099" y1="24.903" x2="156.537" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="158.337" y1="23.103" x2="156.537" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="158.337" y1="23.103" x2="159.099" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="159.099" y1="27.421" x2="156.581" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="156.581" y1="24.903" x2="156.537" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="159.099" y1="23.103" x2="164.708" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="166.508" y1="24.903" x2="167.799" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="164.708" y1="23.103" x2="166.508" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="167.799" y1="24.903" x2="168.91" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="168.91" y1="24.903" x2="169.281" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="169.281" y1="24.903" x2="171.799" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="171.799" y1="23.103" x2="170.71" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="170.71" y1="23.103" x2="168.91" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="171.799" y1="23.103" x2="173.6868" y2="24.9908" width="0.6096" layer="16"/>
+<wire x1="180.4112" y1="24.9908" x2="180.499" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="173.6868" y1="24.9908" x2="180.4112" y2="24.9908" width="0.6096" layer="16"/>
+<wire x1="180.499" y1="24.903" x2="181.981" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="181.981" y1="24.903" x2="184.499" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="184.499" y1="23.103" x2="183.781" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="183.781" y1="23.103" x2="181.981" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="184.499" y1="23.103" x2="185.663" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="187.463" y1="24.903" x2="193.199" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="185.663" y1="23.103" x2="187.463" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="193.199" y1="24.903" x2="194.172" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="195.972" y1="23.103" x2="197.199" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="194.172" y1="24.903" x2="195.972" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="197.199" y1="27.421" x2="194.681" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="194.681" y1="24.903" x2="194.172" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="197.199" y1="23.103" x2="198.999" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="198.999" y1="24.903" x2="205.899" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="205.899" y1="24.903" x2="207.01" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="207.01" y1="24.903" x2="207.381" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="207.381" y1="24.903" x2="209.899" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="209.899" y1="23.103" x2="208.81" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="208.81" y1="23.103" x2="207.01" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="209.899" y1="23.103" x2="211.699" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="211.699" y1="24.903" x2="218.599" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="218.599" y1="24.903" x2="220.081" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="220.081" y1="24.903" x2="222.599" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="222.599" y1="23.103" x2="221.881" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="221.881" y1="23.103" x2="220.081" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="222.599" y1="23.103" x2="224.399" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="224.399" y1="24.903" x2="231.299" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="231.299" y1="24.903" x2="232.781" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="232.781" y1="24.903" x2="235.299" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="235.299" y1="23.103" x2="234.581" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="234.581" y1="23.103" x2="232.781" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="235.299" y1="23.103" x2="237.099" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="245.481" y1="24.903" x2="247.999" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="247.281" y1="23.103" x2="245.481" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="249.799" y1="24.903" x2="256.699" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="256.699" y1="24.903" x2="258.181" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="258.181" y1="24.903" x2="260.699" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="260.699" y1="23.103" x2="259.981" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="259.981" y1="23.103" x2="258.181" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="260.699" y1="23.103" x2="262.499" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="262.499" y1="24.903" x2="269.399" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="269.399" y1="24.903" x2="270.881" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="270.881" y1="24.903" x2="273.399" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="273.399" y1="23.103" x2="272.681" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="272.681" y1="23.103" x2="270.881" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="273.399" y1="23.103" x2="275.199" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="275.199" y1="24.903" x2="282.099" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="282.099" y1="24.903" x2="283.21" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="283.21" y1="24.903" x2="283.581" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="283.581" y1="24.903" x2="286.099" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="286.099" y1="23.103" x2="285.01" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="285.01" y1="23.103" x2="283.21" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="155.575" y1="10.16" x2="154.94" y2="9.525" width="0.2032" layer="16"/>
+<wire x1="154.94" y1="9.525" x2="152.527" y2="9.525" width="0.2032" layer="16"/>
+<via x="137.298" y="20.458" extent="1-16" drill="0.3302"/>
+<wire x1="286.099" y1="23.103" x2="287.899" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="287.899" y1="24.903" x2="294.799" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="294.799" y1="24.903" x2="296.281" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="296.281" y1="24.903" x2="298.799" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="298.799" y1="23.103" x2="298.081" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="298.081" y1="23.103" x2="296.281" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="298.799" y1="23.103" x2="300.599" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="300.599" y1="24.903" x2="307.499" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="307.499" y1="24.903" x2="308.981" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="308.981" y1="24.903" x2="311.499" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="311.499" y1="23.103" x2="310.781" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="310.781" y1="23.103" x2="308.981" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="311.499" y1="23.103" x2="313.299" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="313.299" y1="24.903" x2="320.199" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="320.199" y1="24.903" x2="321.681" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="321.681" y1="24.903" x2="324.199" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="324.199" y1="23.103" x2="323.481" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="323.481" y1="23.103" x2="321.681" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="324.199" y1="23.103" x2="325.999" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="325.999" y1="24.903" x2="332.899" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="332.899" y1="24.903" x2="334.381" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="334.381" y1="24.903" x2="336.899" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="336.899" y1="23.103" x2="336.181" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="336.181" y1="23.103" x2="334.381" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="336.899" y1="23.103" x2="338.699" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="338.699" y1="24.903" x2="345.599" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="345.599" y1="24.903" x2="347.081" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="347.081" y1="24.903" x2="349.599" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="349.599" y1="23.103" x2="348.881" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="348.881" y1="23.103" x2="347.081" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="349.599" y1="23.103" x2="351.399" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="351.399" y1="24.903" x2="358.299" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="358.299" y1="24.903" x2="359.781" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="359.781" y1="24.903" x2="362.299" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="362.299" y1="23.103" x2="361.581" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="361.581" y1="23.103" x2="359.781" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="362.299" y1="23.103" x2="364.099" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="364.099" y1="24.903" x2="370.999" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="370.999" y1="24.903" x2="372.481" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="372.481" y1="24.903" x2="372.544" y2="24.966" width="0.6096" layer="16"/>
+<wire x1="372.544" y1="24.966" x2="374.999" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="374.999" y1="23.103" x2="374.407" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="374.407" y1="23.103" x2="372.544" y2="24.966" width="0.6096" layer="16"/>
+<wire x1="374.999" y1="23.103" x2="376.799" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="376.799" y1="24.903" x2="383.699" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="383.699" y1="24.903" x2="385.181" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="385.181" y1="24.903" x2="387.699" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="387.699" y1="23.103" x2="386.981" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="386.981" y1="23.103" x2="385.181" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="387.699" y1="23.103" x2="389.499" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="389.499" y1="24.903" x2="396.399" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="396.399" y1="24.903" x2="397.881" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="397.881" y1="24.903" x2="400.399" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="400.399" y1="23.103" x2="399.681" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="399.681" y1="23.103" x2="397.881" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="400.399" y1="23.103" x2="402.199" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="402.199" y1="24.903" x2="409.099" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="409.099" y1="24.903" x2="410.581" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="410.581" y1="24.903" x2="413.099" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="413.099" y1="23.103" x2="412.381" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="412.381" y1="23.103" x2="410.581" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="413.099" y1="23.103" x2="414.899" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="414.899" y1="24.903" x2="421.799" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="421.799" y1="24.903" x2="422.91" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="422.91" y1="24.903" x2="423.281" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="423.281" y1="24.903" x2="425.799" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="425.799" y1="23.103" x2="424.71" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="424.71" y1="23.103" x2="422.91" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="425.799" y1="23.103" x2="427.599" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="427.599" y1="24.903" x2="434.499" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="434.499" y1="24.903" x2="435.981" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="435.981" y1="24.903" x2="438.499" y2="27.421" width="0.6096" layer="16"/>
+<wire x1="438.499" y1="23.103" x2="437.781" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="437.781" y1="23.103" x2="435.981" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="207.772" y1="10.16" x2="210.82" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="246.507" y1="10.16" x2="249.555" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="133.27" y1="1.905" x2="133.27" y2="8.97" width="0.6096" layer="1"/>
+<wire x1="133.27" y1="8.97" x2="132.715" y2="9.525" width="0.6096" layer="1"/>
+<via x="132.715" y="9.525" extent="1-16" drill="0.35"/>
+<wire x1="132.715" y1="9.525" x2="127.635" y2="14.605" width="0.6096" layer="16"/>
+<wire x1="127.635" y1="14.605" x2="126.365" y2="14.605" width="0.6096" layer="16"/>
+<contactref element="U09I" pad="1"/>
+<contactref element="U09I" pad="3"/>
+<wire x1="237.099" y1="24.903" x2="243.999" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="243.999" y1="24.903" x2="245.481" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="247.999" y1="23.103" x2="247.281" y2="23.103" width="0.6096" layer="16"/>
+<wire x1="247.999" y1="23.103" x2="249.799" y2="24.903" width="0.6096" layer="16"/>
+<wire x1="210.82" y1="10.16" x2="210.82" y2="11.43" width="0.2032" layer="1"/>
+<wire x1="210.82" y1="11.43" x2="209.55" y2="12.7" width="0.2032" layer="1"/>
+<wire x1="209.55" y1="12.7" x2="209.55" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="209.55" y1="17.78" x2="207.645" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="198.12" y1="19.685" x2="196.85" y2="20.955" width="0.2032" layer="1"/>
+<wire x1="196.85" y1="20.955" x2="196.85" y2="22.754" width="0.2032" layer="1"/>
+<wire x1="196.85" y1="22.754" x2="197.199" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="207.645" y1="19.685" x2="198.12" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="249.555" y1="10.16" x2="249.555" y2="11.43" width="0.2032" layer="1"/>
+<wire x1="249.555" y1="11.43" x2="248.285" y2="12.7" width="0.2032" layer="1"/>
+<wire x1="248.285" y1="12.7" x2="236.855" y2="12.7" width="0.2032" layer="1"/>
+<wire x1="236.855" y1="12.7" x2="233.045" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="233.045" y1="16.51" x2="233.045" y2="19.05" width="0.2032" layer="1"/>
+<wire x1="233.045" y1="19.05" x2="234.315" y2="20.32" width="0.2032" layer="1"/>
+<wire x1="234.315" y1="20.32" x2="236.22" y2="20.32" width="0.2032" layer="1"/>
+<wire x1="236.22" y1="20.32" x2="238.76" y2="22.86" width="0.2032" layer="1"/>
+<wire x1="241.935" y1="22.86" x2="242.951" y2="21.844" width="0.2032" layer="1"/>
+<wire x1="242.951" y1="21.844" x2="246.74" y2="21.844" width="0.2032" layer="1"/>
+<wire x1="246.74" y1="21.844" x2="247.999" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="238.76" y1="22.86" x2="241.935" y2="22.86" width="0.2032" layer="1"/>
+<wire x1="292.227" y1="10.16" x2="295.275" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="295.275" y1="10.16" x2="295.275" y2="13.335" width="0.2032" layer="1"/>
+<wire x1="295.275" y1="13.335" x2="295.91" y2="13.97" width="0.2032" layer="1"/>
+<wire x1="295.91" y1="20.214" x2="298.799" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="295.91" y1="13.97" x2="295.91" y2="20.214" width="0.2032" layer="1"/>
+<wire x1="346.202" y1="10.16" x2="349.25" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="349.25" y1="10.16" x2="349.25" y2="13.97" width="0.2032" layer="1"/>
+<wire x1="349.25" y1="13.97" x2="349.885" y2="14.605" width="0.2032" layer="1"/>
+<wire x1="349.885" y1="22.817" x2="349.599" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="349.885" y1="14.605" x2="349.885" y2="22.817" width="0.2032" layer="1"/>
+<wire x1="383.032" y1="10.16" x2="386.715" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="383.032" y1="10.16" x2="383.032" y2="10.922" width="0.2032" layer="1"/>
+<wire x1="383.032" y1="10.922" x2="385.445" y2="13.335" width="0.2032" layer="1"/>
+<wire x1="385.445" y1="20.849" x2="387.699" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="385.445" y1="13.335" x2="385.445" y2="20.849" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$2">
-<contactref element="U$92" pad="2"/>
-<contactref element="U$93" pad="1"/>
-<wire x1="282.099" y1="23.2266" x2="286.099" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="286.099" y1="19.2266" x2="286.099" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U12I" pad="2"/>
+<contactref element="U12O" pad="1"/>
+<wire x1="282.099" y1="29.221" x2="286.099" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="286.099" y1="25.221" x2="286.099" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="12_CATHODE">
-<contactref element="U$93" pad="2"/>
+<contactref element="U12O" pad="2"/>
 <contactref element="U$37" pad="P$6"/>
-<wire x1="286.099" y1="23.2266" x2="286.099" y2="23.781" width="0.2032" layer="1"/>
-<wire x1="284.5181" y1="25.3619" x2="273.05" y2="25.3619" width="0.2032" layer="1"/>
-<via x="273.05" y="25.3619" extent="1-16" drill="0.3302"/>
-<wire x1="273.05" y1="25.3619" x2="269.2019" y2="29.21" width="0.2032" layer="16"/>
-<wire x1="269.2019" y1="29.21" x2="263.525" y2="29.21" width="0.2032" layer="16"/>
-<wire x1="263.525" y1="29.21" x2="262.255" y2="30.48" width="0.2032" layer="16"/>
-<wire x1="286.099" y1="23.781" x2="284.5181" y2="25.3619" width="0.2032" layer="1"/>
+<via x="274.193" y="15.7988" extent="1-16" drill="0.35"/>
+<wire x1="274.193" y1="18.415" x2="274.193" y2="15.7988" width="0.6096" layer="16"/>
+<wire x1="274.193" y1="18.415" x2="275.463" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="286.374" y1="29.221" x2="286.099" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="275.463" y1="19.685" x2="285.115" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="285.115" y1="19.685" x2="287.655" y2="22.225" width="0.2032" layer="1"/>
+<wire x1="287.655" y1="22.225" x2="287.655" y2="27.94" width="0.2032" layer="1"/>
+<wire x1="287.655" y1="27.94" x2="286.374" y2="29.221" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$1">
-<contactref element="U$94" pad="2"/>
-<contactref element="U$95" pad="1"/>
-<wire x1="269.399" y1="23.2266" x2="273.399" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="273.399" y1="19.2266" x2="273.399" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U11I" pad="2"/>
+<contactref element="U11O" pad="1"/>
+<wire x1="269.399" y1="29.221" x2="273.399" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="273.399" y1="25.221" x2="273.399" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="11_CATHODE">
-<contactref element="U$95" pad="2"/>
+<contactref element="U11O" pad="2"/>
 <contactref element="U$37" pad="P$7"/>
-<wire x1="273.399" y1="23.2266" x2="271.2256" y2="25.4" width="0.2032" layer="1"/>
-<wire x1="271.2256" y1="25.4" x2="271.145" y2="25.4" width="0.2032" layer="1"/>
-<via x="271.145" y="25.4" extent="1-16" drill="0.3302"/>
-<wire x1="271.145" y1="25.4" x2="264.795" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="264.795" y1="25.4" x2="259.715" y2="30.48" width="0.2032" layer="16"/>
+<via x="271.653" y="15.7988" extent="1-16" drill="0.35"/>
+<wire x1="271.653" y1="18.415" x2="271.653" y2="15.7988" width="0.6096" layer="16"/>
+<wire x1="271.653" y1="18.415" x2="275.59" y2="22.352" width="0.2032" layer="16"/>
+<wire x1="275.59" y1="22.352" x2="275.59" y2="23.495" width="0.2032" layer="16"/>
+<via x="275.59" y="23.495" extent="1-16" drill="0.35"/>
+<wire x1="275.59" y1="23.495" x2="275.59" y2="27.94" width="0.2032" layer="1"/>
+<wire x1="274.309" y1="29.221" x2="273.399" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="275.59" y1="27.94" x2="274.309" y2="29.221" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$3">
-<contactref element="U$96" pad="2"/>
-<contactref element="U$97" pad="1"/>
-<wire x1="256.699" y1="23.2266" x2="260.699" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="260.699" y1="19.2266" x2="260.699" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U10I" pad="2"/>
+<contactref element="U10O" pad="1"/>
+<wire x1="256.699" y1="29.221" x2="260.699" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="260.699" y1="25.221" x2="260.699" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="10_CATHODE">
-<contactref element="U$97" pad="2"/>
+<contactref element="U10O" pad="2"/>
 <contactref element="U$37" pad="P$8"/>
-<wire x1="260.699" y1="23.2266" x2="260.699" y2="24.416" width="0.2032" layer="1"/>
-<wire x1="260.699" y1="24.416" x2="259.715" y2="25.4" width="0.2032" layer="1"/>
-<via x="259.715" y="25.4" extent="1-16" drill="0.3302"/>
-<wire x1="259.715" y1="25.4" x2="259.334" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="259.334" y1="25.4" x2="257.175" y2="27.559" width="0.2032" layer="16"/>
-<wire x1="257.175" y1="27.559" x2="257.175" y2="30.48" width="0.2032" layer="16"/>
+<via x="269.113" y="15.7988" extent="1-16" drill="0.35"/>
+<wire x1="269.113" y1="18.415" x2="269.113" y2="15.7988" width="0.6096" layer="16"/>
+<wire x1="269.113" y1="18.415" x2="267.335" y2="20.193" width="0.2032" layer="16"/>
+<via x="267.335" y="23.7606" extent="1-16" drill="0.35"/>
+<wire x1="267.335" y1="23.7606" x2="267.335" y2="27.305" width="0.2032" layer="1"/>
+<wire x1="267.335" y1="27.305" x2="265.419" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="265.419" y1="29.221" x2="260.699" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="267.335" y1="20.193" x2="267.335" y2="23.7606" width="0.2032" layer="16"/>
 </signal>
 <signal name="N$4">
-<contactref element="U$98" pad="2"/>
-<contactref element="U$99" pad="1"/>
-<wire x1="243.999" y1="23.2266" x2="247.999" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="247.999" y1="19.2266" x2="247.999" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U09O" pad="1"/>
+<wire x1="247.999" y1="25.221" x2="243.999" y2="29.221" width="0.2032" layer="1"/>
+<contactref element="U09I" pad="2"/>
+<wire x1="247.999" y1="24.903" x2="247.999" y2="25.221" width="0.2032" layer="1"/>
 </signal>
 <signal name="9_CATHODE">
-<contactref element="U$99" pad="2"/>
+<contactref element="U09O" pad="2"/>
 <contactref element="U$37" pad="P$9"/>
-<wire x1="247.999" y1="23.2266" x2="250.1724" y2="25.4" width="0.2032" layer="1"/>
-<wire x1="250.1724" y1="25.4" x2="250.19" y2="25.4" width="0.2032" layer="1"/>
-<via x="250.19" y="25.4" extent="1-16" drill="0.3302"/>
-<wire x1="250.19" y1="25.4" x2="250.571" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="251.079" y1="25.908" x2="250.571" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="251.079" y1="28.448" x2="251.079" y2="25.908" width="0.2032" layer="16"/>
-<wire x1="251.079" y1="28.448" x2="251.841" y2="29.21" width="0.2032" layer="16"/>
-<wire x1="251.841" y1="29.21" x2="253.365" y2="29.21" width="0.2032" layer="16"/>
-<wire x1="253.365" y1="29.21" x2="254.635" y2="30.48" width="0.2032" layer="16"/>
+<via x="266.573" y="15.7988" extent="1-16" drill="0.35"/>
+<wire x1="266.573" y1="18.415" x2="266.573" y2="15.7988" width="0.6096" layer="16"/>
+<wire x1="266.573" y1="18.415" x2="265.303" y2="19.685" width="0.2032" layer="16"/>
+<wire x1="250.04250625" y1="21.10249375" x2="250.04250625" y2="23.64249375" width="0.2032" layer="16"/>
+<via x="250.04250625" y="23.64249375" extent="1-16" drill="0.35"/>
+<wire x1="250.04250625" y1="23.64249375" x2="250.04250625" y2="28.08749375" width="0.2032" layer="1"/>
+<wire x1="248.909" y1="29.221" x2="247.999" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="265.303" y1="19.685" x2="251.46" y2="19.685" width="0.2032" layer="16"/>
+<wire x1="251.46" y1="19.685" x2="250.04250625" y2="21.10249375" width="0.2032" layer="16"/>
+<wire x1="250.04250625" y1="28.08749375" x2="248.909" y2="29.221" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$5">
-<contactref element="U$106" pad="2"/>
-<contactref element="U$107" pad="1"/>
-<wire x1="193.199" y1="23.2266" x2="197.199" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="197.199" y1="19.2266" x2="197.199" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U05I" pad="2"/>
+<contactref element="U05O" pad="1"/>
+<wire x1="193.199" y1="29.221" x2="197.199" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="197.199" y1="25.221" x2="197.199" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$6">
-<contactref element="U$104" pad="2"/>
-<contactref element="U$105" pad="1"/>
-<wire x1="205.899" y1="23.2266" x2="209.899" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="209.899" y1="19.2266" x2="209.899" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U06I" pad="2"/>
+<contactref element="U06O" pad="1"/>
+<wire x1="205.899" y1="29.221" x2="209.899" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="209.899" y1="25.221" x2="209.899" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$7">
-<contactref element="U$100" pad="2"/>
-<contactref element="U$101" pad="1"/>
-<wire x1="231.299" y1="23.2266" x2="235.299" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="235.299" y1="19.2266" x2="235.299" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U08I" pad="2"/>
+<contactref element="U08O" pad="1"/>
+<wire x1="231.299" y1="29.221" x2="235.299" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="235.299" y1="25.221" x2="235.299" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="8_CATHODE">
-<contactref element="U$101" pad="2"/>
+<contactref element="U08O" pad="2"/>
 <contactref element="U$36" pad="P$2"/>
-<wire x1="195.58" y1="30.48" x2="195.199" y2="30.099" width="0.2032" layer="16"/>
-<via x="195.99595625" y="25.5016" extent="1-16" drill="0.3302"/>
-<wire x1="195.199" y1="30.099" x2="195.199" y2="26.04455625" width="0.2032" layer="16"/>
-<wire x1="195.99595625" y1="25.5016" x2="195.74195625" y2="25.5016" width="0.2032" layer="16"/>
-<wire x1="195.74195625" y1="25.5016" x2="195.199" y2="26.04455625" width="0.2032" layer="16"/>
-<wire x1="195.99595625" y1="25.5016" x2="196.02135625" y2="25.527" width="0.2032" layer="1"/>
-<wire x1="200.787" y1="25.527" x2="200.66" y2="25.527" width="0.2032" layer="1"/>
-<wire x1="200.66" y1="25.527" x2="196.02135625" y2="25.527" width="0.2032" layer="1"/>
-<wire x1="200.787" y1="25.527" x2="232.9986" y2="25.527" width="0.2032" layer="1"/>
-<wire x1="232.9986" y1="25.527" x2="235.299" y2="23.2266" width="0.2032" layer="1"/>
+<via x="190.5" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="190.5" y1="17.145" x2="190.5" y2="14.986" width="0.2032" layer="16"/>
+<wire x1="190.5" y1="17.145" x2="191.77" y2="18.415" width="0.2032" layer="16"/>
+<wire x1="191.77" y1="18.415" x2="219.71" y2="18.415" width="0.2032" layer="16"/>
+<wire x1="229.235" y1="27.94" x2="229.235" y2="29.21" width="0.2032" layer="1"/>
+<wire x1="229.235" y1="29.21" x2="230.505" y2="30.48" width="0.2032" layer="1"/>
+<wire x1="230.505" y1="30.48" x2="234.04" y2="30.48" width="0.2032" layer="1"/>
+<wire x1="234.04" y1="30.48" x2="235.299" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="219.71" y1="18.415" x2="229.235" y2="27.94" width="0.2032" layer="1"/>
+<via x="219.71" y="18.415" extent="1-16" drill="0.35"/>
 </signal>
 <signal name="N$10">
-<contactref element="U$102" pad="2"/>
-<contactref element="U$103" pad="1"/>
-<wire x1="218.599" y1="23.2266" x2="222.599" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="222.599" y1="19.2266" x2="222.599" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U07I" pad="2"/>
+<contactref element="U07O" pad="1"/>
+<wire x1="218.599" y1="29.221" x2="222.599" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="222.599" y1="25.221" x2="222.599" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="7_CATHODE">
-<contactref element="U$103" pad="2"/>
+<contactref element="U07O" pad="2"/>
 <contactref element="U$36" pad="P$3"/>
-<wire x1="193.04" y1="30.48" x2="193.675" y2="29.845" width="0.2032" layer="16"/>
-<wire x1="193.675" y1="26.2509" x2="194.437" y2="25.4889" width="0.2032" layer="16"/>
-<via x="194.437" y="25.4889" extent="1-16" drill="0.3302"/>
-<wire x1="194.691" y1="24.8539" x2="194.437" y2="25.1079" width="0.2032" layer="1"/>
-<wire x1="194.437" y1="25.4889" x2="194.437" y2="25.1079" width="0.2032" layer="1"/>
-<wire x1="220.9717" y1="24.8539" x2="194.691" y2="24.8539" width="0.2032" layer="1"/>
-<wire x1="220.9717" y1="24.8539" x2="222.599" y2="23.2266" width="0.2032" layer="1"/>
-<wire x1="193.675" y1="29.845" x2="193.675" y2="26.2509" width="0.2032" layer="16"/>
+<via x="187.96" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="187.96" y1="17.145" x2="187.96" y2="14.986" width="0.2032" layer="16"/>
+<wire x1="187.96" y1="17.145" x2="189.865" y2="19.05" width="0.2032" layer="16"/>
+<wire x1="212.09" y1="21.59" x2="209.55" y2="19.05" width="0.2032" layer="16"/>
+<wire x1="209.55" y1="19.05" x2="189.865" y2="19.05" width="0.2032" layer="16"/>
+<wire x1="216.535" y1="26.035" x2="216.535" y2="29.21" width="0.2032" layer="1"/>
+<wire x1="216.535" y1="29.21" x2="217.805" y2="30.48" width="0.2032" layer="1"/>
+<wire x1="217.805" y1="30.48" x2="221.34" y2="30.48" width="0.2032" layer="1"/>
+<wire x1="221.34" y1="30.48" x2="222.599" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="212.09" y1="21.59" x2="216.535" y2="26.035" width="0.2032" layer="1"/>
+<via x="212.09" y="21.59" extent="1-16" drill="0.35"/>
 </signal>
 <signal name="6_CATHODE">
-<contactref element="U$105" pad="2"/>
+<contactref element="U06O" pad="2"/>
 <contactref element="U$36" pad="P$4"/>
-<wire x1="209.899" y1="23.2266" x2="209.8184" y2="23.2266" width="0.2032" layer="1"/>
-<wire x1="208.6991" y1="24.3459" x2="194.437" y2="24.3459" width="0.2032" layer="1"/>
-<wire x1="192.8241" y1="25.527" x2="193.2559" y2="25.527" width="0.2032" layer="1"/>
-<wire x1="194.437" y1="24.3459" x2="193.2559" y2="25.527" width="0.2032" layer="1"/>
-<via x="192.8241" y="25.527" extent="1-16" drill="0.3302"/>
-<wire x1="191.897" y1="29.083" x2="190.5" y2="30.48" width="0.2032" layer="16"/>
-<wire x1="209.8184" y1="23.2266" x2="208.6991" y2="24.3459" width="0.2032" layer="1"/>
-<wire x1="192.8241" y1="25.527" x2="191.897" y2="26.2509" width="0.2032" layer="16"/>
-<wire x1="191.897" y1="29.083" x2="191.897" y2="26.2509" width="0.2032" layer="16"/>
+<via x="185.42" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="185.42" y1="17.145" x2="185.42" y2="14.986" width="0.2032" layer="16"/>
+<wire x1="185.42" y1="17.145" x2="187.96" y2="19.685" width="0.2032" layer="16"/>
+<wire x1="190.5" y1="19.685" x2="191.77" y2="20.955" width="0.2032" layer="16"/>
+<wire x1="191.77" y1="20.955" x2="198.755" y2="20.955" width="0.2032" layer="16"/>
+<wire x1="198.755" y1="20.955" x2="203.835" y2="26.035" width="0.2032" layer="1"/>
+<wire x1="203.835" y1="26.035" x2="203.835" y2="29.21" width="0.2032" layer="1"/>
+<wire x1="203.835" y1="29.21" x2="205.105" y2="30.48" width="0.2032" layer="1"/>
+<wire x1="205.105" y1="30.48" x2="208.64" y2="30.48" width="0.2032" layer="1"/>
+<wire x1="208.64" y1="30.48" x2="209.899" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="187.96" y1="19.685" x2="190.5" y2="19.685" width="0.2032" layer="16"/>
+<via x="198.755" y="20.955" extent="1-16" drill="0.35"/>
 </signal>
 <signal name="N$8">
-<contactref element="U$108" pad="2"/>
-<contactref element="U$109" pad="1"/>
-<wire x1="180.499" y1="23.2266" x2="184.499" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="184.499" y1="19.2266" x2="184.499" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U04I" pad="2"/>
+<contactref element="U04O" pad="1"/>
+<wire x1="180.499" y1="29.221" x2="184.499" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="184.499" y1="25.221" x2="184.499" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="4_CATHODE">
-<contactref element="U$109" pad="2"/>
+<contactref element="U04O" pad="2"/>
 <contactref element="U$36" pad="P$6"/>
-<wire x1="184.499" y1="23.2266" x2="184.499" y2="25.114" width="0.2032" layer="1"/>
-<wire x1="184.531" y1="25.146" x2="184.499" y2="25.114" width="0.2032" layer="1"/>
-<wire x1="184.531" y1="25.146" x2="184.531" y2="25.4" width="0.2032" layer="1"/>
-<via x="184.531" y="25.4" extent="1-16" drill="0.3302"/>
-<wire x1="184.531" y1="25.4" x2="184.658" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="185.42" y1="26.162" x2="184.658" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="185.42" y1="26.162" x2="185.42" y2="30.48" width="0.2032" layer="16"/>
+<via x="180.34" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="180.34" y1="17.145" x2="180.34" y2="14.986" width="0.2032" layer="16"/>
+<wire x1="186.055" y1="22.86" x2="180.34" y2="17.145" width="0.2032" layer="1"/>
+<wire x1="184.499" y1="29.221" x2="186.055" y2="27.665" width="0.2032" layer="1"/>
+<wire x1="186.055" y1="27.665" x2="186.055" y2="22.86" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$11">
-<contactref element="U$110" pad="2"/>
-<contactref element="U$111" pad="1"/>
-<wire x1="167.799" y1="23.2266" x2="171.799" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="171.799" y1="19.2266" x2="171.799" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U03I" pad="2"/>
+<contactref element="U03O" pad="1"/>
+<wire x1="167.799" y1="29.221" x2="171.799" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="171.799" y1="25.221" x2="171.799" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="3_CATHODE">
-<contactref element="U$111" pad="2"/>
+<contactref element="U03O" pad="2"/>
 <contactref element="U$36" pad="P$7"/>
-<wire x1="171.799" y1="23.2266" x2="173.9724" y2="25.4" width="0.2032" layer="1"/>
-<wire x1="173.9724" y1="25.4" x2="173.99" y2="25.4" width="0.2032" layer="1"/>
-<via x="173.99" y="25.4" extent="1-16" drill="0.3302"/>
-<wire x1="173.99" y1="25.4" x2="174.371" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="175.006" y1="26.035" x2="174.371" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="175.006" y1="26.035" x2="179.07" y2="26.035" width="0.2032" layer="16"/>
-<wire x1="179.07" y1="26.035" x2="182.88" y2="29.845" width="0.2032" layer="16"/>
-<wire x1="182.88" y1="29.845" x2="182.88" y2="30.48" width="0.2032" layer="16"/>
+<via x="177.8" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="177.8" y1="17.145" x2="177.8" y2="14.986" width="0.2032" layer="16"/>
+<wire x1="171.799" y1="29.221" x2="174.625" y2="26.395" width="0.2032" layer="1"/>
+<via x="174.625" y="24.13" extent="1-16" drill="0.35"/>
+<wire x1="174.625" y1="24.13" x2="174.625" y2="20.32" width="0.2032" layer="16"/>
+<wire x1="174.625" y1="20.32" x2="177.8" y2="17.145" width="0.2032" layer="16"/>
+<wire x1="174.625" y1="26.395" x2="174.625" y2="24.13" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$13">
-<contactref element="U$112" pad="2"/>
-<contactref element="U$113" pad="1"/>
-<wire x1="155.099" y1="23.2266" x2="159.099" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="159.099" y1="19.2266" x2="159.099" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U02I" pad="2"/>
+<contactref element="U02O" pad="1"/>
+<wire x1="155.099" y1="29.221" x2="159.099" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="159.099" y1="25.221" x2="159.099" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="2_CATHODE">
-<contactref element="U$113" pad="2"/>
+<contactref element="U02O" pad="2"/>
 <contactref element="U$36" pad="P$8"/>
-<wire x1="159.099" y1="23.2266" x2="161.2724" y2="25.4" width="0.2032" layer="1"/>
-<wire x1="161.2724" y1="25.4" x2="161.29" y2="25.4" width="0.2032" layer="1"/>
-<via x="161.29" y="25.4" extent="1-16" drill="0.3302"/>
-<wire x1="161.29" y1="25.4" x2="161.544" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="162.687" y1="26.543" x2="161.544" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="171.958" y1="26.543" x2="172.72" y2="27.305" width="0.2032" layer="16"/>
-<wire x1="172.72" y1="27.305" x2="174.752" y2="27.305" width="0.2032" layer="16"/>
-<wire x1="174.752" y1="27.305" x2="175.514" y2="26.543" width="0.2032" layer="16"/>
-<wire x1="175.514" y1="26.543" x2="176.784" y2="26.543" width="0.2032" layer="16"/>
-<wire x1="176.784" y1="26.543" x2="180.34" y2="30.099" width="0.2032" layer="16"/>
-<wire x1="180.34" y1="30.099" x2="180.34" y2="30.48" width="0.2032" layer="16"/>
-<wire x1="162.687" y1="26.543" x2="171.958" y2="26.543" width="0.2032" layer="16"/>
+<via x="175.26" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="175.26" y1="17.145" x2="175.26" y2="14.986" width="0.2032" layer="16"/>
+<wire x1="175.26" y1="17.145" x2="172.72" y2="19.685" width="0.2032" layer="16"/>
+<via x="161.925" y="19.685" extent="1-16" drill="0.3302"/>
+<wire x1="161.925" y1="19.685" x2="161.29" y2="20.32" width="0.2032" layer="1"/>
+<wire x1="161.29" y1="27.03" x2="159.099" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="172.72" y1="19.685" x2="161.925" y2="19.685" width="0.2032" layer="16"/>
+<wire x1="161.29" y1="20.32" x2="161.29" y2="27.03" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$14">
-<contactref element="U$114" pad="2"/>
-<contactref element="U$115" pad="1"/>
-<wire x1="142.399" y1="23.2266" x2="146.399" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="146.399" y1="19.2266" x2="146.399" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U01I" pad="2"/>
+<contactref element="U01O" pad="1"/>
+<wire x1="142.399" y1="29.221" x2="146.399" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="146.399" y1="25.221" x2="146.399" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="1_CATHODE">
-<contactref element="U$115" pad="2"/>
+<contactref element="U01O" pad="2"/>
 <contactref element="U$36" pad="P$9"/>
-<wire x1="146.399" y1="23.2266" x2="146.399" y2="23.844" width="0.2032" layer="1"/>
-<wire x1="146.399" y1="23.844" x2="147.955" y2="25.4" width="0.2032" layer="1"/>
-<via x="147.955" y="25.4" extent="1-16" drill="0.3302"/>
-<wire x1="147.955" y1="25.4" x2="151.13" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="151.13" y1="25.4" x2="155.067" y2="29.337" width="0.2032" layer="16"/>
-<wire x1="155.067" y1="29.337" x2="176.022" y2="29.337" width="0.2032" layer="16"/>
-<wire x1="177.165" y1="30.48" x2="176.022" y2="29.337" width="0.2032" layer="16"/>
-<wire x1="177.165" y1="30.48" x2="177.8" y2="30.48" width="0.2032" layer="16"/>
+<via x="172.72" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="172.72" y1="17.145" x2="172.72" y2="14.986" width="0.2032" layer="16"/>
+<wire x1="172.72" y1="17.145" x2="171.45" y2="18.415" width="0.2032" layer="16"/>
+<wire x1="171.45" y1="18.415" x2="151.257" y2="18.415" width="0.2032" layer="16"/>
+<via x="151.257" y="18.415" extent="1-16" drill="0.3302"/>
+<wire x1="151.257" y1="18.415" x2="148.59" y2="21.082" width="0.2032" layer="1"/>
+<wire x1="148.59" y1="27.03" x2="146.399" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="148.59" y1="21.082" x2="148.59" y2="27.03" width="0.2032" layer="1"/>
 </signal>
 <signal name="5_CATHODE">
-<contactref element="U$107" pad="2"/>
+<contactref element="U05O" pad="2"/>
 <contactref element="U$36" pad="P$5"/>
-<wire x1="197.199" y1="23.2266" x2="194.913" y2="23.2266" width="0.2032" layer="1"/>
-<wire x1="194.913" y1="23.2266" x2="193.8826" y2="24.257" width="0.2032" layer="1"/>
-<wire x1="193.8826" y1="24.257" x2="192.405" y2="24.257" width="0.2032" layer="1"/>
-<wire x1="192.405" y1="24.257" x2="191.135" y2="25.527" width="0.2032" layer="1"/>
-<via x="191.135" y="25.527" extent="1-16" drill="0.3302"/>
-<wire x1="191.135" y1="25.527" x2="190.881" y2="25.527" width="0.2032" layer="16"/>
-<wire x1="190.881" y1="25.527" x2="190.373" y2="26.035" width="0.2032" layer="16"/>
-<wire x1="190.373" y1="26.035" x2="190.373" y2="28.194" width="0.2032" layer="16"/>
-<wire x1="190.373" y1="28.194" x2="188.087" y2="30.48" width="0.2032" layer="16"/>
-<wire x1="188.087" y1="30.48" x2="187.96" y2="30.48" width="0.2032" layer="16"/>
+<via x="182.88" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="182.88" y1="17.145" x2="182.88" y2="14.986" width="0.2032" layer="16"/>
+<wire x1="189.23" y1="23.876" x2="182.88" y2="17.526" width="0.2032" layer="16"/>
+<wire x1="182.88" y1="17.145" x2="182.88" y2="17.526" width="0.2032" layer="16"/>
+<wire x1="189.23" y1="28.575" x2="191.135" y2="30.48" width="0.2032" layer="1"/>
+<wire x1="191.135" y1="30.48" x2="195.94" y2="30.48" width="0.2032" layer="1"/>
+<wire x1="195.94" y1="30.48" x2="197.199" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="189.23" y1="23.876" x2="189.23" y2="28.575" width="0.2032" layer="1"/>
+<via x="189.23" y="23.876" extent="1-16" drill="0.35"/>
 </signal>
-<signal name="N$15">
-<contactref element="U$90" pad="4"/>
+<signal name="SNS13I">
 <contactref element="R6" pad="P$3"/>
-<contactref element="U3" pad="11"/>
-<wire x1="294.799" y1="17.261" x2="294.799" y2="8.096" width="0.2032" layer="1"/>
-<wire x1="294.799" y1="8.096" x2="296.545" y2="6.35" width="0.2032" layer="1"/>
-<wire x1="296.545" y1="6.35" x2="303.53" y2="13.335" width="0.2032" layer="16"/>
-<wire x1="325.12" y1="13.335" x2="327.66" y2="10.795" width="0.2032" layer="16"/>
-<wire x1="327.66" y1="10.795" x2="327.66" y2="10.16" width="0.2032" layer="16"/>
-<wire x1="303.53" y1="13.335" x2="325.12" y2="13.335" width="0.2032" layer="16"/>
-</signal>
-<signal name="N$16">
-<contactref element="U$91" pad="4"/>
-<contactref element="R6" pad="P$2"/>
-<contactref element="U3" pad="12"/>
-<wire x1="294.799" y1="21.4266" x2="293.37" y2="19.9976" width="0.2032" layer="1"/>
-<wire x1="293.37" y1="6.985" x2="294.005" y2="6.35" width="0.2032" layer="1"/>
-<wire x1="293.37" y1="19.9976" x2="293.37" y2="6.985" width="0.2032" layer="1"/>
-<wire x1="294.005" y1="6.35" x2="295.275" y2="5.08" width="0.2032" layer="16"/>
-<wire x1="297.18" y1="5.08" x2="297.815" y2="5.715" width="0.2032" layer="16"/>
-<wire x1="303.53" y1="12.7" x2="322.58" y2="12.7" width="0.2032" layer="16"/>
-<wire x1="322.58" y1="12.7" x2="325.12" y2="10.16" width="0.2032" layer="16"/>
-<wire x1="295.275" y1="5.08" x2="297.18" y2="5.08" width="0.2032" layer="16"/>
-<wire x1="297.815" y1="5.715" x2="297.815" y2="6.985" width="0.2032" layer="16"/>
-<wire x1="297.815" y1="6.985" x2="303.53" y2="12.7" width="0.2032" layer="16"/>
-</signal>
-<signal name="N$17">
-<contactref element="U$88" pad="4"/>
-<contactref element="R6" pad="P$4"/>
-<contactref element="U3" pad="13"/>
-<wire x1="299.085" y1="6.35" x2="299.085" y2="14.605" width="0.2032" layer="1"/>
-<wire x1="301.741" y1="17.261" x2="307.499" y2="17.261" width="0.2032" layer="16"/>
-<wire x1="299.085" y1="14.605" x2="301.741" y2="17.261" width="0.2032" layer="16"/>
-<wire x1="299.085" y1="6.35" x2="304.8" y2="12.065" width="0.2032" layer="16"/>
-<wire x1="320.675" y1="12.065" x2="322.58" y2="10.16" width="0.2032" layer="16"/>
-<wire x1="304.8" y1="12.065" x2="320.675" y2="12.065" width="0.2032" layer="16"/>
-<via x="299.085" y="14.605" extent="1-16" drill="0.3302"/>
-</signal>
-<signal name="N$19">
-<contactref element="U$89" pad="4"/>
-<contactref element="R6" pad="P$5"/>
-<contactref element="U3" pad="14"/>
-<wire x1="301.625" y1="6.35" x2="301.625" y2="8.89" width="0.2032" layer="1"/>
-<wire x1="301.625" y1="8.89" x2="308.61" y2="15.875" width="0.2032" layer="1"/>
-<wire x1="308.61" y1="15.875" x2="308.61" y2="20.3156" width="0.2032" layer="16"/>
-<wire x1="308.61" y1="20.3156" x2="307.499" y2="21.4266" width="0.2032" layer="16"/>
-<wire x1="301.625" y1="6.35" x2="306.705" y2="11.43" width="0.2032" layer="16"/>
-<wire x1="318.77" y1="11.43" x2="320.04" y2="10.16" width="0.2032" layer="16"/>
-<wire x1="306.705" y1="11.43" x2="318.77" y2="11.43" width="0.2032" layer="16"/>
-<via x="308.61" y="15.875" extent="1-16" drill="0.3302"/>
-</signal>
-<signal name="N$20">
-<contactref element="U$84" pad="4"/>
-<contactref element="R6" pad="P$8"/>
-<contactref element="U3" pad="5"/>
-<wire x1="309.245" y1="6.35" x2="310.515" y2="5.08" width="0.2032" layer="16"/>
-<wire x1="322.58" y1="5.08" x2="325.12" y2="2.54" width="0.2032" layer="16"/>
-<wire x1="310.515" y1="5.08" x2="322.58" y2="5.08" width="0.2032" layer="16"/>
-<wire x1="326.39" y1="3.81" x2="325.12" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="332.899" y1="17.261" x2="329.089" y2="13.451" width="0.2032" layer="1"/>
-<wire x1="329.089" y1="13.451" x2="328.411" y2="13.451" width="0.2032" layer="1"/>
-<wire x1="328.411" y1="13.451" x2="326.39" y2="11.43" width="0.2032" layer="1"/>
-<wire x1="326.39" y1="11.43" x2="326.39" y2="3.81" width="0.2032" layer="1"/>
-</signal>
-<signal name="N$22">
-<contactref element="U$85" pad="4"/>
-<contactref element="R6" pad="P$9"/>
-<contactref element="U3" pad="6"/>
-<wire x1="311.785" y1="6.35" x2="323.85" y2="6.35" width="0.2032" layer="16"/>
-<wire x1="323.85" y1="6.35" x2="327.66" y2="2.54" width="0.2032" layer="16"/>
-<wire x1="332.899" y1="21.4266" x2="333.5384" y2="21.4266" width="0.2032" layer="16"/>
-<wire x1="333.5384" y1="21.4266" x2="334.645" y2="20.32" width="0.2032" layer="16"/>
-<wire x1="334.645" y1="20.32" x2="334.645" y2="15.875" width="0.2032" layer="16"/>
-<via x="334.645" y="15.875" extent="1-16" drill="0.3302"/>
-<wire x1="334.645" y1="15.875" x2="331.47" y2="12.7" width="0.2032" layer="1"/>
-<wire x1="331.47" y1="12.7" x2="330.2" y2="12.7" width="0.2032" layer="1"/>
-<wire x1="330.2" y1="12.7" x2="328.93" y2="11.43" width="0.2032" layer="1"/>
-<wire x1="328.93" y1="3.81" x2="327.66" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="328.93" y1="11.43" x2="328.93" y2="3.81" width="0.2032" layer="1"/>
-</signal>
-<signal name="N$23">
-<contactref element="U$86" pad="4"/>
-<contactref element="R6" pad="P$6"/>
-<contactref element="U3" pad="3"/>
-<wire x1="304.165" y1="6.35" x2="306.705" y2="3.81" width="0.2032" layer="16"/>
-<wire x1="318.77" y1="3.81" x2="320.04" y2="2.54" width="0.2032" layer="16"/>
-<wire x1="306.705" y1="3.81" x2="318.77" y2="3.81" width="0.2032" layer="16"/>
-<wire x1="320.199" y1="17.261" x2="318.77" y2="15.832" width="0.2032" layer="1"/>
-<wire x1="318.77" y1="3.81" x2="320.04" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="318.77" y1="15.832" x2="318.77" y2="3.81" width="0.2032" layer="1"/>
-</signal>
-<signal name="N$24">
-<contactref element="U$87" pad="4"/>
-<contactref element="R6" pad="P$7"/>
+<contactref element="U13I" pad="4"/>
 <contactref element="U3" pad="4"/>
-<wire x1="306.705" y1="6.35" x2="308.61" y2="4.445" width="0.2032" layer="16"/>
-<wire x1="320.675" y1="4.445" x2="322.58" y2="2.54" width="0.2032" layer="16"/>
-<wire x1="308.61" y1="4.445" x2="320.675" y2="4.445" width="0.2032" layer="16"/>
-<wire x1="320.199" y1="21.4266" x2="320.2034" y2="21.4266" width="0.2032" layer="16"/>
-<wire x1="320.2034" y1="21.4266" x2="322.58" y2="19.05" width="0.2032" layer="16"/>
-<wire x1="322.58" y1="19.05" x2="322.58" y2="15.24" width="0.2032" layer="16"/>
-<via x="322.58" y="15.24" extent="1-16" drill="0.3302"/>
-<wire x1="322.58" y1="15.24" x2="322.58" y2="12.7" width="0.2032" layer="1"/>
-<wire x1="322.58" y1="12.7" x2="321.31" y2="11.43" width="0.2032" layer="1"/>
-<wire x1="321.31" y1="3.81" x2="322.58" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="321.31" y1="11.43" x2="321.31" y2="3.81" width="0.2032" layer="1"/>
+<wire x1="302.895" y1="2.54" x2="300.355" y2="5.08" width="0.2032" layer="1"/>
+<wire x1="295.91" y1="5.08" x2="294.005" y2="6.985" width="0.2032" layer="1"/>
+<wire x1="294.005" y1="15.875" x2="294.64" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="300.355" y1="5.08" x2="295.91" y2="5.08" width="0.2032" layer="1"/>
+<wire x1="294.005" y1="6.985" x2="294.005" y2="15.875" width="0.2032" layer="1"/>
+<wire x1="294.64" y1="16.51" x2="294.64" y2="22.944" width="0.2032" layer="1"/>
+<wire x1="294.64" y1="22.944" x2="294.799" y2="23.103" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$25">
-<contactref element="U$80" pad="4"/>
+<signal name="SNS13O">
+<contactref element="R6" pad="P$2"/>
+<contactref element="U13O" pad="4"/>
+<contactref element="U3" pad="3"/>
+<wire x1="300.355" y1="2.54" x2="298.45" y2="4.445" width="0.2032" layer="1"/>
+<wire x1="292.1" y1="4.445" x2="290.83" y2="5.715" width="0.2032" layer="1"/>
+<wire x1="290.83" y1="5.715" x2="290.83" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="290.83" y1="15.24" x2="292.1" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="298.45" y1="4.445" x2="292.1" y2="4.445" width="0.2032" layer="1"/>
+<wire x1="292.1" y1="16.51" x2="292.1" y2="24.722" width="0.2032" layer="1"/>
+<wire x1="292.1" y1="24.722" x2="294.799" y2="27.421" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS14O">
+<contactref element="R6" pad="P$4"/>
+<contactref element="U14O" pad="4"/>
+<contactref element="U3" pad="5"/>
+<wire x1="305.435" y1="2.54" x2="302.26" y2="5.715" width="0.2032" layer="1"/>
+<wire x1="298.45" y1="5.715" x2="296.545" y2="7.62" width="0.2032" layer="1"/>
+<wire x1="296.545" y1="7.62" x2="296.545" y2="12.7" width="0.2032" layer="1"/>
+<wire x1="296.545" y1="12.7" x2="297.18" y2="13.335" width="0.2032" layer="1"/>
+<wire x1="297.18" y1="13.335" x2="297.18" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="302.26" y1="5.715" x2="298.45" y2="5.715" width="0.2032" layer="1"/>
+<wire x1="297.18" y1="16.51" x2="297.18" y2="18.415" width="0.2032" layer="1"/>
+<wire x1="306.186" y1="27.421" x2="307.499" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="297.18" y1="18.415" x2="306.186" y2="27.421" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS14I">
+<contactref element="R6" pad="P$5"/>
+<contactref element="U14I" pad="4"/>
+<contactref element="U3" pad="6"/>
+<wire x1="307.975" y1="2.54" x2="304.165" y2="6.35" width="0.2032" layer="1"/>
+<wire x1="300.355" y1="6.35" x2="299.085" y2="7.62" width="0.2032" layer="1"/>
+<wire x1="299.085" y1="7.62" x2="299.085" y2="12.7" width="0.2032" layer="1"/>
+<wire x1="299.085" y1="12.7" x2="299.72" y2="13.335" width="0.2032" layer="1"/>
+<wire x1="299.72" y1="13.335" x2="299.72" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="304.165" y1="6.35" x2="300.355" y2="6.35" width="0.2032" layer="1"/>
+<wire x1="299.72" y1="16.51" x2="299.72" y2="20.32" width="0.2032" layer="1"/>
+<wire x1="302.503" y1="23.103" x2="307.499" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="299.72" y1="20.32" x2="302.503" y2="23.103" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS16O">
+<contactref element="R6" pad="P$8"/>
+<contactref element="U3" pad="12"/>
+<wire x1="305.435" y1="10.16" x2="305.435" y2="12.7" width="0.2032" layer="1"/>
+<wire x1="307.34" y1="14.605" x2="307.34" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="305.435" y1="12.7" x2="307.34" y2="14.605" width="0.2032" layer="1"/>
+<contactref element="U16O" pad="4"/>
+<wire x1="307.34" y1="16.51" x2="307.34" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="307.34" y1="17.78" x2="309.245" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="309.245" y1="19.685" x2="329.565" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="329.565" y1="19.685" x2="331.47" y2="21.59" width="0.2032" layer="1"/>
+<wire x1="331.47" y1="25.992" x2="332.899" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="331.47" y1="21.59" x2="331.47" y2="25.992" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS16I">
+<contactref element="R6" pad="P$9"/>
+<contactref element="U3" pad="11"/>
+<wire x1="309.88" y1="16.51" x2="309.88" y2="14.605" width="0.2032" layer="1"/>
+<wire x1="309.88" y1="14.605" x2="307.975" y2="12.7" width="0.2032" layer="1"/>
+<wire x1="307.975" y1="12.7" x2="307.975" y2="10.16" width="0.2032" layer="1"/>
+<contactref element="U16I" pad="4"/>
+<wire x1="309.88" y1="16.51" x2="309.88" y2="17.145" width="0.2032" layer="1"/>
+<wire x1="309.88" y1="17.145" x2="311.785" y2="19.05" width="0.2032" layer="1"/>
+<wire x1="311.785" y1="19.05" x2="330.835" y2="19.05" width="0.2032" layer="1"/>
+<wire x1="330.835" y1="19.05" x2="332.899" y2="21.114" width="0.2032" layer="1"/>
+<wire x1="332.899" y1="21.114" x2="332.899" y2="23.103" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS15O">
+<contactref element="R6" pad="P$6"/>
+<contactref element="U15O" pad="4"/>
+<contactref element="U3" pad="14"/>
+<wire x1="300.355" y1="10.16" x2="300.355" y2="12.7" width="0.2032" layer="1"/>
+<wire x1="302.26" y1="14.605" x2="302.26" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="300.355" y1="12.7" x2="302.26" y2="14.605" width="0.2032" layer="1"/>
+<wire x1="302.26" y1="16.51" x2="302.26" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="306.07" y1="21.59" x2="313.055" y2="21.59" width="0.2032" layer="1"/>
+<wire x1="318.886" y1="27.421" x2="320.199" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="302.26" y1="17.78" x2="306.07" y2="21.59" width="0.2032" layer="1"/>
+<wire x1="313.055" y1="21.59" x2="318.886" y2="27.421" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS15I">
+<contactref element="R6" pad="P$7"/>
+<contactref element="U15I" pad="4"/>
+<contactref element="U3" pad="13"/>
+<wire x1="302.895" y1="10.16" x2="302.895" y2="12.7" width="0.2032" layer="1"/>
+<wire x1="302.895" y1="12.7" x2="304.8" y2="14.605" width="0.2032" layer="1"/>
+<wire x1="304.8" y1="14.605" x2="304.8" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="304.8" y1="16.51" x2="304.8" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="304.8" y1="17.78" x2="307.34" y2="20.32" width="0.2032" layer="1"/>
+<wire x1="315.203" y1="23.103" x2="320.199" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="307.34" y1="20.32" x2="312.42" y2="20.32" width="0.2032" layer="1"/>
+<wire x1="312.42" y1="20.32" x2="315.203" y2="23.103" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS18O">
 <contactref element="R5" pad="P$4"/>
-<contactref element="U2" pad="13"/>
-<wire x1="350.52" y1="6.35" x2="351.198" y2="6.35" width="0.2032" layer="16"/>
-<wire x1="357.029" y1="12.181" x2="356.8915" y2="12.0435" width="0.2032" layer="16"/>
-<wire x1="356.8915" y1="12.0435" x2="351.198" y2="6.35" width="0.2032" layer="16"/>
-<wire x1="357.029" y1="15.991" x2="357.029" y2="12.181" width="0.2032" layer="16"/>
-<wire x1="357.029" y1="15.991" x2="358.299" y2="17.261" width="0.2032" layer="16"/>
-<wire x1="375.285" y1="10.16" x2="373.38" y2="12.065" width="0.2032" layer="1"/>
-<wire x1="356.913" y1="12.065" x2="356.8915" y2="12.0435" width="0.2032" layer="1"/>
-<via x="356.8915" y="12.0435" extent="1-16" drill="0.3302"/>
-<wire x1="373.38" y1="12.065" x2="356.913" y2="12.065" width="0.2032" layer="1"/>
-</signal>
-<signal name="N$26">
-<contactref element="U$81" pad="4"/>
-<contactref element="R5" pad="P$5"/>
-<contactref element="U2" pad="14"/>
-<wire x1="353.06" y1="6.35" x2="354.965" y2="8.255" width="0.2032" layer="16"/>
-<wire x1="358.299" y1="21.4266" x2="360.045" y2="19.6806" width="0.2032" layer="16"/>
-<via x="360.045" y="11.4173" extent="1-16" drill="0.3302"/>
-<wire x1="371.4877" y1="11.4173" x2="372.745" y2="10.16" width="0.2032" layer="1"/>
-<wire x1="360.045" y1="11.4173" x2="371.4877" y2="11.4173" width="0.2032" layer="1"/>
-<wire x1="356.8827" y1="8.255" x2="360.045" y2="11.4173" width="0.2032" layer="16"/>
-<wire x1="354.965" y1="8.255" x2="356.8827" y2="8.255" width="0.2032" layer="16"/>
-<wire x1="360.045" y1="19.6806" x2="360.045" y2="11.4173" width="0.2032" layer="16"/>
-</signal>
-<signal name="N$27">
-<contactref element="U$76" pad="4"/>
-<contactref element="R5" pad="P$8"/>
 <contactref element="U2" pad="5"/>
-<wire x1="360.68" y1="6.35" x2="362.4072" y2="4.6228" width="0.2032" layer="16"/>
-<wire x1="375.7422" y1="4.6228" x2="377.825" y2="2.54" width="0.2032" layer="16"/>
-<wire x1="362.4072" y1="4.6228" x2="375.7422" y2="4.6228" width="0.2032" layer="16"/>
-<wire x1="383.699" y1="17.7182" x2="377.1282" y2="17.7182" width="0.2032" layer="16"/>
-<wire x1="372.745" y1="13.335" x2="370.84" y2="13.335" width="0.2032" layer="16"/>
-<wire x1="370.84" y1="13.335" x2="368.935" y2="11.43" width="0.2032" layer="16"/>
-<wire x1="368.935" y1="11.43" x2="368.935" y2="8.89" width="0.2032" layer="16"/>
-<wire x1="368.935" y1="8.89" x2="368.3" y2="8.255" width="0.2032" layer="16"/>
-<wire x1="362.585" y1="8.255" x2="360.68" y2="6.35" width="0.2032" layer="16"/>
-<wire x1="377.1282" y1="17.7182" x2="372.745" y2="13.335" width="0.2032" layer="16"/>
-<wire x1="368.3" y1="8.255" x2="362.585" y2="8.255" width="0.2032" layer="16"/>
+<contactref element="U18O" pad="4"/>
+<wire x1="359.41" y1="2.54" x2="356.87" y2="5.08" width="0.2032" layer="1"/>
+<wire x1="356.87" y1="5.08" x2="352.425" y2="5.08" width="0.2032" layer="1"/>
+<wire x1="352.425" y1="5.08" x2="350.52" y2="6.985" width="0.2032" layer="1"/>
+<wire x1="350.52" y1="6.985" x2="350.52" y2="15.875" width="0.2032" layer="1"/>
+<wire x1="350.52" y1="15.875" x2="351.155" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="351.155" y1="16.51" x2="353.695" y2="19.05" width="0.2032" layer="1"/>
+<wire x1="353.695" y1="19.05" x2="354.33" y2="19.05" width="0.2032" layer="1"/>
+<wire x1="354.33" y1="19.05" x2="355.6" y2="20.32" width="0.2032" layer="1"/>
+<wire x1="355.6" y1="20.32" x2="355.6" y2="24.765" width="0.2032" layer="1"/>
+<wire x1="355.6" y1="24.765" x2="358.256" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="358.256" y1="27.421" x2="358.299" y2="27.421" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$29">
-<contactref element="U$78" pad="4"/>
-<contactref element="R5" pad="P$6"/>
-<contactref element="U2" pad="3"/>
-<wire x1="355.6" y1="6.35" x2="358.14" y2="3.81" width="0.2032" layer="16"/>
-<wire x1="371.475" y1="3.81" x2="372.745" y2="2.54" width="0.2032" layer="16"/>
-<wire x1="358.14" y1="3.81" x2="371.475" y2="3.81" width="0.2032" layer="16"/>
-<wire x1="355.6" y1="6.35" x2="359.41" y2="10.16" width="0.2032" layer="16"/>
-<wire x1="363.898" y1="10.16" x2="370.999" y2="17.261" width="0.2032" layer="16"/>
-<wire x1="359.41" y1="10.16" x2="363.898" y2="10.16" width="0.2032" layer="16"/>
+<signal name="SNS18I">
+<contactref element="R5" pad="P$5"/>
+<contactref element="U2" pad="6"/>
+<contactref element="U18I" pad="4"/>
+<wire x1="361.95" y1="2.54" x2="358.775" y2="5.715" width="0.2032" layer="1"/>
+<wire x1="358.775" y1="5.715" x2="354.33" y2="5.715" width="0.2032" layer="1"/>
+<wire x1="354.33" y1="5.715" x2="353.06" y2="6.985" width="0.2032" layer="1"/>
+<wire x1="353.06" y1="6.985" x2="353.06" y2="15.875" width="0.2032" layer="1"/>
+<wire x1="353.06" y1="15.875" x2="353.695" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="353.695" y1="16.51" x2="358.299" y2="21.114" width="0.2032" layer="1"/>
+<wire x1="358.299" y1="21.114" x2="358.299" y2="23.103" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$32">
-<contactref element="U$79" pad="4"/>
-<contactref element="R5" pad="P$7"/>
-<contactref element="U2" pad="4"/>
-<wire x1="358.14" y1="6.35" x2="360.2736" y2="4.2164" width="0.2032" layer="16"/>
-<wire x1="373.6086" y1="4.2164" x2="375.285" y2="2.54" width="0.2032" layer="16"/>
-<wire x1="360.2736" y1="4.2164" x2="373.6086" y2="4.2164" width="0.2032" layer="16"/>
-<wire x1="358.14" y1="6.35" x2="361.315" y2="9.525" width="0.2032" layer="16"/>
-<wire x1="372.745" y1="17.145" x2="372.745" y2="19.6806" width="0.2032" layer="16"/>
-<wire x1="372.745" y1="19.6806" x2="370.999" y2="21.4266" width="0.2032" layer="16"/>
-<wire x1="361.315" y1="9.525" x2="365.125" y2="9.525" width="0.2032" layer="16"/>
-<wire x1="365.125" y1="9.525" x2="372.745" y2="17.145" width="0.2032" layer="16"/>
-</signal>
-<signal name="N$33">
-<contactref element="U$83" pad="4"/>
-<contactref element="R5" pad="P$3"/>
+<signal name="SNS20O">
+<contactref element="R5" pad="P$8"/>
 <contactref element="U2" pad="12"/>
-<wire x1="347.98" y1="6.35" x2="347.98" y2="12.6873" width="0.2032" layer="16"/>
-<wire x1="347.98" y1="12.6873" x2="347.98" y2="19.0456" width="0.2032" layer="16"/>
-<wire x1="347.98" y1="19.0456" x2="345.599" y2="21.4266" width="0.2032" layer="16"/>
-<wire x1="377.825" y1="10.16" x2="375.285" y2="12.7" width="0.2032" layer="1"/>
-<wire x1="347.9927" y1="12.7" x2="347.98" y2="12.6873" width="0.2032" layer="1"/>
-<via x="347.98" y="12.6873" extent="1-16" drill="0.3302"/>
-<wire x1="375.285" y1="12.7" x2="347.9927" y2="12.7" width="0.2032" layer="1"/>
+<wire x1="359.41" y1="10.16" x2="359.41" y2="14.605" width="0.2032" layer="1"/>
+<wire x1="359.41" y1="14.605" x2="361.315" y2="16.51" width="0.2032" layer="1"/>
+<contactref element="U20O" pad="4"/>
+<wire x1="361.315" y1="16.51" x2="364.8964" y2="20.0914" width="0.2032" layer="1"/>
+<wire x1="382.386" y1="27.421" x2="383.699" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="364.8964" y1="20.0914" x2="375.0564" y2="20.0914" width="0.2032" layer="1"/>
+<wire x1="375.0564" y1="20.0914" x2="382.386" y2="27.421" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$35">
-<contactref element="U$82" pad="4"/>
+<signal name="SNS19O">
+<contactref element="R5" pad="P$6"/>
+<contactref element="U19O" pad="4"/>
+<contactref element="U2" pad="14"/>
+<wire x1="354.33" y1="10.16" x2="354.33" y2="14.605" width="0.2032" layer="1"/>
+<wire x1="354.33" y1="14.605" x2="356.235" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="356.235" y1="16.51" x2="361.315" y2="21.59" width="0.2032" layer="1"/>
+<wire x1="361.315" y1="21.59" x2="364.49" y2="21.59" width="0.2032" layer="1"/>
+<wire x1="370.321" y1="27.421" x2="370.999" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="364.49" y1="21.59" x2="370.321" y2="27.421" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS19I">
+<contactref element="R5" pad="P$7"/>
+<contactref element="U19I" pad="4"/>
+<contactref element="U2" pad="13"/>
+<wire x1="356.87" y1="10.16" x2="356.87" y2="14.605" width="0.2032" layer="1"/>
+<wire x1="356.87" y1="14.605" x2="358.775" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="366.638" y1="23.103" x2="361.315" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="358.775" y1="16.51" x2="360.045" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="361.315" y1="17.78" x2="360.045" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="366.638" y1="23.103" x2="370.999" y2="23.103" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS17I">
+<contactref element="R5" pad="P$3"/>
+<contactref element="U2" pad="4"/>
+<contactref element="U17I" pad="4"/>
+<wire x1="356.87" y1="2.54" x2="354.965" y2="4.445" width="0.2032" layer="1"/>
+<wire x1="349.25" y1="4.445" x2="347.98" y2="5.715" width="0.2032" layer="1"/>
+<wire x1="347.98" y1="5.715" x2="347.98" y2="15.875" width="0.2032" layer="1"/>
+<wire x1="347.98" y1="15.875" x2="348.615" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="354.965" y1="4.445" x2="349.25" y2="4.445" width="0.2032" layer="1"/>
+<wire x1="348.615" y1="16.51" x2="348.615" y2="20.087" width="0.2032" layer="1"/>
+<wire x1="348.615" y1="20.087" x2="345.599" y2="23.103" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS17O">
 <contactref element="R5" pad="P$2"/>
-<contactref element="U2" pad="11"/>
-<wire x1="345.44" y1="6.35" x2="345.44" y2="13.335" width="0.2032" layer="16"/>
-<wire x1="345.44" y1="13.335" x2="345.44" y2="17.102" width="0.2032" layer="16"/>
-<wire x1="345.44" y1="17.102" x2="345.599" y2="17.261" width="0.2032" layer="16"/>
-<wire x1="380.365" y1="10.16" x2="377.19" y2="13.335" width="0.2032" layer="1"/>
-<via x="345.44" y="13.335" extent="1-16" drill="0.3302"/>
-<wire x1="377.19" y1="13.335" x2="345.44" y2="13.335" width="0.2032" layer="1"/>
+<contactref element="U2" pad="3"/>
+<contactref element="U17O" pad="4"/>
+<wire x1="354.33" y1="2.54" x2="353.06" y2="3.81" width="0.2032" layer="1"/>
+<wire x1="346.71" y1="3.81" x2="344.805" y2="5.715" width="0.2032" layer="1"/>
+<wire x1="344.805" y1="12.065" x2="346.075" y2="13.335" width="0.2032" layer="1"/>
+<wire x1="346.075" y1="13.335" x2="346.075" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="353.06" y1="3.81" x2="346.71" y2="3.81" width="0.2032" layer="1"/>
+<wire x1="344.805" y1="5.715" x2="344.805" y2="12.065" width="0.2032" layer="1"/>
+<wire x1="346.075" y1="16.51" x2="346.075" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="346.075" y1="17.78" x2="344.17" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="344.17" y1="25.992" x2="345.599" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="344.17" y1="19.685" x2="344.17" y2="25.992" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$36">
-<contactref element="U$72" pad="4"/>
-<contactref element="R2" pad="P$7"/>
-<contactref element="U1" pad="13"/>
-<wire x1="427.355" y1="10.16" x2="426.085" y2="8.89" width="0.2032" layer="1"/>
-<wire x1="426.085" y1="8.89" x2="413.385" y2="8.89" width="0.2032" layer="1"/>
-<wire x1="413.385" y1="8.89" x2="410.845" y2="6.35" width="0.2032" layer="1"/>
-<wire x1="409.099" y1="17.261" x2="409.099" y2="8.096" width="0.2032" layer="16"/>
-<wire x1="409.099" y1="8.096" x2="410.845" y2="6.35" width="0.2032" layer="16"/>
-</signal>
-<signal name="N$37">
-<contactref element="U$73" pad="4"/>
-<contactref element="R2" pad="P$6"/>
-<contactref element="U1" pad="14"/>
-<wire x1="424.815" y1="10.16" x2="423.545" y2="11.43" width="0.2032" layer="1"/>
-<wire x1="423.545" y1="11.43" x2="413.385" y2="11.43" width="0.2032" layer="1"/>
-<wire x1="413.385" y1="11.43" x2="408.305" y2="6.35" width="0.2032" layer="1"/>
-<wire x1="409.099" y1="21.4266" x2="407.67" y2="19.9976" width="0.2032" layer="16"/>
-<wire x1="407.67" y1="6.985" x2="408.305" y2="6.35" width="0.2032" layer="16"/>
-<wire x1="407.67" y1="19.9976" x2="407.67" y2="6.985" width="0.2032" layer="16"/>
-</signal>
-<signal name="N$38">
-<contactref element="U$68" pad="4"/>
-<contactref element="R2" pad="P$5"/>
+<signal name="SNS22O">
+<contactref element="R2" pad="P$4"/>
 <contactref element="U1" pad="5"/>
-<wire x1="434.499" y1="17.261" x2="434.499" y2="12.224" width="0.2032" layer="16"/>
-<wire x1="434.499" y1="12.224" x2="433.705" y2="11.43" width="0.2032" layer="16"/>
-<wire x1="433.705" y1="6.35" x2="429.895" y2="2.54" width="0.2032" layer="16"/>
-<wire x1="433.705" y1="11.43" x2="433.705" y2="6.35" width="0.2032" layer="16"/>
-<wire x1="429.895" y1="2.54" x2="427.355" y2="0" width="0.2032" layer="1"/>
-<wire x1="427.355" y1="0" x2="409.575" y2="0" width="0.2032" layer="1"/>
-<wire x1="409.575" y1="0" x2="409.575" y2="-0.0254" width="0.2032" layer="1"/>
-<via x="409.575" y="-0.0254" extent="1-16" drill="0.3302"/>
-<wire x1="409.575" y1="-0.0254" x2="405.765" y2="3.7846" width="0.2032" layer="16"/>
-<wire x1="405.765" y1="3.7846" x2="405.765" y2="6.35" width="0.2032" layer="16"/>
+<contactref element="U22O" pad="4"/>
+<wire x1="396.875" y1="2.54" x2="391.795" y2="7.62" width="0.2032" layer="1"/>
+<wire x1="391.795" y1="7.62" x2="389.255" y2="7.62" width="0.2032" layer="1"/>
+<wire x1="389.255" y1="7.62" x2="387.985" y2="8.89" width="0.2032" layer="1"/>
+<wire x1="387.985" y1="8.89" x2="387.985" y2="10.795" width="0.2032" layer="1"/>
+<wire x1="387.985" y1="10.795" x2="393.065" y2="15.875" width="0.2032" layer="1"/>
+<wire x1="393.065" y1="15.875" x2="398.145" y2="15.875" width="0.2032" layer="1"/>
+<wire x1="398.145" y1="15.875" x2="400.05" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="400.05" y1="17.78" x2="400.05" y2="18.415" width="0.2032" layer="1"/>
+<wire x1="400.05" y1="18.415" x2="409.056" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="409.056" y1="27.421" x2="409.099" y2="27.421" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$40">
-<contactref element="U$70" pad="4"/>
-<contactref element="R2" pad="P$2"/>
-<contactref element="U1" pad="3"/>
-<wire x1="421.799" y1="17.261" x2="426.995" y2="12.065" width="0.2032" layer="16"/>
-<wire x1="427.99" y1="12.065" x2="428.625" y2="11.43" width="0.2032" layer="16"/>
-<wire x1="426.995" y1="12.065" x2="427.99" y2="12.065" width="0.2032" layer="16"/>
-<wire x1="428.625" y1="6.35" x2="424.815" y2="2.54" width="0.2032" layer="16"/>
-<wire x1="428.625" y1="11.43" x2="428.625" y2="6.35" width="0.2032" layer="16"/>
-<wire x1="424.815" y1="2.54" x2="423.545" y2="1.27" width="0.2032" layer="1"/>
-<via x="402.59" y="1.27" extent="1-16" drill="0.3302"/>
-<wire x1="402.59" y1="1.27" x2="398.145" y2="5.715" width="0.2032" layer="16"/>
-<wire x1="398.145" y1="5.715" x2="398.145" y2="6.35" width="0.2032" layer="16"/>
-<wire x1="423.545" y1="1.27" x2="402.59" y2="1.27" width="0.2032" layer="1"/>
+<signal name="SNS22I">
+<contactref element="R2" pad="P$5"/>
+<contactref element="U1" pad="6"/>
+<contactref element="U22I" pad="4"/>
+<wire x1="399.415" y1="2.54" x2="393.7" y2="8.255" width="0.2032" layer="1"/>
+<wire x1="391.16" y1="8.255" x2="390.525" y2="8.89" width="0.2032" layer="1"/>
+<wire x1="390.525" y1="10.47053125" x2="395.29446875" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="399.415" y1="15.24" x2="402.59" y2="18.415" width="0.2032" layer="1"/>
+<wire x1="393.7" y1="8.255" x2="391.16" y2="8.255" width="0.2032" layer="1"/>
+<wire x1="390.525" y1="8.89" x2="390.525" y2="10.47053125" width="0.2032" layer="1"/>
+<wire x1="395.29446875" y1="15.24" x2="399.415" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="402.59" y1="18.415" x2="403.86" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="405.681" y1="19.685" x2="409.099" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="403.86" y1="19.685" x2="405.681" y2="19.685" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$41">
-<contactref element="U$71" pad="4"/>
-<contactref element="R2" pad="P$3"/>
-<contactref element="U1" pad="4"/>
-<wire x1="421.799" y1="21.4266" x2="424.18" y2="19.0456" width="0.2032" layer="16"/>
-<wire x1="424.18" y1="19.0456" x2="424.18" y2="16.51" width="0.2032" layer="16"/>
-<wire x1="424.18" y1="16.51" x2="427.99" y2="12.7" width="0.2032" layer="16"/>
-<wire x1="427.99" y1="12.7" x2="429.895" y2="12.7" width="0.2032" layer="16"/>
-<wire x1="429.895" y1="12.7" x2="431.165" y2="11.43" width="0.2032" layer="16"/>
-<wire x1="431.165" y1="6.35" x2="427.355" y2="2.54" width="0.2032" layer="16"/>
-<wire x1="431.165" y1="11.43" x2="431.165" y2="6.35" width="0.2032" layer="16"/>
-<wire x1="425.4373" y1="0.6223" x2="405.765" y2="0.6223" width="0.2032" layer="1"/>
-<via x="405.765" y="0.6223" extent="1-16" drill="0.3302"/>
-<wire x1="405.765" y1="0.6223" x2="400.685" y2="5.7023" width="0.2032" layer="16"/>
-<wire x1="400.685" y1="5.7023" x2="400.685" y2="6.35" width="0.2032" layer="16"/>
-<wire x1="427.355" y1="2.54" x2="425.4373" y2="0.6223" width="0.2032" layer="1"/>
-</signal>
-<signal name="N$42">
-<contactref element="U$75" pad="4"/>
+<signal name="SNS24O">
 <contactref element="R2" pad="P$8"/>
 <contactref element="U1" pad="12"/>
-<wire x1="429.895" y1="10.16" x2="427.99" y2="8.255" width="0.2032" layer="1"/>
-<wire x1="415.29" y1="8.255" x2="413.385" y2="6.35" width="0.2032" layer="1"/>
-<wire x1="427.99" y1="8.255" x2="415.29" y2="8.255" width="0.2032" layer="1"/>
-<wire x1="396.399" y1="21.4266" x2="394.97" y2="19.9976" width="0.2032" layer="16"/>
-<wire x1="397.8258" y1="16.1942" x2="407.035" y2="6.985" width="0.2032" layer="16"/>
-<wire x1="395.9571125" y1="16.1942" x2="397.8258" y2="16.1942" width="0.2032" layer="16"/>
-<wire x1="394.97" y1="17.1813125" x2="395.9571125" y2="16.1942" width="0.2032" layer="16"/>
-<wire x1="407.035" y1="6.985" x2="407.035" y2="5.715" width="0.2032" layer="16"/>
-<wire x1="407.035" y1="5.715" x2="408.305" y2="4.445" width="0.2032" layer="16"/>
-<wire x1="408.305" y1="4.445" x2="411.48" y2="4.445" width="0.2032" layer="16"/>
-<wire x1="411.48" y1="4.445" x2="413.385" y2="6.35" width="0.2032" layer="16"/>
-<wire x1="394.97" y1="19.9976" x2="394.97" y2="17.1813125" width="0.2032" layer="16"/>
+<contactref element="U24O" pad="4"/>
+<wire x1="396.875" y1="10.16" x2="400.05" y2="13.335" width="0.2032" layer="1"/>
+<wire x1="403.2852625" y1="13.335" x2="406.8666625" y2="16.9164" width="0.2032" layer="1"/>
+<wire x1="408.7114" y1="16.9164" x2="410.21" y2="18.415" width="0.2032" layer="1"/>
+<wire x1="406.8666625" y1="16.9164" x2="408.7114" y2="16.9164" width="0.2032" layer="1"/>
+<wire x1="400.05" y1="13.335" x2="403.2852625" y2="13.335" width="0.2032" layer="1"/>
+<wire x1="410.21" y1="18.415" x2="411.48" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="433.821" y1="27.421" x2="434.499" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="411.48" y1="19.685" x2="426.085" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="426.085" y1="19.685" x2="433.821" y2="27.421" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$43">
-<contactref element="U$74" pad="4"/>
-<contactref element="R2" pad="P$9"/>
-<contactref element="U1" pad="11"/>
-<wire x1="432.435" y1="10.16" x2="432.435" y2="9.525" width="0.2032" layer="1"/>
-<wire x1="432.435" y1="9.525" x2="430.53" y2="7.62" width="0.2032" layer="1"/>
-<wire x1="417.195" y1="7.62" x2="415.925" y2="6.35" width="0.2032" layer="1"/>
-<wire x1="430.53" y1="7.62" x2="417.195" y2="7.62" width="0.2032" layer="1"/>
-<wire x1="415.925" y1="6.35" x2="415.925" y2="12.065" width="0.2032" layer="16"/>
-<wire x1="415.925" y1="12.065" x2="413.385" y2="14.605" width="0.2032" layer="16"/>
-<via x="413.385" y="14.605" extent="1-16" drill="0.3302"/>
-<wire x1="413.385" y1="14.605" x2="408.94" y2="14.605" width="0.2032" layer="1"/>
-<wire x1="408.94" y1="14.605" x2="407.035" y2="16.51" width="0.2032" layer="1"/>
-<wire x1="407.035" y1="16.51" x2="403.86" y2="16.51" width="0.2032" layer="1"/>
-<wire x1="403.86" y1="16.51" x2="402.59" y2="15.24" width="0.2032" layer="1"/>
-<wire x1="402.59" y1="15.24" x2="398.42" y2="15.24" width="0.2032" layer="1"/>
-<wire x1="398.42" y1="15.24" x2="396.399" y2="17.261" width="0.2032" layer="1"/>
+<signal name="SNS23O">
+<contactref element="R2" pad="P$6"/>
+<contactref element="U1" pad="14"/>
+<contactref element="U23O" pad="4"/>
+<wire x1="391.795" y1="10.16" x2="396.24" y2="14.605" width="0.2032" layer="1"/>
+<wire x1="396.24" y1="14.605" x2="401.32" y2="14.605" width="0.2032" layer="1"/>
+<wire x1="401.32" y1="14.605" x2="405.13" y2="18.415" width="0.2032" layer="1"/>
+<wire x1="405.13" y1="18.415" x2="407.67" y2="20.955" width="0.2032" layer="1"/>
+<wire x1="420.486" y1="27.421" x2="421.799" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="407.67" y1="20.955" x2="414.02" y2="20.955" width="0.2032" layer="1"/>
+<wire x1="414.02" y1="20.955" x2="420.486" y2="27.421" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS23I">
+<contactref element="R2" pad="P$7"/>
+<contactref element="U1" pad="13"/>
+<contactref element="U23I" pad="4"/>
+<wire x1="394.335" y1="10.16" x2="398.145" y2="13.97" width="0.2032" layer="1"/>
+<wire x1="403.225" y1="13.97" x2="407.67" y2="18.415" width="0.2032" layer="1"/>
+<wire x1="398.145" y1="13.97" x2="403.225" y2="13.97" width="0.2032" layer="1"/>
+<wire x1="407.67" y1="18.415" x2="409.575" y2="20.32" width="0.2032" layer="1"/>
+<wire x1="416.803" y1="23.103" x2="421.799" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="409.575" y1="20.32" x2="414.02" y2="20.32" width="0.2032" layer="1"/>
+<wire x1="414.02" y1="20.32" x2="416.803" y2="23.103" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS21I">
+<contactref element="R2" pad="P$3"/>
+<contactref element="U1" pad="4"/>
+<contactref element="U21I" pad="4"/>
+<wire x1="394.335" y1="2.54" x2="389.89" y2="6.985" width="0.2032" layer="1"/>
+<wire x1="387.35" y1="6.985" x2="385.445" y2="8.89" width="0.2032" layer="1"/>
+<wire x1="385.445" y1="8.89" x2="385.445" y2="10.795" width="0.2032" layer="1"/>
+<wire x1="385.445" y1="10.795" x2="386.715" y2="12.065" width="0.2032" layer="1"/>
+<wire x1="388.62" y1="12.065" x2="393.065" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="393.065" y1="16.51" x2="396.24" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="396.24" y1="16.51" x2="397.51" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="397.51" y1="17.78" x2="397.51" y2="18.415" width="0.2032" layer="1"/>
+<wire x1="389.89" y1="6.985" x2="387.35" y2="6.985" width="0.2032" layer="1"/>
+<wire x1="386.715" y1="12.065" x2="388.62" y2="12.065" width="0.2032" layer="1"/>
+<wire x1="397.51" y1="18.415" x2="397.51" y2="21.992" width="0.2032" layer="1"/>
+<wire x1="397.51" y1="21.992" x2="396.399" y2="23.103" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS21O">
+<contactref element="R2" pad="P$2"/>
+<contactref element="U1" pad="3"/>
+<contactref element="U21O" pad="4"/>
+<wire x1="391.795" y1="2.54" x2="387.985" y2="6.35" width="0.2032" layer="1"/>
+<wire x1="386.715" y1="6.35" x2="384.81" y2="8.255" width="0.2032" layer="1"/>
+<wire x1="384.81" y1="8.255" x2="384.81" y2="11.43" width="0.2032" layer="1"/>
+<wire x1="386.08" y1="12.7" x2="387.985" y2="12.7" width="0.2032" layer="1"/>
+<wire x1="387.985" y1="12.7" x2="392.43" y2="17.145" width="0.2032" layer="1"/>
+<wire x1="392.43" y1="17.145" x2="393.7" y2="17.145" width="0.2032" layer="1"/>
+<wire x1="393.7" y1="17.145" x2="394.97" y2="18.415" width="0.2032" layer="1"/>
+<wire x1="387.985" y1="6.35" x2="386.715" y2="6.35" width="0.2032" layer="1"/>
+<wire x1="384.81" y1="11.43" x2="386.08" y2="12.7" width="0.2032" layer="1"/>
+<wire x1="394.97" y1="18.415" x2="394.97" y2="25.992" width="0.2032" layer="1"/>
+<wire x1="394.97" y1="25.992" x2="396.399" y2="27.421" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$45">
-<contactref element="U$68" pad="2"/>
-<contactref element="U$69" pad="1"/>
-<wire x1="434.499" y1="23.2266" x2="438.499" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="438.499" y1="19.2266" x2="438.499" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U24I" pad="2"/>
+<contactref element="U24O" pad="1"/>
+<wire x1="434.499" y1="29.221" x2="438.499" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="438.499" y1="25.221" x2="438.499" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$46">
-<contactref element="U$70" pad="2"/>
-<contactref element="U$71" pad="1"/>
-<wire x1="421.799" y1="23.2266" x2="425.799" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="425.799" y1="19.2266" x2="425.799" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U23I" pad="2"/>
+<contactref element="U23O" pad="1"/>
+<wire x1="421.799" y1="29.221" x2="425.799" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="425.799" y1="25.221" x2="425.799" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$47">
-<contactref element="U$72" pad="2"/>
-<contactref element="U$73" pad="1"/>
-<wire x1="411.829" y1="21.7666" x2="410.369" y2="23.2266" width="0.2032" layer="16"/>
-<wire x1="409.099" y1="23.2266" x2="410.369" y2="23.2266" width="0.2032" layer="16"/>
-<wire x1="411.829" y1="21.7666" x2="411.829" y2="20.331" width="0.2032" layer="16"/>
-<wire x1="411.829" y1="20.331" x2="413.099" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U22I" pad="2"/>
+<contactref element="U22O" pad="1"/>
+<wire x1="409.099" y1="29.221" x2="413.099" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="413.099" y1="25.221" x2="413.099" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$48">
-<contactref element="U$74" pad="2"/>
-<contactref element="U$75" pad="1"/>
-<wire x1="396.399" y1="23.2266" x2="400.399" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="400.399" y1="19.2266" x2="400.399" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U21I" pad="2"/>
+<contactref element="U21O" pad="1"/>
+<wire x1="397.4658" y1="27.8628875" x2="397.4658" y2="27.8362" width="0.2032" layer="1"/>
+<wire x1="397.4658" y1="27.8362" x2="400.399" y2="24.903" width="0.2032" layer="1"/>
+<wire x1="396.399" y1="29.221" x2="396.399" y2="28.9296875" width="0.2032" layer="1"/>
+<wire x1="396.399" y1="28.9296875" x2="397.4658" y2="27.8628875" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$49">
-<contactref element="U$82" pad="2"/>
-<contactref element="U$83" pad="1"/>
-<wire x1="345.599" y1="23.2266" x2="349.599" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="349.599" y1="19.2266" x2="349.599" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U17I" pad="2"/>
+<contactref element="U17O" pad="1"/>
+<wire x1="345.599" y1="29.221" x2="349.599" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="349.599" y1="25.221" x2="349.599" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$50">
-<contactref element="U$80" pad="2"/>
-<contactref element="U$81" pad="1"/>
-<wire x1="358.299" y1="23.2266" x2="362.299" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="362.299" y1="19.2266" x2="362.299" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U18I" pad="2"/>
+<contactref element="U18O" pad="1"/>
+<wire x1="358.299" y1="29.221" x2="362.299" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="362.299" y1="25.221" x2="362.299" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$51">
-<contactref element="U$76" pad="2"/>
-<contactref element="U$77" pad="1"/>
-<wire x1="383.699" y1="23.6838" x2="387.699" y2="19.6838" width="0.2032" layer="16"/>
-<wire x1="387.699" y1="19.6838" x2="387.699" y2="19.5182" width="0.2032" layer="16"/>
+<contactref element="U20I" pad="2"/>
+<contactref element="U20O" pad="1"/>
+<wire x1="383.699" y1="29.221" x2="387.699" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="387.699" y1="25.221" x2="387.699" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$52">
-<contactref element="U$78" pad="2"/>
-<contactref element="U$79" pad="1"/>
-<wire x1="370.999" y1="23.2266" x2="374.999" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="374.999" y1="19.2266" x2="374.999" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U19I" pad="2"/>
+<contactref element="U19O" pad="1"/>
+<wire x1="370.999" y1="29.221" x2="374.999" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="374.999" y1="25.221" x2="374.999" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$53">
-<contactref element="U$84" pad="2"/>
-<contactref element="U$85" pad="1"/>
-<wire x1="332.899" y1="23.2266" x2="336.899" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="336.899" y1="19.2266" x2="336.899" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U16I" pad="2"/>
+<contactref element="U16O" pad="1"/>
+<wire x1="332.899" y1="29.221" x2="336.899" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="336.899" y1="25.221" x2="336.899" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$54">
-<contactref element="U$86" pad="2"/>
-<contactref element="U$87" pad="1"/>
-<wire x1="320.199" y1="23.2266" x2="324.199" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="324.199" y1="19.2266" x2="324.199" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U15I" pad="2"/>
+<contactref element="U15O" pad="1"/>
+<wire x1="320.199" y1="29.221" x2="324.199" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="324.199" y1="25.221" x2="324.199" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$55">
-<contactref element="U$88" pad="2"/>
-<contactref element="U$89" pad="1"/>
-<wire x1="307.499" y1="23.2266" x2="311.499" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="311.499" y1="19.2266" x2="311.499" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U14I" pad="2"/>
+<contactref element="U14O" pad="1"/>
+<wire x1="307.499" y1="29.221" x2="311.499" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="311.499" y1="25.221" x2="311.499" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$56">
-<contactref element="U$90" pad="2"/>
-<contactref element="U$91" pad="1"/>
-<wire x1="294.799" y1="23.2266" x2="298.799" y2="19.2266" width="0.2032" layer="16"/>
-<wire x1="298.799" y1="19.2266" x2="298.799" y2="19.061" width="0.2032" layer="16"/>
+<contactref element="U13I" pad="2"/>
+<contactref element="U13O" pad="1"/>
+<wire x1="294.799" y1="29.221" x2="298.799" y2="25.221" width="0.2032" layer="1"/>
+<wire x1="298.799" y1="25.221" x2="298.799" y2="24.903" width="0.2032" layer="1"/>
 </signal>
 <signal name="SCL">
 <contactref element="MS2" pad="18"/>
 <contactref element="J4" pad="2"/>
 <contactref element="R3" pad="P$1"/>
 <contactref element="U$45" pad="SCL"/>
-<wire x1="101.6" y1="16.51" x2="102.87" y2="17.78" width="0.2032" layer="16"/>
-<wire x1="114.3" y1="17.78" x2="115.57" y2="19.05" width="0.2032" layer="16"/>
-<wire x1="102.87" y1="17.78" x2="114.3" y2="17.78" width="0.2032" layer="16"/>
-<wire x1="101.6" y1="16.51" x2="101.6" y2="8.255" width="0.2032" layer="16"/>
-<wire x1="101.6" y1="8.255" x2="104.14" y2="5.715" width="0.2032" layer="16"/>
-<wire x1="115.57" y1="19.05" x2="116.84" y2="20.32" width="0.2032" layer="1"/>
-<wire x1="116.84" y1="20.32" x2="121.92" y2="20.32" width="0.2032" layer="1"/>
-<wire x1="121.92" y1="20.32" x2="122.555" y2="19.685" width="0.2032" layer="1"/>
-<wire x1="139.68213125" y1="12.7" x2="139.7" y2="12.7" width="0.2032" layer="1"/>
-<wire x1="136.6774" y1="13.8176" x2="138.56453125" y2="13.8176" width="0.2032" layer="1"/>
-<wire x1="138.56453125" y1="13.8176" x2="139.68213125" y2="12.7" width="0.2032" layer="1"/>
-<wire x1="139.7" y1="12.7" x2="143.51" y2="8.89" width="0.2032" layer="1"/>
-<wire x1="143.51" y1="6.905" x2="148.51" y2="1.905" width="0.2032" layer="1"/>
-<wire x1="122.555" y1="19.685" x2="130.81" y2="19.685" width="0.2032" layer="1"/>
-<wire x1="130.81" y1="19.685" x2="136.6774" y2="13.8176" width="0.2032" layer="1"/>
-<wire x1="143.51" y1="8.89" x2="143.51" y2="6.905" width="0.2032" layer="1"/>
+<wire x1="104.14" y1="5.715" x2="101.6" y2="8.255" width="0.2032" layer="1"/>
+<wire x1="101.6" y1="8.255" x2="101.6" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="101.6" y1="19.685" x2="102.235" y2="20.32" width="0.2032" layer="1"/>
+<wire x1="114.3" y1="20.32" x2="115.57" y2="19.05" width="0.2032" layer="1"/>
+<wire x1="101.6" y1="16.51" x2="101.6" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="102.235" y1="20.32" x2="114.3" y2="20.32" width="0.2032" layer="1"/>
+<wire x1="115.57" y1="19.05" x2="116.84" y2="20.32" width="0.2032" layer="16"/>
+<wire x1="116.84" y1="20.32" x2="122.555" y2="20.32" width="0.2032" layer="16"/>
+<wire x1="122.555" y1="20.32" x2="123.825" y2="19.05" width="0.2032" layer="16"/>
+<wire x1="123.825" y1="19.05" x2="127.635" y2="19.05" width="0.2032" layer="16"/>
+<wire x1="140.335" y1="6.35" x2="145.415" y2="6.35" width="0.2032" layer="1"/>
+<wire x1="145.415" y1="6.35" x2="148.51" y2="3.255" width="0.2032" layer="1"/>
+<wire x1="148.51" y1="3.255" x2="148.51" y2="1.905" width="0.2032" layer="1"/>
+<wire x1="127.635" y1="19.05" x2="137.795" y2="8.89" width="0.2032" layer="16"/>
+<wire x1="137.795" y1="8.89" x2="140.335" y2="6.35" width="0.2032" layer="1"/>
+<via x="137.795" y="8.89" extent="1-16" drill="0.3302"/>
 </signal>
-<signal name="N$62">
-<contactref element="U$92" pad="4"/>
+<signal name="SNS12O">
 <contactref element="R7" pad="P$8"/>
-<contactref element="U4" pad="5"/>
-<wire x1="256.54" y1="6.35" x2="257.683" y2="5.207" width="0.2032" layer="1"/>
-<wire x1="269.748" y1="5.207" x2="272.415" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="257.683" y1="5.207" x2="269.748" y2="5.207" width="0.2032" layer="1"/>
-<wire x1="282.099" y1="17.261" x2="282.734" y2="16.626" width="0.2032" layer="16"/>
-<wire x1="282.734" y1="16.626" x2="282.734" y2="9.684" width="0.2032" layer="16"/>
-<via x="282.734" y="9.684" extent="1-16" drill="0.3302"/>
-<wire x1="272.415" y1="2.54" x2="273.685" y2="1.27" width="0.2032" layer="1"/>
-<wire x1="273.685" y1="1.27" x2="275.59" y2="1.27" width="0.2032" layer="1"/>
-<wire x1="275.59" y1="1.27" x2="276.225" y2="1.905" width="0.2032" layer="1"/>
-<wire x1="276.225" y1="1.905" x2="276.225" y2="3.175" width="0.2032" layer="1"/>
-<wire x1="276.225" y1="3.175" x2="282.734" y2="9.684" width="0.2032" layer="1"/>
+<contactref element="U12O" pad="4"/>
+<contactref element="U4" pad="12"/>
+<wire x1="259.715" y1="10.16" x2="259.715" y2="13.335" width="0.2032" layer="1"/>
+<wire x1="259.715" y1="13.335" x2="256.54" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="245.745" y1="16.51" x2="244.475" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="256.54" y1="16.51" x2="245.745" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="244.475" y1="17.78" x2="244.475" y2="18.415" width="0.2032" layer="1"/>
+<wire x1="244.475" y1="18.415" x2="245.11" y2="19.05" width="0.2032" layer="1"/>
+<wire x1="245.11" y1="19.05" x2="259.715" y2="19.05" width="0.2032" layer="1"/>
+<wire x1="259.715" y1="19.05" x2="264.16" y2="23.495" width="0.2032" layer="1"/>
+<wire x1="264.16" y1="23.495" x2="265.43" y2="23.495" width="0.2032" layer="1"/>
+<wire x1="265.43" y1="23.495" x2="267.335" y2="21.59" width="0.2032" layer="1"/>
+<wire x1="267.335" y1="21.59" x2="274.955" y2="21.59" width="0.2032" layer="1"/>
+<wire x1="280.786" y1="27.421" x2="282.099" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="274.955" y1="21.59" x2="280.786" y2="27.421" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$65">
-<contactref element="U$94" pad="4"/>
+<signal name="SNS11O">
 <contactref element="R7" pad="P$6"/>
-<contactref element="U4" pad="3"/>
-<wire x1="265.684" y1="4.191" x2="267.335" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="251.46" y1="6.35" x2="253.619" y2="4.191" width="0.2032" layer="1"/>
-<wire x1="253.619" y1="4.191" x2="265.684" y2="4.191" width="0.2032" layer="1"/>
-<wire x1="269.399" y1="17.261" x2="269.399" y2="14.764" width="0.2032" layer="16"/>
-<wire x1="268.5923" y1="11.8094125" x2="268.605" y2="11.7967125" width="0.2032" layer="16"/>
-<wire x1="268.605" y1="11.7967125" x2="268.605" y2="8.89" width="0.2032" layer="16"/>
-<wire x1="268.5923" y1="13.9573" x2="268.5923" y2="11.8094125" width="0.2032" layer="16"/>
-<wire x1="268.605" y1="8.89" x2="267.97" y2="8.255" width="0.2032" layer="1"/>
-<wire x1="253.365" y1="8.255" x2="251.46" y2="6.35" width="0.2032" layer="1"/>
-<wire x1="269.399" y1="14.764" x2="268.5923" y2="13.9573" width="0.2032" layer="16"/>
-<wire x1="267.97" y1="8.255" x2="253.365" y2="8.255" width="0.2032" layer="1"/>
-<via x="268.605" y="8.89" extent="1-16" drill="0.3302"/>
+<contactref element="U11O" pad="4"/>
+<contactref element="U4" pad="14"/>
+<wire x1="254.635" y1="10.16" x2="254.635" y2="12.065" width="0.2032" layer="1"/>
+<wire x1="254.635" y1="12.065" x2="251.46" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="251.46" y1="15.24" x2="241.935" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="241.935" y1="15.24" x2="239.395" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="239.395" y1="17.78" x2="241.681" y2="20.066" width="0.2032" layer="1"/>
+<wire x1="269.399" y1="27.421" x2="266.562" y2="27.421" width="0.2032" layer="16"/>
+<wire x1="266.562" y1="27.421" x2="264.911" y2="25.77" width="0.2032" layer="16"/>
+<wire x1="264.911" y1="25.77" x2="259.207" y2="20.066" width="0.2032" layer="1"/>
+<wire x1="241.681" y1="20.066" x2="259.207" y2="20.066" width="0.2032" layer="1"/>
+<via x="264.911" y="25.77" extent="1-16" drill="0.35"/>
 </signal>
-<signal name="N$68">
-<contactref element="U$98" pad="4"/>
-<contactref element="R7" pad="P$2"/>
-<contactref element="U4" pad="11"/>
-<wire x1="241.3" y1="6.35" x2="241.3" y2="14.562" width="0.2032" layer="16"/>
-<wire x1="241.3" y1="14.562" x2="243.999" y2="17.261" width="0.2032" layer="16"/>
-<wire x1="274.955" y1="10.16" x2="274.955" y2="12.7" width="0.2032" layer="16"/>
-<wire x1="274.955" y1="12.7" x2="274.32" y2="13.335" width="0.2032" layer="16"/>
-<via x="274.32" y="13.335" extent="1-16" drill="0.3302"/>
-<wire x1="274.32" y1="13.335" x2="273.7866" y2="13.8684" width="0.2032" layer="1"/>
-<wire x1="247.3916" y1="13.8684" x2="243.999" y2="17.261" width="0.2032" layer="1"/>
-<wire x1="273.7866" y1="13.8684" x2="247.3916" y2="13.8684" width="0.2032" layer="1"/>
+<signal name="SNS09I">
+<contactref element="U4" pad="4"/>
+<contactref element="R7" pad="P$3"/>
+<contactref element="U09I" pad="4"/>
+<wire x1="257.175" y1="2.54" x2="254.635" y2="5.08" width="0.2032" layer="1"/>
+<wire x1="254.635" y1="5.08" x2="250.19" y2="5.08" width="0.2032" layer="1"/>
+<wire x1="250.19" y1="5.08" x2="248.285" y2="6.985" width="0.2032" layer="1"/>
+<wire x1="248.285" y1="6.985" x2="248.285" y2="10.795" width="0.2032" layer="1"/>
+<wire x1="248.285" y1="10.795" x2="247.015" y2="12.065" width="0.2032" layer="1"/>
+<wire x1="247.015" y1="12.065" x2="234.95" y2="12.065" width="0.2032" layer="1"/>
+<wire x1="234.95" y1="12.065" x2="231.775" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="231.775" y1="15.24" x2="231.775" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="231.775" y1="17.78" x2="232.41" y2="18.415" width="0.2032" layer="1"/>
+<wire x1="232.41" y1="18.415" x2="232.41" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="233.9086" y1="21.1836" x2="235.7533375" y2="21.1836" width="0.2032" layer="1"/>
+<wire x1="232.41" y1="19.685" x2="233.9086" y2="21.1836" width="0.2032" layer="1"/>
+<wire x1="243.364" y1="23.738" x2="238.3077375" y2="23.738" width="0.2032" layer="1"/>
+<wire x1="243.364" y1="23.738" x2="243.999" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="235.7533375" y1="21.1836" x2="238.3077375" y2="23.738" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$34">
-<contactref element="U$96" pad="4"/>
+<signal name="SNS10O">
 <contactref element="R7" pad="P$4"/>
-<contactref element="U4" pad="13"/>
-<wire x1="246.38" y1="6.35" x2="246.38" y2="12.6873" width="0.2032" layer="16"/>
-<wire x1="246.38" y1="12.6873" x2="246.38" y2="12.7" width="0.2032" layer="16"/>
-<wire x1="250.941" y1="17.261" x2="256.699" y2="17.261" width="0.2032" layer="16"/>
-<wire x1="246.38" y1="12.7" x2="250.941" y2="17.261" width="0.2032" layer="16"/>
-<wire x1="269.875" y1="11.4427" x2="269.24" y2="12.0777" width="0.2032" layer="16"/>
-<via x="269.24" y="12.0777" extent="1-16" drill="0.3302"/>
-<wire x1="246.38" y1="12.6873" x2="246.4054" y2="12.7127" width="0.2032" layer="1"/>
-<wire x1="269.24" y1="12.0777" x2="268.605" y2="12.7127" width="0.2032" layer="1"/>
-<wire x1="268.605" y1="12.7127" x2="246.4054" y2="12.7127" width="0.2032" layer="1"/>
-<via x="246.38" y="12.6873" extent="1-16" drill="0.3302"/>
-<wire x1="269.875" y1="10.16" x2="269.875" y2="11.4427" width="0.2032" layer="16"/>
+<contactref element="U10O" pad="4"/>
+<contactref element="U4" pad="5"/>
+<wire x1="259.715" y1="2.54" x2="256.54" y2="5.715" width="0.2032" layer="1"/>
+<wire x1="252.73" y1="5.715" x2="250.825" y2="7.62" width="0.2032" layer="1"/>
+<wire x1="250.825" y1="11.43" x2="248.285" y2="13.97" width="0.2032" layer="1"/>
+<wire x1="248.285" y1="13.97" x2="238.125" y2="13.97" width="0.2032" layer="1"/>
+<wire x1="238.125" y1="13.97" x2="234.315" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="256.54" y1="5.715" x2="252.73" y2="5.715" width="0.2032" layer="1"/>
+<wire x1="250.825" y1="7.62" x2="250.825" y2="11.43" width="0.2032" layer="1"/>
+<wire x1="234.315" y1="17.78" x2="234.315" y2="18.415" width="0.2032" layer="1"/>
+<wire x1="234.315" y1="18.415" x2="235.585" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="235.585" y1="19.685" x2="240.03" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="240.03" y1="19.685" x2="241.681" y2="21.336" width="0.2032" layer="1"/>
+<wire x1="241.681" y1="21.336" x2="248.666" y2="21.336" width="0.2032" layer="1"/>
+<wire x1="254.751" y1="27.421" x2="256.699" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="248.666" y1="21.336" x2="254.751" y2="27.421" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$87">
-<contactref element="U$115" pad="4"/>
+<signal name="SNS01O">
+<contactref element="U01O" pad="4"/>
 <contactref element="R12" pad="P$2"/>
-<contactref element="U6" pad="12"/>
-<wire x1="134.62" y1="8.255" x2="134.62" y2="11.43" width="0.2032" layer="16"/>
-<wire x1="137.033" y1="13.843" x2="138.684" y2="13.843" width="0.2032" layer="16"/>
-<wire x1="138.684" y1="13.843" x2="140.589" y2="15.748" width="0.2032" layer="16"/>
-<wire x1="140.589" y1="19.6166" x2="142.399" y2="21.4266" width="0.2032" layer="16"/>
-<wire x1="134.62" y1="11.43" x2="137.033" y2="13.843" width="0.2032" layer="16"/>
-<wire x1="140.589" y1="15.748" x2="140.589" y2="19.6166" width="0.2032" layer="16"/>
-<wire x1="142.399" y1="21.4266" x2="143.0384" y2="21.4266" width="0.2032" layer="16"/>
-<wire x1="143.0384" y1="21.4266" x2="144.78" y2="19.685" width="0.2032" layer="16"/>
-<wire x1="144.78" y1="14.605" x2="147.32" y2="12.065" width="0.2032" layer="16"/>
-<via x="147.32" y="12.065" extent="1-16" drill="0.55"/>
-<wire x1="147.32" y1="12.065" x2="149.225" y2="10.16" width="0.2032" layer="1"/>
-<wire x1="153.67" y1="10.16" x2="154.94" y2="8.89" width="0.2032" layer="1"/>
-<wire x1="154.94" y1="8.89" x2="164.465" y2="8.89" width="0.2032" layer="1"/>
-<wire x1="164.465" y1="8.89" x2="165.735" y2="10.16" width="0.2032" layer="1"/>
-<wire x1="144.78" y1="19.685" x2="144.78" y2="14.605" width="0.2032" layer="16"/>
-<wire x1="149.225" y1="10.16" x2="153.67" y2="10.16" width="0.2032" layer="1"/>
+<contactref element="U6" pad="3"/>
+<wire x1="151.13" y1="11.43" x2="151.13" y2="8.255" width="0.2032" layer="1"/>
+<wire x1="151.13" y1="8.255" x2="153.035" y2="6.35" width="0.2032" layer="1"/>
+<wire x1="156.845" y1="6.35" x2="160.655" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="147.32" y1="16.51" x2="147.32" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="151.13" y1="11.43" x2="147.32" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="153.035" y1="6.35" x2="156.845" y2="6.35" width="0.2032" layer="1"/>
+<wire x1="147.32" y1="16.51" x2="140.335" y2="23.495" width="0.2032" layer="1"/>
+<wire x1="140.335" y1="23.495" x2="140.335" y2="25.4" width="0.2032" layer="1"/>
+<wire x1="140.335" y1="25.4" x2="142.356" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="142.356" y1="27.421" x2="142.399" y2="27.421" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$89">
-<contactref element="U$104" pad="4"/>
-<contactref element="R11" pad="P$4"/>
-<contactref element="U5" pad="13"/>
-<wire x1="191.77" y1="6.985" x2="191.77" y2="9.1803125" width="0.2032" layer="16"/>
-<wire x1="205.899" y1="17.261" x2="205.518" y2="17.642" width="0.2032" layer="16"/>
-<wire x1="205.518" y1="17.642" x2="200.2316875" y2="17.642" width="0.2032" layer="16"/>
-<wire x1="191.77" y1="9.1803125" x2="200.2316875" y2="17.642" width="0.2032" layer="16"/>
-<wire x1="215.9" y1="10.16" x2="212.725" y2="13.335" width="0.2032" layer="16"/>
-<wire x1="207.285" y1="13.335" x2="205.899" y2="14.721" width="0.2032" layer="16"/>
-<wire x1="205.899" y1="14.721" x2="205.899" y2="17.261" width="0.2032" layer="16"/>
-<wire x1="212.725" y1="13.335" x2="207.285" y2="13.335" width="0.2032" layer="16"/>
+<signal name="SNS06I">
+<contactref element="U06I" pad="4"/>
+<contactref element="R11" pad="P$5"/>
+<contactref element="U5" pad="6"/>
+<wire x1="223.52" y1="2.54" x2="217.17" y2="8.89" width="0.2032" layer="1"/>
+<wire x1="215.265" y1="8.89" x2="214.63" y2="9.525" width="0.2032" layer="1"/>
+<wire x1="214.63" y1="9.525" x2="214.63" y2="11.43" width="0.2032" layer="1"/>
+<wire x1="214.63" y1="11.43" x2="213.36" y2="12.7" width="0.2032" layer="1"/>
+<wire x1="213.36" y1="12.7" x2="213.36" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="217.17" y1="8.89" x2="215.265" y2="8.89" width="0.2032" layer="1"/>
+<wire x1="205.899" y1="23.103" x2="206.767" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="213.36" y1="16.51" x2="206.767" y2="23.103" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$91">
-<contactref element="U$100" pad="4"/>
+<signal name="SNS08O">
+<contactref element="U08O" pad="4"/>
 <contactref element="R11" pad="P$8"/>
-<contactref element="U5" pad="5"/>
-<wire x1="201.93" y1="6.985" x2="203.2" y2="5.715" width="0.2032" layer="1"/>
-<wire x1="203.2" y1="5.715" x2="215.265" y2="5.715" width="0.2032" layer="1"/>
-<wire x1="215.265" y1="5.715" x2="218.44" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="231.299" y1="17.261" x2="231.299" y2="13.494" width="0.2032" layer="16"/>
-<wire x1="231.299" y1="13.494" x2="222.25" y2="4.445" width="0.2032" layer="16"/>
-<wire x1="222.25" y1="4.445" x2="220.345" y2="4.445" width="0.2032" layer="16"/>
-<wire x1="220.345" y1="4.445" x2="218.44" y2="2.54" width="0.2032" layer="16"/>
-</signal>
-<signal name="N$93">
-<contactref element="U$102" pad="4"/>
-<contactref element="R11" pad="P$6"/>
-<contactref element="U5" pad="3"/>
-<wire x1="196.85" y1="6.985" x2="199.39" y2="4.445" width="0.2032" layer="1"/>
-<wire x1="199.39" y1="4.445" x2="211.455" y2="4.445" width="0.2032" layer="1"/>
-<wire x1="211.455" y1="4.445" x2="213.36" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="218.599" y1="17.261" x2="217.17" y2="15.832" width="0.2032" layer="16"/>
-<wire x1="217.17" y1="6.35" x2="213.36" y2="2.54" width="0.2032" layer="16"/>
-<wire x1="217.17" y1="15.832" x2="217.17" y2="6.35" width="0.2032" layer="16"/>
-</signal>
-<signal name="N$97">
-<contactref element="U$106" pad="4"/>
-<contactref element="R11" pad="P$2"/>
-<contactref element="U5" pad="11"/>
-<wire x1="186.69" y1="6.985" x2="186.69" y2="10.752" width="0.2032" layer="16"/>
-<wire x1="186.69" y1="10.752" x2="193.199" y2="17.261" width="0.2032" layer="16"/>
-<wire x1="220.98" y1="10.16" x2="220.98" y2="11.43" width="0.2032" layer="1"/>
-<wire x1="220.98" y1="11.43" x2="215.9" y2="16.51" width="0.2032" layer="1"/>
-<wire x1="212.09" y1="16.51" x2="211.455" y2="15.875" width="0.2032" layer="1"/>
-<wire x1="211.455" y1="15.875" x2="203.835" y2="15.875" width="0.2032" layer="1"/>
-<wire x1="203.835" y1="15.875" x2="203.2" y2="16.51" width="0.2032" layer="1"/>
-<wire x1="203.2" y1="16.51" x2="199.39" y2="16.51" width="0.2032" layer="1"/>
-<wire x1="199.39" y1="16.51" x2="198.755" y2="15.875" width="0.2032" layer="1"/>
-<wire x1="198.755" y1="15.875" x2="196.215" y2="15.875" width="0.2032" layer="1"/>
-<wire x1="194.829" y1="17.261" x2="193.199" y2="17.261" width="0.2032" layer="1"/>
-<wire x1="215.9" y1="16.51" x2="212.09" y2="16.51" width="0.2032" layer="1"/>
-<wire x1="196.215" y1="15.875" x2="194.829" y2="17.261" width="0.2032" layer="1"/>
+<contactref element="U5" pad="12"/>
+<wire x1="220.98" y1="10.16" x2="220.98" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="220.98" y1="16.51" x2="220.98" y2="18.415" width="0.2032" layer="1"/>
+<wire x1="229.986" y1="27.421" x2="231.299" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="220.98" y1="18.415" x2="229.986" y2="27.421" width="0.2032" layer="1"/>
 </signal>
 <signal name="13_CATHODE">
-<contactref element="U$91" pad="2"/>
+<contactref element="U13O" pad="2"/>
 <contactref element="U$35" pad="P$5"/>
-<wire x1="307.34" y1="25.4" x2="312.42" y2="30.48" width="0.2032" layer="16"/>
-<via x="300.99" y="25.4" extent="1-16" drill="0.3302"/>
-<wire x1="298.799" y1="23.2266" x2="300.9724" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="300.9724" y1="25.4" x2="300.99" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="300.99" y1="25.4" x2="307.34" y2="25.4" width="0.2032" layer="16"/>
+<via x="325.882" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="325.755" y1="17.145" x2="325.882" y2="17.018" width="0.6096" layer="16"/>
+<wire x1="325.882" y1="17.018" x2="325.882" y2="14.986" width="0.6096" layer="16"/>
+<wire x1="323.85" y1="19.05" x2="302.895" y2="19.05" width="0.2032" layer="16"/>
+<wire x1="302.895" y1="19.05" x2="300.99" y2="20.955" width="0.2032" layer="16"/>
+<wire x1="300.99" y1="20.955" x2="300.99" y2="23.495" width="0.2032" layer="16"/>
+<wire x1="325.755" y1="17.145" x2="323.85" y2="19.05" width="0.2032" layer="16"/>
+<via x="300.99" y="23.495" extent="1-16" drill="0.35"/>
+<wire x1="300.99" y1="23.495" x2="300.99" y2="27.305" width="0.2032" layer="1"/>
+<wire x1="300.99" y1="27.305" x2="299.074" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="299.074" y1="29.221" x2="298.799" y2="29.221" width="0.2032" layer="1"/>
 </signal>
 <signal name="14_CATHODE">
-<contactref element="U$89" pad="2"/>
+<contactref element="U14O" pad="2"/>
 <contactref element="U$35" pad="P$4"/>
-<wire x1="314.96" y1="28.8466" x2="314.96" y2="30.48" width="0.2032" layer="16"/>
-<via x="311.531" y="25.4" extent="1-16" drill="0.3302"/>
-<wire x1="311.499" y1="23.2266" x2="311.499" y2="25.368" width="0.3048" layer="16"/>
-<wire x1="311.499" y1="25.368" x2="311.531" y2="25.4" width="0.3048" layer="16"/>
-<wire x1="311.531" y1="25.4" x2="312.039" y2="25.4" width="0.3048" layer="16"/>
-<wire x1="314.325" y1="28.2116" x2="314.96" y2="28.8466" width="0.3048" layer="16"/>
-<wire x1="312.039" y1="25.4" x2="314.325" y2="27.686" width="0.3048" layer="16"/>
-<wire x1="314.325" y1="27.686" x2="314.325" y2="28.2116" width="0.3048" layer="16"/>
+<via x="328.422" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="328.422" y1="14.986" x2="328.295" y2="15.113" width="0.6096" layer="16"/>
+<wire x1="328.295" y1="15.113" x2="328.295" y2="17.145" width="0.6096" layer="16"/>
+<wire x1="328.295" y1="17.145" x2="325.755" y2="19.685" width="0.2032" layer="16"/>
+<wire x1="325.755" y1="19.685" x2="314.96" y2="19.685" width="0.2032" layer="16"/>
+<wire x1="314.96" y1="19.685" x2="313.69" y2="20.955" width="0.2032" layer="16"/>
+<wire x1="313.69" y1="20.955" x2="313.69" y2="23.495" width="0.2032" layer="16"/>
+<via x="313.69" y="23.495" extent="1-16" drill="0.35"/>
+<wire x1="313.69" y1="23.495" x2="313.69" y2="27.305" width="0.2032" layer="1"/>
+<wire x1="313.69" y1="27.305" x2="311.774" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="311.774" y1="29.221" x2="311.499" y2="29.221" width="0.2032" layer="1"/>
 </signal>
 <signal name="15_CATHODE">
-<contactref element="U$87" pad="2"/>
+<contactref element="U15O" pad="2"/>
 <contactref element="U$35" pad="P$3"/>
-<via x="322.072" y="25.4" extent="1-16" drill="0.3302"/>
-<wire x1="324.199" y1="23.2266" x2="324.199" y2="23.273" width="0.2032" layer="16"/>
-<wire x1="324.199" y1="23.273" x2="322.072" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="322.072" y1="25.4" x2="321.31" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="321.31" y1="25.4" x2="317.5" y2="29.21" width="0.2032" layer="16"/>
-<wire x1="317.5" y1="29.21" x2="317.5" y2="30.48" width="0.2032" layer="16"/>
+<via x="330.962" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="330.835" y1="17.145" x2="330.962" y2="17.018" width="0.6096" layer="16"/>
+<wire x1="330.962" y1="17.018" x2="330.962" y2="14.986" width="0.6096" layer="16"/>
+<wire x1="330.835" y1="23.4072" x2="330.2" y2="24.0422" width="0.2032" layer="16"/>
+<via x="330.2" y="24.0422" extent="1-16" drill="0.35"/>
+<wire x1="330.2" y1="24.0422" x2="325.0212" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="325.0212" y1="29.221" x2="324.199" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="330.835" y1="17.145" x2="330.835" y2="23.4072" width="0.2032" layer="16"/>
 </signal>
 <signal name="16_CATHODE">
-<contactref element="U$85" pad="2"/>
+<contactref element="U16O" pad="2"/>
 <contactref element="U$35" pad="P$2"/>
-<wire x1="336.899" y1="23.2266" x2="334.7256" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="325.12" y1="25.4" x2="320.04" y2="30.48" width="0.2032" layer="16"/>
-<wire x1="334.7256" y1="25.4" x2="326.136" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="326.136" y1="25.4" x2="325.12" y2="25.4" width="0.2032" layer="16"/>
-<via x="326.136" y="25.4" extent="1-16" drill="0.3302"/>
+<via x="333.502" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="333.502" y1="14.986" x2="333.502" y2="17.018" width="0.6096" layer="16"/>
+<wire x1="333.502" y1="17.018" x2="333.375" y2="17.145" width="0.6096" layer="16"/>
+<wire x1="333.375" y1="17.145" x2="335.915" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="335.915" y1="19.685" x2="337.185" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="337.809" y1="29.221" x2="336.899" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="337.185" y1="19.685" x2="339.09" y2="21.59" width="0.2032" layer="1"/>
+<wire x1="339.09" y1="21.59" x2="339.09" y2="27.94" width="0.2032" layer="1"/>
+<wire x1="339.09" y1="27.94" x2="337.809" y2="29.221" width="0.2032" layer="1"/>
 </signal>
 <signal name="17_CATHODE">
-<contactref element="U$83" pad="2"/>
+<contactref element="U17O" pad="2"/>
 <contactref element="U$34" pad="P$9"/>
-<wire x1="353.695" y1="31.115" x2="396.24" y2="31.115" width="0.2032" layer="16"/>
-<wire x1="396.24" y1="31.115" x2="398.145" y2="29.21" width="0.2032" layer="16"/>
-<wire x1="398.145" y1="29.21" x2="401.955" y2="29.21" width="0.2032" layer="16"/>
-<wire x1="401.955" y1="29.21" x2="403.225" y2="30.48" width="0.2032" layer="16"/>
-<wire x1="351.155" y1="26.8970125" x2="351.155" y2="28.575" width="0.2032" layer="16"/>
-<wire x1="351.155" y1="28.575" x2="353.695" y2="31.115" width="0.2032" layer="16"/>
-<via x="349.631" y="25.4" extent="1-16" drill="0.3302"/>
-<wire x1="349.599" y1="23.2266" x2="349.599" y2="25.368" width="0.2032" layer="16"/>
-<wire x1="349.599" y1="25.368" x2="349.631" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="351.1280125" y1="26.8970125" x2="351.155" y2="26.8970125" width="0.2032" layer="16"/>
-<wire x1="349.631" y1="25.4" x2="349.8723" y2="25.6413" width="0.2032" layer="16"/>
-<wire x1="349.8723" y1="25.6413" x2="349.8992875" y2="25.6413" width="0.2032" layer="16"/>
-<wire x1="349.8992875" y1="25.6413" x2="350.2787" y2="26.0207125" width="0.2032" layer="16"/>
-<wire x1="350.2787" y1="26.0207125" x2="350.2787" y2="26.0477" width="0.2032" layer="16"/>
-<wire x1="350.2787" y1="26.0477" x2="351.1280125" y2="26.8970125" width="0.2032" layer="16"/>
+<via x="368.808" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="368.808" y1="17.78" x2="368.808" y2="14.986" width="0.6096" layer="16"/>
+<wire x1="368.808" y1="17.78" x2="366.903" y2="19.685" width="0.2032" layer="16"/>
+<wire x1="366.903" y1="19.685" x2="353.06" y2="19.685" width="0.2032" layer="16"/>
+<via x="353.06" y="19.685" extent="1-16" drill="0.35"/>
+<wire x1="353.06" y1="19.685" x2="351.79" y2="20.955" width="0.2032" layer="1"/>
+<wire x1="351.79" y1="20.955" x2="351.79" y2="27.94" width="0.2032" layer="1"/>
+<wire x1="351.79" y1="27.94" x2="350.509" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="350.509" y1="29.221" x2="349.599" y2="29.221" width="0.2032" layer="1"/>
 </signal>
 <signal name="18_CATHODE">
-<contactref element="U$81" pad="2"/>
+<contactref element="U18O" pad="2"/>
 <contactref element="U$34" pad="P$8"/>
-<wire x1="405.765" y1="30.48" x2="404.495" y2="29.21" width="0.2032" layer="16"/>
-<wire x1="404.495" y1="29.21" x2="403.225" y2="29.21" width="0.2032" layer="16"/>
-<wire x1="403.225" y1="29.21" x2="402.59" y2="28.575" width="0.2032" layer="16"/>
-<wire x1="402.59" y1="28.575" x2="396.24" y2="28.575" width="0.2032" layer="16"/>
-<wire x1="396.24" y1="28.575" x2="394.97" y2="29.845" width="0.2032" layer="16"/>
-<wire x1="365.125" y1="29.845" x2="394.97" y2="29.845" width="0.2032" layer="16"/>
-<via x="362.331" y="25.4" extent="1-16" drill="0.3302"/>
-<wire x1="362.299" y1="23.2266" x2="362.331" y2="23.2586" width="0.2032" layer="16"/>
-<wire x1="362.331" y1="23.2586" x2="362.331" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="362.331" y1="25.4" x2="362.5723" y2="25.6413" width="0.2032" layer="16"/>
-<wire x1="362.5723" y1="25.6413" x2="362.5992875" y2="25.6413" width="0.2032" layer="16"/>
-<wire x1="362.5992875" y1="25.6413" x2="363.855" y2="26.8970125" width="0.2032" layer="16"/>
-<wire x1="363.855" y1="28.575" x2="365.125" y2="29.845" width="0.2032" layer="16"/>
-<wire x1="363.855" y1="26.8970125" x2="363.855" y2="28.575" width="0.2032" layer="16"/>
+<via x="371.348" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="371.348" y1="17.78" x2="371.348" y2="14.986" width="0.6096" layer="16"/>
+<wire x1="371.348" y1="17.78" x2="371.348" y2="20.447" width="0.2032" layer="16"/>
+<wire x1="371.348" y1="20.447" x2="368.3" y2="23.495" width="0.2032" layer="16"/>
+<wire x1="365.6722" y1="23.495" x2="365.125" y2="24.0422" width="0.2032" layer="16"/>
+<via x="365.125" y="24.0422" extent="1-16" drill="0.35"/>
+<wire x1="365.125" y1="24.0422" x2="364.49" y2="24.6772" width="0.2032" layer="1"/>
+<wire x1="364.49" y1="24.6772" x2="364.49" y2="27.305" width="0.2032" layer="1"/>
+<wire x1="364.49" y1="27.305" x2="362.574" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="362.574" y1="29.221" x2="362.299" y2="29.221" width="0.2032" layer="1"/>
+<wire x1="368.3" y1="23.495" x2="365.6722" y2="23.495" width="0.2032" layer="16"/>
 </signal>
 <signal name="19_CATHODE">
-<contactref element="U$79" pad="2"/>
+<contactref element="U19O" pad="2"/>
 <contactref element="U$34" pad="P$7"/>
-<wire x1="405.638" y1="26.543" x2="408.305" y2="29.21" width="0.2032" layer="16"/>
-<wire x1="408.305" y1="29.21" x2="408.305" y2="30.48" width="0.2032" layer="16"/>
-<wire x1="379.73" y1="25.4" x2="383.54" y2="29.21" width="0.2032" layer="16"/>
-<wire x1="383.54" y1="29.21" x2="393.7" y2="29.21" width="0.2032" layer="16"/>
-<wire x1="393.7" y1="29.21" x2="394.97" y2="27.94" width="0.2032" layer="16"/>
-<wire x1="394.97" y1="27.94" x2="400.05" y2="27.94" width="0.2032" layer="16"/>
-<wire x1="400.05" y1="27.94" x2="401.447" y2="26.543" width="0.2032" layer="16"/>
-<wire x1="401.447" y1="26.543" x2="405.638" y2="26.543" width="0.2032" layer="16"/>
-<via x="377.317" y="25.4" extent="1-16" drill="0.3302"/>
-<wire x1="374.999" y1="23.2266" x2="377.1724" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="377.1724" y1="25.4" x2="377.317" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="377.317" y1="25.4" x2="379.73" y2="25.4" width="0.2032" layer="16"/>
+<via x="373.888" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="373.888" y1="14.986" x2="373.888" y2="17.78" width="0.6096" layer="16"/>
+<wire x1="373.888" y1="17.78" x2="373.888" y2="20.193" width="0.2032" layer="16"/>
+<wire x1="373.888" y1="20.193" x2="377.19" y2="23.495" width="0.2032" layer="16"/>
+<via x="377.19" y="23.495" extent="1-16" drill="0.35"/>
+<wire x1="377.19" y1="23.495" x2="377.19" y2="27.03" width="0.2032" layer="1"/>
+<wire x1="377.19" y1="27.03" x2="374.999" y2="29.221" width="0.2032" layer="1"/>
 </signal>
 <signal name="20_CATHODE">
-<contactref element="U$77" pad="2"/>
+<contactref element="U20O" pad="2"/>
 <contactref element="U$34" pad="P$6"/>
-<wire x1="410.845" y1="30.48" x2="410.845" y2="29.845" width="0.2032" layer="16"/>
-<wire x1="410.845" y1="29.845" x2="406.4" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="389.4152" y1="25.4" x2="387.699" y2="23.6838" width="0.2032" layer="16"/>
-<wire x1="406.4" y1="25.4" x2="389.636" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="389.636" y1="25.4" x2="389.4152" y2="25.4" width="0.2032" layer="16"/>
-<via x="389.636" y="25.4" extent="1-16" drill="0.3302"/>
+<via x="376.428" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="376.428" y1="17.78" x2="376.428" y2="14.986" width="0.6096" layer="16"/>
+<wire x1="376.428" y1="17.78" x2="378.333" y2="19.685" width="0.2032" layer="16"/>
+<wire x1="378.333" y1="19.685" x2="379.73" y2="19.685" width="0.2032" layer="16"/>
+<wire x1="379.73" y1="19.685" x2="381.635" y2="21.59" width="0.2032" layer="16"/>
+<wire x1="381.635" y1="21.59" x2="387.985" y2="21.59" width="0.2032" layer="16"/>
+<wire x1="387.985" y1="21.59" x2="389.89" y2="23.495" width="0.2032" layer="16"/>
+<via x="389.89" y="23.495" extent="1-16" drill="0.35"/>
+<wire x1="389.89" y1="23.495" x2="389.89" y2="27.03" width="0.2032" layer="1"/>
+<wire x1="389.89" y1="27.03" x2="387.699" y2="29.221" width="0.2032" layer="1"/>
 </signal>
 <signal name="21_CATHODE">
-<contactref element="U$75" pad="2"/>
+<contactref element="U21O" pad="2"/>
 <contactref element="U$34" pad="P$5"/>
-<wire x1="400.399" y1="23.2266" x2="401.9374" y2="24.765" width="0.2032" layer="16"/>
-<wire x1="407.67" y1="24.765" x2="408.305" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="408.305" y1="25.4" x2="409.067" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="413.385" y1="29.718" x2="409.067" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="413.385" y1="29.718" x2="413.385" y2="30.48" width="0.2032" layer="16"/>
-<wire x1="401.9374" y1="24.765" x2="407.67" y2="24.765" width="0.2032" layer="16"/>
-<via x="408.305" y="25.4" extent="1-16" drill="0.3302"/>
+<via x="378.968" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="378.968" y1="14.986" x2="378.968" y2="17.78" width="0.6096" layer="16"/>
+<wire x1="378.968" y1="17.78" x2="382.1684" y2="20.9804" width="0.2032" layer="16"/>
+<wire x1="388.7056625" y1="20.9804" x2="390.9916625" y2="23.2664" width="0.2032" layer="16"/>
+<wire x1="392.6586" y1="23.2664" x2="394.9446" y2="20.9804" width="0.2032" layer="16"/>
+<wire x1="400.7104" y1="20.9804" x2="402.59" y2="22.86" width="0.2032" layer="16"/>
+<wire x1="382.1684" y1="20.9804" x2="388.7056625" y2="20.9804" width="0.2032" layer="16"/>
+<wire x1="390.9916625" y1="23.2664" x2="392.6586" y2="23.2664" width="0.2032" layer="16"/>
+<wire x1="394.9446" y1="20.9804" x2="400.7104" y2="20.9804" width="0.2032" layer="16"/>
+<via x="402.59" y="22.86" extent="1-16" drill="0.35"/>
+<wire x1="402.59" y1="22.86" x2="402.59" y2="27.03" width="0.2032" layer="1"/>
+<wire x1="402.59" y1="27.03" x2="400.399" y2="29.221" width="0.2032" layer="1"/>
 </signal>
 <signal name="22_CATHODE">
-<contactref element="U$73" pad="2"/>
+<contactref element="U22O" pad="2"/>
 <contactref element="U$34" pad="P$4"/>
-<wire x1="415.925" y1="30.48" x2="414.655" y2="29.21" width="0.2032" layer="16"/>
-<via x="413.131" y="25.4" extent="1-16" drill="0.3302"/>
-<wire x1="413.099" y1="23.2266" x2="413.099" y2="25.368" width="0.2032" layer="16"/>
-<wire x1="413.099" y1="25.368" x2="413.131" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="413.131" y1="25.4" x2="414.02" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="414.02" y1="25.4" x2="414.655" y2="26.035" width="0.2032" layer="16"/>
-<wire x1="414.655" y1="26.035" x2="414.655" y2="29.21" width="0.2032" layer="16"/>
+<via x="381.508" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="381.508" y1="17.78" x2="381.508" y2="14.986" width="0.6096" layer="16"/>
+<wire x1="381.508" y1="17.78" x2="384.302" y2="20.574" width="0.2032" layer="16"/>
+<wire x1="388.874" y1="20.574" x2="391.16" y2="22.86" width="0.2032" layer="16"/>
+<wire x1="391.16" y1="22.86" x2="392.43" y2="22.86" width="0.2032" layer="16"/>
+<wire x1="392.43" y1="22.86" x2="394.716" y2="20.574" width="0.2032" layer="16"/>
+<wire x1="394.716" y1="20.574" x2="401.574" y2="20.574" width="0.2032" layer="16"/>
+<wire x1="403.5806" y1="22.5806" x2="406.0444" y2="22.5806" width="0.2032" layer="16"/>
+<wire x1="406.0444" y1="22.5806" x2="408.1272" y2="20.4978" width="0.2032" layer="16"/>
+<wire x1="414.1978" y1="20.4978" x2="415.29" y2="21.59" width="0.2032" layer="16"/>
+<wire x1="415.29" y1="21.59" x2="415.29" y2="23.495" width="0.2032" layer="16"/>
+<wire x1="384.302" y1="20.574" x2="388.874" y2="20.574" width="0.2032" layer="16"/>
+<wire x1="401.574" y1="20.574" x2="403.5806" y2="22.5806" width="0.2032" layer="16"/>
+<wire x1="408.1272" y1="20.4978" x2="414.1978" y2="20.4978" width="0.2032" layer="16"/>
+<via x="415.29" y="23.495" extent="1-16" drill="0.35"/>
+<wire x1="415.29" y1="23.495" x2="415.29" y2="27.03" width="0.2032" layer="1"/>
+<wire x1="415.29" y1="27.03" x2="413.099" y2="29.221" width="0.2032" layer="1"/>
 </signal>
 <signal name="23_CATHODE">
-<contactref element="U$71" pad="2"/>
+<contactref element="U23O" pad="2"/>
 <contactref element="U$34" pad="P$3"/>
-<wire x1="420.765396875" y1="24.4966" x2="424.529" y2="24.4966" width="0.2032" layer="16"/>
-<wire x1="424.529" y1="24.4966" x2="425.799" y2="23.2266" width="0.2032" layer="16"/>
-<wire x1="418.465" y1="30.48" x2="418.973" y2="29.972" width="0.2032" layer="16"/>
-<wire x1="418.973" y1="29.972" x2="418.973" y2="26.035" width="0.2032" layer="16"/>
-<via x="419.862" y="25.4" extent="1-16" drill="0.3302"/>
-<wire x1="419.608" y1="25.4" x2="418.973" y2="26.035" width="0.2032" layer="16"/>
-<wire x1="419.608" y1="25.4" x2="419.862" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="419.862" y1="25.4" x2="420.765396875" y2="24.496603125" width="0.2032" layer="16"/>
-<wire x1="420.765396875" y1="24.496603125" x2="420.765396875" y2="24.4966" width="0.2032" layer="16"/>
+<via x="384.048" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="384.048" y1="14.986" x2="384.048" y2="17.78" width="0.6096" layer="16"/>
+<wire x1="384.048" y1="17.78" x2="386.3594" y2="20.0914" width="0.2032" layer="16"/>
+<wire x1="425.2214" y1="20.0914" x2="427.99" y2="22.86" width="0.2032" layer="16"/>
+<wire x1="427.99" y1="22.86" x2="427.99" y2="23.495" width="0.2032" layer="16"/>
+<wire x1="386.3594" y1="20.0914" x2="425.2214" y2="20.0914" width="0.2032" layer="16"/>
+<via x="427.99" y="23.495" extent="1-16" drill="0.35"/>
+<wire x1="427.99" y1="23.495" x2="427.99" y2="27.03" width="0.2032" layer="1"/>
+<wire x1="427.99" y1="27.03" x2="425.799" y2="29.221" width="0.2032" layer="1"/>
 </signal>
 <signal name="24_CATHODE">
-<contactref element="U$69" pad="2"/>
+<contactref element="U24O" pad="2"/>
 <contactref element="U$34" pad="P$2"/>
-<wire x1="438.499" y1="23.2266" x2="438.499" y2="23.6076" width="0.2032" layer="1"/>
-<wire x1="438.499" y1="23.6076" x2="436.965703125" y2="25.146" width="0.2032" layer="1"/>
-<wire x1="422.783" y1="25.4" x2="423.037" y2="25.146" width="0.2032" layer="1"/>
-<wire x1="436.965703125" y1="25.146" x2="423.037" y2="25.146" width="0.2032" layer="1"/>
-<wire x1="421.513" y1="29.972" x2="421.513" y2="26.162" width="0.2032" layer="16"/>
-<wire x1="422.783" y1="25.4" x2="422.275" y2="25.4" width="0.2032" layer="16"/>
-<wire x1="422.275" y1="25.4" x2="421.513" y2="26.162" width="0.2032" layer="16"/>
-<wire x1="421.513" y1="29.972" x2="421.005" y2="30.48" width="0.2032" layer="16"/>
-<via x="422.783" y="25.4" extent="1-16" drill="0.3302"/>
+<via x="386.588" y="14.986" extent="1-16" drill="0.35"/>
+<wire x1="386.588" y1="17.78" x2="386.588" y2="14.986" width="0.6096" layer="16"/>
+<wire x1="386.588" y1="17.78" x2="388.493" y2="19.685" width="0.2032" layer="16"/>
+<wire x1="438.15" y1="19.685" x2="440.69" y2="22.225" width="0.2032" layer="16"/>
+<wire x1="440.69" y1="22.225" x2="440.69" y2="27.94" width="0.2032" layer="16"/>
+<wire x1="440.69" y1="27.94" x2="439.409" y2="29.221" width="0.2032" layer="16"/>
+<wire x1="439.409" y1="29.221" x2="438.499" y2="29.221" width="0.2032" layer="16"/>
+<wire x1="388.493" y1="19.685" x2="438.15" y2="19.685" width="0.2032" layer="16"/>
 </signal>
-<signal name="N$12">
-<contactref element="U$77" pad="4"/>
+<signal name="SNS20I">
 <contactref element="R5" pad="P$9"/>
-<contactref element="U2" pad="6"/>
-<wire x1="363.22" y1="6.35" x2="364.49" y2="5.08" width="0.2032" layer="16"/>
-<wire x1="377.825" y1="5.08" x2="380.365" y2="2.54" width="0.2032" layer="16"/>
-<wire x1="364.49" y1="5.08" x2="377.825" y2="5.08" width="0.2032" layer="16"/>
-<wire x1="383.699" y1="21.8838" x2="385.445" y2="20.1378" width="0.2032" layer="16"/>
-<wire x1="385.445" y1="20.1378" x2="385.445" y2="17.145" width="0.2032" layer="16"/>
-<wire x1="385.445" y1="17.145" x2="381.635" y2="13.335" width="0.2032" layer="16"/>
-<wire x1="371.475" y1="11.43" x2="371.475" y2="8.255" width="0.2032" layer="16"/>
-<wire x1="371.475" y1="8.255" x2="370.84" y2="7.62" width="0.2032" layer="16"/>
-<wire x1="364.49" y1="7.62" x2="363.22" y2="6.35" width="0.2032" layer="16"/>
-<wire x1="381.635" y1="13.335" x2="373.38" y2="13.335" width="0.2032" layer="16"/>
-<wire x1="373.38" y1="13.335" x2="371.475" y2="11.43" width="0.2032" layer="16"/>
-<wire x1="370.84" y1="7.62" x2="364.49" y2="7.62" width="0.2032" layer="16"/>
+<contactref element="U2" pad="11"/>
+<wire x1="361.95" y1="10.16" x2="361.95" y2="14.605" width="0.2032" layer="1"/>
+<wire x1="361.95" y1="14.605" x2="363.855" y2="16.51" width="0.2032" layer="1"/>
+<contactref element="U20I" pad="4"/>
+<wire x1="363.855" y1="16.51" x2="363.855" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="380.281" y1="19.685" x2="383.699" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="363.855" y1="17.78" x2="365.76" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="365.76" y1="19.685" x2="380.281" y2="19.685" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$74">
-<contactref element="U$107" pad="4"/>
-<contactref element="R11" pad="P$3"/>
-<contactref element="U5" pad="12"/>
-<wire x1="189.23" y1="6.985" x2="189.23" y2="9.525" width="0.2032" layer="16"/>
-<wire x1="189.23" y1="9.525" x2="194.945" y2="15.24" width="0.2032" layer="16"/>
-<wire x1="194.945" y1="15.24" x2="194.945" y2="19.6806" width="0.2032" layer="16"/>
-<wire x1="194.945" y1="19.6806" x2="193.199" y2="21.4266" width="0.2032" layer="16"/>
-<wire x1="218.44" y1="10.16" x2="217.17" y2="8.89" width="0.2032" layer="1"/>
-<wire x1="212.725" y1="8.89" x2="212.09" y2="9.525" width="0.2032" layer="1"/>
-<wire x1="212.09" y1="9.525" x2="212.09" y2="10.795" width="0.2032" layer="1"/>
-<wire x1="212.09" y1="10.795" x2="211.455" y2="11.43" width="0.2032" layer="1"/>
-<wire x1="204.47" y1="11.43" x2="202.565" y2="13.335" width="0.2032" layer="1"/>
-<wire x1="196.85" y1="13.335" x2="194.945" y2="15.24" width="0.2032" layer="1"/>
-<via x="194.945" y="15.24" extent="1-16" drill="0.3302"/>
-<wire x1="217.17" y1="8.89" x2="212.725" y2="8.89" width="0.2032" layer="1"/>
-<wire x1="211.455" y1="11.43" x2="204.47" y2="11.43" width="0.2032" layer="1"/>
-<wire x1="202.565" y1="13.335" x2="196.85" y2="13.335" width="0.2032" layer="1"/>
+<signal name="SNS24I">
+<contactref element="R2" pad="P$9"/>
+<contactref element="U1" pad="11"/>
+<contactref element="U24I" pad="4"/>
+<wire x1="407.797" y1="16.51" x2="403.606" y2="12.319" width="0.2032" layer="1"/>
+<wire x1="403.606" y1="12.319" x2="401.574" y2="12.319" width="0.2032" layer="1"/>
+<wire x1="399.415" y1="10.16" x2="401.574" y2="12.319" width="0.2032" layer="1"/>
+<wire x1="410.845" y1="16.51" x2="412.75" y2="18.415" width="0.2032" layer="1"/>
+<wire x1="407.797" y1="16.51" x2="410.845" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="412.75" y1="18.415" x2="429.811" y2="18.415" width="0.2032" layer="1"/>
+<wire x1="429.811" y1="18.415" x2="434.499" y2="23.103" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$39">
-<contactref element="U$69" pad="4"/>
-<contactref element="R2" pad="P$4"/>
-<contactref element="U1" pad="6"/>
-<wire x1="434.499" y1="21.4266" x2="436.2406" y2="19.685" width="0.2032" layer="16"/>
-<wire x1="436.2406" y1="19.685" x2="436.245" y2="19.685" width="0.2032" layer="16"/>
-<wire x1="436.245" y1="6.35" x2="432.435" y2="2.54" width="0.2032" layer="16"/>
-<wire x1="436.245" y1="19.685" x2="436.245" y2="6.35" width="0.2032" layer="16"/>
-<wire x1="403.225" y1="6.35" x2="403.225" y2="4.445" width="0.2032" layer="16"/>
-<wire x1="403.225" y1="4.445" x2="408.305" y2="-0.635" width="0.2032" layer="16"/>
-<via x="408.305" y="-0.635" extent="1-16" drill="0.3302"/>
-<wire x1="408.305" y1="-0.635" x2="408.94" y2="-1.27" width="0.2032" layer="1"/>
-<wire x1="408.94" y1="-1.27" x2="428.625" y2="-1.27" width="0.2032" layer="1"/>
-<wire x1="428.625" y1="-1.27" x2="432.435" y2="2.54" width="0.2032" layer="1"/>
-</signal>
-<signal name="N$21">
+<signal name="PWR_13-24">
 <contactref element="U$34" pad="P$1"/>
 <contactref element="Q6" pad="2"/>
 <contactref element="U$35" pad="P$1"/>
-<wire x1="132.08" y1="23.495" x2="139.954" y2="23.495" width="0.6096" layer="16"/>
-<wire x1="139.954" y1="23.495" x2="140.97" y2="24.511" width="0.6096" layer="16"/>
-<wire x1="292.227" y1="26.289" x2="290.449" y2="24.511" width="0.6096" layer="1"/>
-<wire x1="290.449" y1="24.511" x2="140.97" y2="24.511" width="0.6096" layer="16"/>
-<wire x1="292.227" y1="26.289" x2="300.99" y2="26.289" width="0.6096" layer="1"/>
-<wire x1="300.99" y1="26.289" x2="311.531" y2="26.289" width="0.6096" layer="1"/>
-<wire x1="311.531" y1="26.289" x2="322.58" y2="26.289" width="0.6096" layer="1"/>
-<wire x1="322.58" y1="26.289" x2="422.91" y2="26.289" width="0.6096" layer="1"/>
-<via x="290.449" y="24.511" extent="1-16" drill="0.3302"/>
-<wire x1="322.58" y1="30.48" x2="322.58" y2="26.289" width="0.6096" layer="1"/>
-<wire x1="423.545" y1="30.48" x2="423.545" y2="26.924" width="0.6096" layer="1"/>
-<wire x1="423.545" y1="26.924" x2="422.91" y2="26.289" width="0.6096" layer="1"/>
-<via x="300.99" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="311.531" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="322.072" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="326.136" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="349.631" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="362.331" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="377.317" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="389.636" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="408.305" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="413.131" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="419.862" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="422.783" y="26.289" extent="1-16" drill="0.3302"/>
+<wire x1="132.08" y1="23.495" x2="136.525" y2="23.495" width="0.6096" layer="1"/>
+<wire x1="136.525" y1="23.495" x2="141.605" y2="18.415" width="0.6096" layer="1"/>
+<wire x1="141.605" y1="14.605" x2="143.51" y2="12.7" width="0.6096" layer="1"/>
+<via x="143.51" y="12.7" extent="1-16" drill="0.3302"/>
+<wire x1="143.51" y1="12.7" x2="191.135" y2="12.7" width="0.6096" layer="16"/>
+<wire x1="192.151" y1="13.716" x2="191.135" y2="12.7" width="0.6096" layer="16"/>
+<wire x1="141.605" y1="18.415" x2="141.605" y2="14.605" width="0.6096" layer="1"/>
+<wire x1="389.128" y1="17.78" x2="389.128" y2="15.24" width="0.6096" layer="16"/>
+<wire x1="389.128" y1="15.24" x2="387.858" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="387.858" y1="13.97" x2="386.588" y2="13.97" width="0.6096" layer="16"/>
+<via x="368.808" y="13.97" extent="1-16" drill="0.35"/>
+<via x="373.888" y="13.97" extent="1-16" drill="0.35"/>
+<via x="376.428" y="13.97" extent="1-16" drill="0.35"/>
+<via x="378.968" y="13.97" extent="1-16" drill="0.35"/>
+<via x="381.508" y="13.97" extent="1-16" drill="0.35"/>
+<via x="384.048" y="13.97" extent="1-16" drill="0.35"/>
+<via x="386.588" y="13.97" extent="1-16" drill="0.35"/>
+<wire x1="386.588" y1="13.97" x2="384.048" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="381.508" y1="13.97" x2="384.048" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="378.968" y1="13.97" x2="381.508" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="376.428" y1="13.97" x2="378.968" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="373.888" y1="13.97" x2="376.428" y2="13.97" width="0.6096" layer="16"/>
+<via x="371.348" y="13.97" extent="1-16" drill="0.35"/>
+<wire x1="371.348" y1="13.97" x2="373.888" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="368.808" y1="13.97" x2="371.348" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="335.915" y1="17.145" x2="340.487" y2="17.145" width="0.6096" layer="16"/>
+<wire x1="343.662" y1="13.97" x2="340.487" y2="17.145" width="0.6096" layer="16"/>
+<wire x1="368.808" y1="13.97" x2="343.662" y2="13.97" width="0.6096" layer="16"/>
+<via x="325.882" y="13.97" extent="1-16" drill="0.35"/>
+<via x="328.422" y="13.97" extent="1-16" drill="0.35"/>
+<via x="330.962" y="13.97" extent="1-16" drill="0.35"/>
+<via x="333.502" y="13.97" extent="1-16" drill="0.35"/>
+<wire x1="335.915" y1="17.145" x2="334.645" y2="15.875" width="0.6096" layer="16"/>
+<wire x1="334.645" y1="15.875" x2="334.645" y2="14.605" width="0.6096" layer="16"/>
+<wire x1="334.645" y1="14.605" x2="334.01" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="334.01" y1="13.97" x2="333.502" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="333.502" y1="13.97" x2="330.962" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="330.962" y1="13.97" x2="328.422" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="328.422" y1="13.97" x2="325.882" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="276.86" y1="13.97" x2="276.225" y2="13.335" width="0.6096" layer="16"/>
+<wire x1="200.406" y1="13.335" x2="200.025" y2="13.716" width="0.6096" layer="16"/>
+<wire x1="200.025" y1="13.716" x2="192.151" y2="13.716" width="0.6096" layer="16"/>
+<wire x1="325.882" y1="13.97" x2="276.86" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="276.225" y1="13.335" x2="200.406" y2="13.335" width="0.6096" layer="16"/>
 </signal>
 <signal name="MISO">
 <contactref element="U6" pad="9"/>
 <contactref element="MS2" pad="13"/>
 <contactref element="U$45" pad="MISO"/>
-<wire x1="110.49" y1="-1.27" x2="109.22" y2="0" width="0.2032" layer="1"/>
-<wire x1="109.22" y1="0" x2="107.95" y2="0" width="0.2032" layer="1"/>
-<wire x1="107.95" y1="0" x2="106.68" y2="1.27" width="0.2032" layer="1"/>
-<wire x1="106.68" y1="1.27" x2="107.95" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="120.65" y1="2.54" x2="125.095" y2="-1.905" width="0.2032" layer="1"/>
-<wire x1="125.095" y1="-1.905" x2="156.845" y2="-1.905" width="0.2032" layer="1"/>
-<wire x1="156.845" y1="-1.905" x2="158.115" y2="-0.635" width="0.2032" layer="1"/>
-<wire x1="158.115" y1="-0.635" x2="169.545" y2="-0.635" width="0.2032" layer="16"/>
-<wire x1="172.085" y1="8.89" x2="173.355" y2="10.16" width="0.2032" layer="1"/>
-<wire x1="107.95" y1="2.54" x2="120.65" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="169.545" y1="-0.635" x2="172.085" y2="1.905" width="0.2032" layer="16"/>
-<wire x1="172.085" y1="1.905" x2="172.085" y2="8.89" width="0.2032" layer="1"/>
-<via x="158.115" y="-0.635" extent="1-16" drill="0.3302"/>
-<via x="172.085" y="1.905" extent="1-16" drill="0.3302"/>
+<wire x1="106.68" y1="1.27" x2="108.0262" y2="-0.0762" width="0.2032" layer="1"/>
+<wire x1="108.0262" y1="-0.0762" x2="108.44449375" y2="-0.0762" width="0.2032" layer="1"/>
+<wire x1="109.63829375" y1="-1.27" x2="110.49" y2="-1.27" width="0.2032" layer="1"/>
+<wire x1="108.44449375" y1="-0.0762" x2="109.63829375" y2="-1.27" width="0.2032" layer="1"/>
+<wire x1="110.49" y1="-1.27" x2="110.49" y2="-0.635" width="0.2032" layer="16"/>
+<wire x1="110.49" y1="-0.635" x2="111.76" y2="0.635" width="0.2032" layer="16"/>
+<wire x1="120.65" y1="0.635" x2="123.19" y2="-1.905" width="0.2032" layer="16"/>
+<wire x1="123.19" y1="-1.905" x2="173.99" y2="-1.905" width="0.2032" layer="16"/>
+<wire x1="173.99" y1="-1.905" x2="174.625" y2="-1.27" width="0.2032" layer="1"/>
+<wire x1="174.625" y1="-1.27" x2="174.625" y2="8.89" width="0.2032" layer="1"/>
+<wire x1="174.625" y1="8.89" x2="173.355" y2="10.16" width="0.2032" layer="1"/>
+<wire x1="111.76" y1="0.635" x2="120.65" y2="0.635" width="0.2032" layer="16"/>
+<via x="173.99" y="-1.905" extent="1-16" drill="0.3302"/>
 </signal>
 <signal name="SER1">
 <contactref element="U6" pad="10"/>
 <contactref element="U5" pad="9"/>
-<wire x1="170.815" y1="10.16" x2="173.355" y2="12.7" width="0.2032" layer="16"/>
-<wire x1="173.355" y1="12.7" x2="176.53" y2="12.7" width="0.2032" layer="16"/>
-<via x="176.53" y="12.7" extent="1-16" drill="0.3302"/>
-<wire x1="176.53" y1="12.7" x2="201.93" y2="12.7" width="0.2032" layer="1"/>
-<wire x1="201.93" y1="12.7" x2="207.645" y2="6.985" width="0.2032" layer="1"/>
-<wire x1="207.645" y1="6.985" x2="222.885" y2="6.985" width="0.2032" layer="1"/>
-<wire x1="222.885" y1="6.985" x2="226.06" y2="10.16" width="0.2032" layer="16"/>
-<via x="222.885" y="6.985" extent="1-16" drill="0.3302"/>
+<wire x1="226.06" y1="7.62" x2="228.6" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="172.72" y1="7.62" x2="170.815" y2="9.525" width="0.2032" layer="16"/>
+<wire x1="170.815" y1="10.16" x2="170.815" y2="9.525" width="0.2032" layer="16"/>
+<wire x1="226.06" y1="7.62" x2="172.72" y2="7.62" width="0.2032" layer="16"/>
 </signal>
 <signal name="SER2">
 <contactref element="U5" pad="10"/>
 <contactref element="U4" pad="9"/>
-<wire x1="280.035" y1="10.16" x2="278.765" y2="11.43" width="0.2032" layer="1"/>
-<wire x1="223.52" y1="10.16" x2="224.79" y2="11.43" width="0.2032" layer="1"/>
-<wire x1="278.765" y1="11.43" x2="224.79" y2="11.43" width="0.2032" layer="1"/>
-</signal>
-<signal name="SER3">
-<contactref element="U3" pad="10"/>
-<contactref element="U2" pad="9"/>
-<wire x1="330.2" y1="10.16" x2="331.47" y2="8.89" width="0.2032" layer="1"/>
-<wire x1="331.47" y1="8.89" x2="334.01" y2="8.89" width="0.2032" layer="1"/>
-<wire x1="338.455" y1="13.335" x2="342.9" y2="13.335" width="0.2032" layer="1"/>
-<wire x1="342.9" y1="13.335" x2="344.805" y2="15.24" width="0.2032" layer="1"/>
-<wire x1="351.79" y1="15.24" x2="353.06" y2="16.51" width="0.2032" layer="1"/>
-<wire x1="353.06" y1="16.51" x2="356.235" y2="16.51" width="0.2032" layer="1"/>
-<wire x1="356.235" y1="16.51" x2="356.87" y2="15.875" width="0.2032" layer="1"/>
-<wire x1="356.87" y1="15.875" x2="364.49" y2="15.875" width="0.2032" layer="1"/>
-<wire x1="364.49" y1="15.875" x2="365.125" y2="16.51" width="0.2032" layer="1"/>
-<wire x1="365.125" y1="16.51" x2="368.3" y2="16.51" width="0.2032" layer="1"/>
-<wire x1="368.3" y1="16.51" x2="370.205" y2="14.605" width="0.2032" layer="1"/>
-<wire x1="370.205" y1="14.605" x2="377.19" y2="14.605" width="0.2032" layer="1"/>
-<wire x1="377.19" y1="14.605" x2="379.73" y2="12.065" width="0.2032" layer="1"/>
-<wire x1="383.54" y1="12.065" x2="385.445" y2="10.16" width="0.2032" layer="1"/>
-<wire x1="334.01" y1="8.89" x2="338.455" y2="13.335" width="0.2032" layer="1"/>
-<wire x1="344.805" y1="15.24" x2="351.79" y2="15.24" width="0.2032" layer="1"/>
-<wire x1="379.73" y1="12.065" x2="383.54" y2="12.065" width="0.2032" layer="1"/>
+<wire x1="226.06" y1="10.16" x2="227.33" y2="11.43" width="0.2032" layer="16"/>
+<wire x1="243.11510625" y1="11.43" x2="243.16590625" y2="11.4808" width="0.2032" layer="16"/>
+<wire x1="243.16590625" y1="11.4808" x2="266.0142" y2="11.4808" width="0.2032" layer="16"/>
+<wire x1="266.0142" y1="11.4808" x2="267.335" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="227.33" y1="11.43" x2="243.11510625" y2="11.43" width="0.2032" layer="16"/>
 </signal>
 <signal name="SER4">
+<contactref element="U3" pad="10"/>
+<contactref element="U2" pad="9"/>
+<wire x1="310.515" y1="10.16" x2="311.8358" y2="11.4808" width="0.2032" layer="16"/>
+<wire x1="365.7092" y1="11.4808" x2="367.03" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="311.8358" y1="11.4808" x2="365.7092" y2="11.4808" width="0.2032" layer="16"/>
+</signal>
+<signal name="SER5">
 <contactref element="U2" pad="10"/>
 <contactref element="U1" pad="9"/>
-<wire x1="382.905" y1="10.16" x2="384.175" y2="8.89" width="0.2032" layer="1"/>
-<wire x1="384.175" y1="8.89" x2="386.08" y2="8.89" width="0.2032" layer="1"/>
-<wire x1="386.08" y1="8.89" x2="390.525" y2="13.335" width="0.2032" layer="1"/>
-<wire x1="390.525" y1="13.335" x2="434.34" y2="13.335" width="0.2032" layer="1"/>
-<wire x1="434.34" y1="13.335" x2="437.515" y2="10.16" width="0.2032" layer="1"/>
+<wire x1="364.49" y1="10.16" x2="367.03" y2="7.62" width="0.2032" layer="16"/>
+<wire x1="401.955" y1="7.62" x2="404.495" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="367.03" y1="7.62" x2="401.955" y2="7.62" width="0.2032" layer="16"/>
 </signal>
 <signal name="SCK">
 <contactref element="U1" pad="2"/>
@@ -19796,39 +19909,38 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <contactref element="U6" pad="2"/>
 <contactref element="MS2" pad="11"/>
 <contactref element="U$45" pad="SCK"/>
-<wire x1="105.41" y1="-1.27" x2="104.14" y2="0" width="0.2032" layer="1"/>
-<wire x1="104.14" y1="0" x2="102.87" y2="0" width="0.2032" layer="1"/>
-<wire x1="102.87" y1="0" x2="101.6" y2="1.27" width="0.2032" layer="1"/>
-<wire x1="101.6" y1="1.27" x2="103.505" y2="3.175" width="0.2032" layer="1"/>
-<wire x1="125.8316" y1="-1.3716" x2="154.2034" y2="-1.3716" width="0.2032" layer="1"/>
-<wire x1="154.2034" y1="-1.3716" x2="158.115" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="103.505" y1="3.175" x2="121.285" y2="3.175" width="0.2032" layer="1"/>
-<wire x1="121.285" y1="3.175" x2="125.8316" y2="-1.3716" width="0.2032" layer="1"/>
-<wire x1="158.115" y1="2.54" x2="160.02" y2="0.635" width="0.2032" layer="16"/>
-<wire x1="160.02" y1="0.635" x2="164.465" y2="0.635" width="0.2032" layer="16"/>
-<via x="164.465" y="0.635" extent="1-16" drill="0.3302"/>
-<wire x1="164.465" y1="0.635" x2="202.565" y2="0.635" width="0.2032" layer="1"/>
-<wire x1="202.565" y1="0.635" x2="205.74" y2="3.81" width="0.2032" layer="1"/>
-<wire x1="205.74" y1="3.81" x2="209.55" y2="3.81" width="0.2032" layer="1"/>
-<wire x1="209.55" y1="3.81" x2="210.82" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="210.82" y1="2.54" x2="212.725" y2="0.635" width="0.2032" layer="1"/>
-<wire x1="258.445" y1="0.635" x2="261.493" y2="3.683" width="0.2032" layer="1"/>
-<wire x1="261.493" y1="3.683" x2="263.652" y2="3.683" width="0.2032" layer="1"/>
-<wire x1="263.652" y1="3.683" x2="264.795" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="212.725" y1="0.635" x2="258.445" y2="0.635" width="0.2032" layer="1"/>
-<wire x1="264.795" y1="2.54" x2="266.7" y2="0.635" width="0.2032" layer="1"/>
-<wire x1="266.7" y1="0.635" x2="310.515" y2="0.635" width="0.2032" layer="1"/>
-<wire x1="310.515" y1="0.635" x2="313.69" y2="3.81" width="0.2032" layer="1"/>
-<wire x1="313.69" y1="3.81" x2="316.23" y2="3.81" width="0.2032" layer="1"/>
-<wire x1="316.23" y1="3.81" x2="317.5" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="317.5" y1="2.54" x2="319.405" y2="0.635" width="0.2032" layer="1"/>
-<wire x1="319.405" y1="0.635" x2="363.22" y2="0.635" width="0.2032" layer="1"/>
-<wire x1="363.22" y1="0.635" x2="366.395" y2="3.81" width="0.2032" layer="1"/>
-<wire x1="366.395" y1="3.81" x2="368.935" y2="3.81" width="0.2032" layer="1"/>
-<wire x1="368.935" y1="3.81" x2="370.205" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="421.005" y1="3.81" x2="371.475" y2="3.81" width="0.2032" layer="1"/>
-<wire x1="370.205" y1="2.54" x2="371.475" y2="3.81" width="0.2032" layer="1"/>
-<wire x1="421.005" y1="3.81" x2="422.275" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="103.62446875" y1="0.0254" x2="104.1146" y2="0.0254" width="0.2032" layer="1"/>
+<wire x1="104.1146" y1="0.0254" x2="105.41" y2="-1.27" width="0.2032" layer="1"/>
+<wire x1="101.6" y1="1.27" x2="102.37986875" y2="1.27" width="0.2032" layer="1"/>
+<wire x1="102.37986875" y1="1.27" x2="103.62446875" y2="0.0254" width="0.2032" layer="1"/>
+<wire x1="105.41" y1="-1.27" x2="106.68" y2="0" width="0.2032" layer="16"/>
+<wire x1="106.68" y1="0" x2="109.855" y2="0" width="0.2032" layer="16"/>
+<wire x1="109.855" y1="0" x2="111.125" y2="1.27" width="0.2032" layer="16"/>
+<via x="111.125" y="1.27" extent="1-16" drill="0.3302"/>
+<wire x1="121.285" y1="1.27" x2="123.825" y2="-1.27" width="0.2032" layer="1"/>
+<wire x1="123.825" y1="-1.27" x2="154.305" y2="-1.27" width="0.2032" layer="1"/>
+<wire x1="154.305" y1="-1.27" x2="158.115" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="111.125" y1="1.27" x2="121.285" y2="1.27" width="0.2032" layer="1"/>
+<wire x1="158.115" y1="2.54" x2="160.655" y2="0" width="0.2032" layer="16"/>
+<wire x1="205.74" y1="0" x2="210.185" y2="4.445" width="0.2032" layer="16"/>
+<wire x1="210.185" y1="4.445" x2="211.455" y2="4.445" width="0.2032" layer="16"/>
+<wire x1="211.455" y1="4.445" x2="213.36" y2="2.54" width="0.2032" layer="16"/>
+<wire x1="160.655" y1="0" x2="205.74" y2="0" width="0.2032" layer="16"/>
+<wire x1="213.36" y1="2.54" x2="215.9" y2="0" width="0.2032" layer="16"/>
+<wire x1="244.475" y1="0" x2="248.285" y2="3.81" width="0.2032" layer="16"/>
+<wire x1="248.285" y1="3.81" x2="250.825" y2="3.81" width="0.2032" layer="16"/>
+<wire x1="250.825" y1="3.81" x2="252.095" y2="2.54" width="0.2032" layer="16"/>
+<wire x1="215.9" y1="0" x2="244.475" y2="0" width="0.2032" layer="16"/>
+<wire x1="252.095" y1="2.54" x2="252.73" y2="2.54" width="0.2032" layer="16"/>
+<wire x1="252.73" y1="2.54" x2="254.635" y2="4.445" width="0.2032" layer="16"/>
+<wire x1="295.91" y1="4.445" x2="297.815" y2="2.54" width="0.2032" layer="16"/>
+<wire x1="254.635" y1="4.445" x2="295.91" y2="4.445" width="0.2032" layer="16"/>
+<wire x1="297.815" y1="2.54" x2="299.72" y2="4.445" width="0.2032" layer="16"/>
+<wire x1="349.885" y1="4.445" x2="351.79" y2="2.54" width="0.2032" layer="16"/>
+<wire x1="299.72" y1="4.445" x2="349.885" y2="4.445" width="0.2032" layer="16"/>
+<wire x1="351.79" y1="2.54" x2="353.695" y2="4.445" width="0.2032" layer="16"/>
+<wire x1="387.35" y1="4.445" x2="389.255" y2="2.54" width="0.2032" layer="16"/>
+<wire x1="353.695" y1="4.445" x2="387.35" y2="4.445" width="0.2032" layer="16"/>
 </signal>
 <signal name="LOAD">
 <contactref element="U1" pad="1"/>
@@ -19839,84 +19951,75 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <contactref element="U6" pad="1"/>
 <contactref element="MS2" pad="10"/>
 <contactref element="U$45" pad="A5"/>
-<wire x1="102.87" y1="-1.27" x2="101.6" y2="0" width="0.2032" layer="1"/>
-<wire x1="101.6" y1="0" x2="100.33" y2="0" width="0.2032" layer="1"/>
-<wire x1="100.33" y1="0" x2="99.06" y2="1.27" width="0.2032" layer="1"/>
-<wire x1="99.06" y1="1.27" x2="101.6" y2="3.81" width="0.2032" layer="1"/>
-<wire x1="122.555" y1="3.81" x2="126.365" y2="0" width="0.2032" layer="1"/>
-<wire x1="126.365" y1="0" x2="135.255" y2="0" width="0.2032" layer="1"/>
-<wire x1="135.255" y1="0" x2="136.525" y2="1.27" width="0.2032" layer="1"/>
-<wire x1="136.525" y1="1.27" x2="139.7" y2="1.27" width="0.2032" layer="1"/>
-<wire x1="139.7" y1="1.27" x2="140.97" y2="0" width="0.2032" layer="1"/>
-<wire x1="140.97" y1="0" x2="153.035" y2="0" width="0.2032" layer="1"/>
-<wire x1="153.035" y1="0" x2="155.575" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="101.6" y1="3.81" x2="122.555" y2="3.81" width="0.2032" layer="1"/>
-<wire x1="155.575" y1="2.54" x2="156.845" y2="3.81" width="0.2032" layer="1"/>
-<wire x1="156.845" y1="3.81" x2="158.75" y2="3.81" width="0.2032" layer="1"/>
-<wire x1="158.75" y1="3.81" x2="159.385" y2="3.175" width="0.2032" layer="1"/>
-<wire x1="159.385" y1="3.175" x2="159.385" y2="1.905" width="0.2032" layer="1"/>
-<wire x1="159.385" y1="1.905" x2="161.925" y2="-0.635" width="0.2032" layer="1"/>
-<wire x1="205.105" y1="-0.635" x2="208.28" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="161.925" y1="-0.635" x2="205.105" y2="-0.635" width="0.2032" layer="1"/>
-<wire x1="208.28" y1="2.54" x2="211.455" y2="-0.635" width="0.2032" layer="1"/>
-<wire x1="211.455" y1="-0.635" x2="259.08" y2="-0.635" width="0.2032" layer="1"/>
-<wire x1="259.08" y1="-0.635" x2="262.255" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="262.255" y1="2.54" x2="265.43" y2="-0.635" width="0.2032" layer="1"/>
-<wire x1="265.43" y1="-0.635" x2="311.785" y2="-0.635" width="0.2032" layer="1"/>
-<wire x1="311.785" y1="-0.635" x2="314.96" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="314.96" y1="2.54" x2="318.135" y2="-0.635" width="0.2032" layer="1"/>
-<wire x1="318.135" y1="-0.635" x2="364.49" y2="-0.635" width="0.2032" layer="1"/>
-<wire x1="364.49" y1="-0.635" x2="367.665" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="419.1" y1="3.175" x2="419.735" y2="2.54" width="0.2032" layer="1"/>
-<wire x1="419.1" y1="3.175" x2="393.7" y2="3.175" width="0.2032" layer="1"/>
-<wire x1="393.7" y1="3.175" x2="391.16" y2="0.635" width="0.2032" layer="1"/>
-<wire x1="391.16" y1="0.635" x2="369.57" y2="0.635" width="0.2032" layer="1"/>
-<wire x1="367.665" y1="2.54" x2="369.57" y2="0.635" width="0.2032" layer="1"/>
+<wire x1="101.08446875" y1="0.0254" x2="101.5746" y2="0.0254" width="0.2032" layer="1"/>
+<wire x1="101.5746" y1="0.0254" x2="102.87" y2="-1.27" width="0.2032" layer="1"/>
+<wire x1="99.06" y1="1.27" x2="99.83986875" y2="1.27" width="0.2032" layer="1"/>
+<wire x1="99.83986875" y1="1.27" x2="101.08446875" y2="0.0254" width="0.2032" layer="1"/>
+<wire x1="99.06" y1="1.27" x2="100.33" y2="2.54" width="0.2032" layer="16"/>
+<wire x1="121.92" y1="2.54" x2="125.095" y2="-0.635" width="0.2032" layer="16"/>
+<wire x1="125.095" y1="-0.635" x2="152.4" y2="-0.635" width="0.2032" layer="16"/>
+<wire x1="152.4" y1="-0.635" x2="155.575" y2="2.54" width="0.2032" layer="16"/>
+<wire x1="100.33" y1="2.54" x2="121.92" y2="2.54" width="0.2032" layer="16"/>
+<wire x1="155.575" y1="2.54" x2="158.75" y2="-0.635" width="0.2032" layer="16"/>
+<wire x1="207.645" y1="-0.635" x2="210.82" y2="2.54" width="0.2032" layer="16"/>
+<wire x1="158.75" y1="-0.635" x2="207.645" y2="-0.635" width="0.2032" layer="16"/>
+<wire x1="210.82" y1="2.54" x2="213.995" y2="-0.635" width="0.2032" layer="16"/>
+<wire x1="245.11" y1="-0.635" x2="248.285" y2="2.54" width="0.2032" layer="16"/>
+<wire x1="248.285" y1="2.54" x2="249.555" y2="2.54" width="0.2032" layer="16"/>
+<wire x1="213.995" y1="-0.635" x2="245.11" y2="-0.635" width="0.2032" layer="16"/>
+<wire x1="249.555" y1="2.54" x2="251.46" y2="0.635" width="0.2032" layer="16"/>
+<wire x1="293.37" y1="0.635" x2="295.275" y2="2.54" width="0.2032" layer="16"/>
+<wire x1="251.46" y1="0.635" x2="293.37" y2="0.635" width="0.2032" layer="16"/>
+<wire x1="295.275" y1="2.54" x2="295.91" y2="2.54" width="0.2032" layer="16"/>
+<wire x1="295.91" y1="2.54" x2="297.815" y2="0.635" width="0.2032" layer="16"/>
+<wire x1="297.815" y1="0.635" x2="347.345" y2="0.635" width="0.2032" layer="16"/>
+<wire x1="347.345" y1="0.635" x2="349.25" y2="2.54" width="0.2032" layer="16"/>
+<wire x1="349.25" y1="2.54" x2="351.155" y2="0.635" width="0.2032" layer="16"/>
+<wire x1="384.81" y1="0.635" x2="386.715" y2="2.54" width="0.2032" layer="16"/>
+<wire x1="351.155" y1="0.635" x2="384.81" y2="0.635" width="0.2032" layer="16"/>
 </signal>
-<signal name="N$63">
+<signal name="PWR_1-12">
 <contactref element="U$36" pad="P$1"/>
 <contactref element="U$37" pad="P$1"/>
 <contactref element="Q7" pad="2"/>
-<wire x1="125.73" y1="23.495" x2="127" y2="24.765" width="0.6096" layer="16"/>
-<wire x1="139.065" y1="24.765" x2="140.589" y2="26.289" width="0.6096" layer="1"/>
-<wire x1="198.12" y1="28.067" x2="196.469" y2="26.416" width="0.6096" layer="1"/>
-<wire x1="198.12" y1="28.067" x2="198.12" y2="30.48" width="0.6096" layer="1"/>
-<wire x1="127" y1="24.765" x2="139.065" y2="24.765" width="0.6096" layer="16"/>
-<wire x1="140.589" y1="26.289" x2="147.955" y2="26.289" width="0.6096" layer="1"/>
-<via x="139.065" y="24.765" extent="1-16" drill="0.55"/>
-<wire x1="147.955" y1="26.289" x2="158.496" y2="26.289" width="0.6096" layer="1"/>
-<wire x1="158.496" y1="26.289" x2="161.29" y2="26.289" width="0.6096" layer="1"/>
-<wire x1="161.29" y1="26.289" x2="173.99" y2="26.289" width="0.6096" layer="1"/>
-<wire x1="173.99" y1="26.289" x2="184.531" y2="26.289" width="0.6096" layer="1"/>
-<wire x1="191.135" y1="26.416" x2="190.246" y2="26.416" width="0.6096" layer="1"/>
-<wire x1="190.246" y1="26.416" x2="190.119" y2="26.289" width="0.6096" layer="1"/>
-<wire x1="190.119" y1="26.289" x2="184.531" y2="26.289" width="0.6096" layer="1"/>
-<wire x1="192.786" y1="26.416" x2="191.135" y2="26.416" width="0.6096" layer="1"/>
-<wire x1="194.437" y1="26.416" x2="192.786" y2="26.416" width="0.6096" layer="1"/>
-<wire x1="195.961" y1="26.416" x2="194.437" y2="26.416" width="0.6096" layer="1"/>
-<wire x1="195.961" y1="26.416" x2="196.469" y2="26.416" width="0.6096" layer="1"/>
-<via x="147.955" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="161.29" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="173.99" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="184.531" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="191.135" y="26.416" extent="1-16" drill="0.3302"/>
-<via x="192.786" y="26.416" extent="1-16" drill="0.3302"/>
-<via x="194.437" y="26.416" extent="1-16" drill="0.3302"/>
-<via x="195.961" y="26.416" extent="1-16" drill="0.3302"/>
-<wire x1="198.12" y1="30.48" x2="243.84" y2="30.48" width="0.6096" layer="1"/>
-<wire x1="248.031" y1="26.289" x2="250.19" y2="26.289" width="0.6096" layer="1"/>
-<wire x1="250.19" y1="26.289" x2="259.715" y2="26.289" width="0.6096" layer="1"/>
-<wire x1="259.715" y1="26.289" x2="271.145" y2="26.289" width="0.6096" layer="1"/>
-<wire x1="271.145" y1="26.289" x2="273.05" y2="26.289" width="0.6096" layer="1"/>
-<wire x1="273.05" y1="26.289" x2="273.685" y2="26.289" width="0.6096" layer="1"/>
-<wire x1="243.84" y1="30.48" x2="248.031" y2="26.289" width="0.6096" layer="1"/>
-<wire x1="274.955" y1="30.48" x2="274.955" y2="27.559" width="0.6096" layer="1"/>
-<wire x1="274.955" y1="27.559" x2="273.685" y2="26.289" width="0.6096" layer="1"/>
-<via x="250.19" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="259.715" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="271.145" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="273.05" y="26.289" extent="1-16" drill="0.3302"/>
-<via x="158.496" y="26.289" extent="1-16" drill="0.3302"/>
+<wire x1="190.5" y1="13.97" x2="187.96" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="187.96" y1="13.97" x2="185.42" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="185.42" y1="13.97" x2="182.88" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="182.88" y1="13.97" x2="180.34" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="180.34" y1="13.97" x2="177.8" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="177.8" y1="13.97" x2="175.26" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="175.26" y1="13.97" x2="172.72" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="172.72" y1="13.97" x2="133.985" y2="13.97" width="0.6096" layer="16"/>
+<wire x1="133.985" y1="13.97" x2="128.905" y2="19.05" width="0.6096" layer="16"/>
+<wire x1="128.905" y1="19.05" x2="128.905" y2="21.59" width="0.6096" layer="16"/>
+<wire x1="128.905" y1="21.59" x2="127" y2="23.495" width="0.6096" layer="16"/>
+<wire x1="127" y1="23.495" x2="125.73" y2="23.495" width="0.6096" layer="16"/>
+<via x="172.72" y="13.97" extent="1-16" drill="0.35"/>
+<via x="175.26" y="13.97" extent="1-16" drill="0.35"/>
+<via x="177.8" y="13.97" extent="1-16" drill="0.35"/>
+<via x="180.34" y="13.97" extent="1-16" drill="0.35"/>
+<via x="182.88" y="13.97" extent="1-16" drill="0.35"/>
+<via x="185.42" y="13.97" extent="1-16" drill="0.35"/>
+<via x="187.96" y="13.97" extent="1-16" drill="0.35"/>
+<via x="190.5" y="13.97" extent="1-16" drill="0.35"/>
+<via x="266.573" y="14.7828" extent="1-16" drill="0.35"/>
+<via x="269.113" y="14.7828" extent="1-16" drill="0.35"/>
+<via x="271.653" y="14.7828" extent="1-16" drill="0.35"/>
+<via x="274.193" y="14.7828" extent="1-16" drill="0.35"/>
+<wire x1="190.5" y1="13.97" x2="190.6552" y2="14.1252" width="0.6096" layer="16"/>
+<wire x1="190.6552" y1="14.1252" x2="190.85655625" y2="14.1252" width="0.6096" layer="16"/>
+<wire x1="190.85655625" y1="14.1252" x2="193.04" y2="16.30864375" width="0.6096" layer="16"/>
+<wire x1="193.04" y1="16.30864375" x2="193.04" y2="17.145" width="0.6096" layer="16"/>
+<wire x1="193.04" y1="17.145" x2="193.675" y2="17.78" width="0.6096" layer="16"/>
+<wire x1="198.12" y1="17.78" x2="201.1172" y2="14.7828" width="0.6096" layer="16"/>
+<wire x1="193.675" y1="17.78" x2="198.12" y2="17.78" width="0.6096" layer="16"/>
+<wire x1="201.1172" y1="14.7828" x2="266.573" y2="14.7828" width="0.6096" layer="16"/>
+<wire x1="269.113" y1="14.7828" x2="266.573" y2="14.7828" width="0.6096" layer="16"/>
+<wire x1="269.113" y1="14.7828" x2="271.653" y2="14.7828" width="0.6096" layer="16"/>
+<wire x1="271.653" y1="14.7828" x2="274.193" y2="14.7828" width="0.6096" layer="16"/>
+<wire x1="274.193" y1="14.7828" x2="284.226" y2="14.7828" width="0.6096" layer="16"/>
+<wire x1="284.226" y1="14.7828" x2="286.893" y2="17.4498" width="0.6096" layer="16"/>
+<wire x1="286.893" y1="17.4498" x2="286.893" y2="18.415" width="0.6096" layer="16"/>
 </signal>
 <signal name="5V">
 <contactref element="J1" pad="2"/>
@@ -19924,105 +20027,306 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <contactref element="U7" pad="VIN"/>
 <contactref element="C7" pad="1"/>
 <contactref element="U$40" pad="1"/>
-<wire x1="99.06" y1="27.305" x2="99.06" y2="26.162" width="0.6096" layer="1"/>
-<wire x1="126.365" y1="12.7" x2="121.92" y2="12.7" width="0.6096" layer="16"/>
-<wire x1="119.507" y1="15.113" x2="119.507" y2="19.6286625" width="0.6096" layer="16"/>
-<wire x1="119.507" y1="19.6286625" x2="117.1646625" y2="21.971" width="0.6096" layer="16"/>
-<wire x1="121.92" y1="12.7" x2="119.507" y2="15.113" width="0.6096" layer="16"/>
-<wire x1="97.917" y1="21.971" x2="96.393" y2="23.495" width="0.6096" layer="16"/>
-<wire x1="117.1646625" y1="21.971" x2="97.917" y2="21.971" width="0.6096" layer="16"/>
-<wire x1="99.06" y1="26.162" x2="96.393" y2="23.495" width="0.6096" layer="1"/>
-<wire x1="93.345" y1="21.336" x2="93.345" y2="22.225" width="0.6096" layer="1"/>
-<wire x1="93.345" y1="22.225" x2="94.615" y2="23.495" width="0.6096" layer="1"/>
-<wire x1="94.615" y1="23.495" x2="96.393" y2="23.495" width="0.6096" layer="1"/>
-<wire x1="93.345" y1="21.336" x2="93.091" y2="21.336" width="0.6096" layer="1"/>
-<wire x1="93.091" y1="21.336" x2="92.71" y2="20.955" width="0.6096" layer="1"/>
-<wire x1="77.39" y1="20.955" x2="76.835" y2="20.4" width="0.6096" layer="1"/>
-<wire x1="92.71" y1="20.955" x2="77.39" y2="20.955" width="0.6096" layer="1"/>
+<contactref element="SERVO5" pad="2"/>
+<contactref element="SERVO4" pad="2"/>
+<contactref element="SERVO3" pad="2"/>
+<contactref element="SERVO2" pad="2"/>
+<contactref element="SERVO1" pad="2"/>
+<wire x1="76.835" y1="20.4" x2="77.517" y2="21.082" width="0.6096" layer="1"/>
+<wire x1="92.456" y1="21.082" x2="77.517" y2="21.082" width="0.6096" layer="1"/>
+<wire x1="92.71" y1="21.336" x2="92.456" y2="21.082" width="0.6096" layer="1"/>
+<wire x1="93.345" y1="21.336" x2="92.71" y2="21.336" width="0.6096" layer="1"/>
+<wire x1="93.345" y1="21.336" x2="93.345" y2="22.86" width="0.6096" layer="1"/>
+<wire x1="93.345" y1="22.86" x2="93.98" y2="23.495" width="0.6096" layer="1"/>
+<wire x1="93.98" y1="23.495" x2="96.393" y2="23.495" width="0.6096" layer="1"/>
+<wire x1="96.393" y1="23.495" x2="98.298" y2="21.59" width="0.6096" layer="1"/>
+<wire x1="98.298" y1="21.59" x2="120.015" y2="21.59" width="0.6096" layer="1"/>
+<wire x1="96.393" y1="23.495" x2="99.06" y2="26.162" width="0.6096" layer="1"/>
+<wire x1="99.06" y1="26.162" x2="99.06" y2="27.305" width="0.6096" layer="1"/>
+<wire x1="120.015" y1="21.59" x2="123.19" y2="18.415" width="0.6096" layer="1"/>
+<wire x1="123.19" y1="18.415" x2="123.19" y2="14.605" width="0.6096" layer="1"/>
+<wire x1="123.19" y1="14.605" x2="125.095" y2="12.7" width="0.6096" layer="1"/>
+<wire x1="125.095" y1="12.7" x2="126.365" y2="12.7" width="0.6096" layer="1"/>
+<via x="141.605" y="11.43" extent="1-16" drill="0.55"/>
+<wire x1="141.605" y1="11.43" x2="127.635" y2="11.43" width="0.6096" layer="1"/>
+<wire x1="127.635" y1="11.43" x2="126.365" y2="12.7" width="0.6096" layer="1"/>
+<wire x1="197.104" y1="12.446" x2="196.342" y2="11.684" width="0.6096" layer="16"/>
+<wire x1="196.342" y1="11.684" x2="141.859" y2="11.684" width="0.6096" layer="16"/>
+<wire x1="141.859" y1="11.684" x2="141.605" y2="11.43" width="0.6096" layer="16"/>
+<wire x1="339.725" y1="12.7" x2="339.471" y2="12.446" width="0.6096" layer="16"/>
+<wire x1="339.471" y1="12.446" x2="197.104" y2="12.446" width="0.6096" layer="16"/>
+<wire x1="409.194" y1="12.7" x2="339.725" y2="12.7" width="0.6096" layer="16"/>
+<wire x1="409.194" y1="12.7" x2="420.37" y2="12.7" width="0.6096" layer="16"/>
+<wire x1="436.88" y1="12.7" x2="420.37" y2="12.7" width="0.6096" layer="16"/>
 </signal>
 <signal name="P1">
 <contactref element="MS2" pad="21"/>
 <contactref element="Q7" pad="1"/>
 <contactref element="R15" pad="P$2"/>
 <contactref element="U$45" pad="D10"/>
-<wire x1="104.14" y1="13.335" x2="105.41" y2="14.605" width="0.2032" layer="1"/>
-<wire x1="105.41" y1="14.605" x2="105.41" y2="17.145" width="0.2032" layer="1"/>
-<wire x1="105.41" y1="17.145" x2="107.315" y2="19.05" width="0.2032" layer="1"/>
-<wire x1="107.315" y1="19.05" x2="107.95" y2="19.05" width="0.2032" layer="1"/>
-<wire x1="91.44" y1="16.51" x2="94.615" y2="13.335" width="0.2032" layer="1"/>
-<wire x1="94.615" y1="13.335" x2="104.14" y2="13.335" width="0.2032" layer="1"/>
-<wire x1="107.95" y1="19.05" x2="109.855" y2="20.955" width="0.2032" layer="1"/>
-<wire x1="120.65" y1="20.955" x2="125.73" y2="26.035" width="0.2032" layer="1"/>
-<wire x1="109.855" y1="20.955" x2="120.65" y2="20.955" width="0.2032" layer="1"/>
+<wire x1="91.44" y1="16.51" x2="94.615" y2="13.335" width="0.2032" layer="16"/>
+<wire x1="94.615" y1="13.335" x2="104.14" y2="13.335" width="0.2032" layer="16"/>
+<wire x1="104.14" y1="13.335" x2="106.68" y2="13.335" width="0.2032" layer="16"/>
+<wire x1="107.95" y1="14.605" x2="107.95" y2="19.05" width="0.2032" layer="16"/>
+<wire x1="106.68" y1="13.335" x2="107.95" y2="14.605" width="0.2032" layer="16"/>
+<wire x1="107.95" y1="19.05" x2="107.95" y2="27.305" width="0.2032" layer="16"/>
+<wire x1="107.95" y1="27.305" x2="110.49" y2="29.845" width="0.2032" layer="16"/>
+<wire x1="110.49" y1="29.845" x2="121.92" y2="29.845" width="0.2032" layer="16"/>
+<wire x1="121.92" y1="29.845" x2="125.73" y2="26.035" width="0.2032" layer="16"/>
 </signal>
 <signal name="SDA">
 <contactref element="MS2" pad="17"/>
 <contactref element="J4" pad="1"/>
 <contactref element="R1" pad="P$1"/>
 <contactref element="U$45" pad="SDA"/>
-<wire x1="104.14" y1="16.51" x2="105.41" y2="15.24" width="0.2032" layer="16"/>
-<wire x1="105.41" y1="15.24" x2="114.3" y2="15.24" width="0.2032" layer="16"/>
-<wire x1="114.3" y1="15.24" x2="118.11" y2="19.05" width="0.2032" layer="16"/>
-<wire x1="104.14" y1="16.51" x2="102.235" y2="14.605" width="0.2032" layer="16"/>
-<wire x1="102.235" y1="14.605" x2="102.235" y2="10.16" width="0.2032" layer="16"/>
-<wire x1="102.235" y1="10.16" x2="104.14" y2="8.255" width="0.2032" layer="16"/>
-<wire x1="118.11" y1="19.05" x2="128.905" y2="19.05" width="0.2032" layer="1"/>
-<wire x1="128.905" y1="19.05" x2="137.16" y2="10.795" width="0.2032" layer="1"/>
-<wire x1="137.16" y1="10.795" x2="139.7" y2="10.795" width="0.2032" layer="1"/>
-<wire x1="139.7" y1="10.795" x2="140.97" y2="9.525" width="0.2032" layer="1"/>
-<wire x1="140.97" y1="4.445" x2="143.51" y2="1.905" width="0.2032" layer="1"/>
-<wire x1="140.97" y1="9.525" x2="140.97" y2="4.445" width="0.2032" layer="1"/>
+<wire x1="104.14" y1="8.255" x2="106.045" y2="10.16" width="0.2032" layer="1"/>
+<wire x1="106.045" y1="14.605" x2="104.14" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="106.045" y1="10.16" x2="106.045" y2="14.605" width="0.2032" layer="1"/>
+<wire x1="104.14" y1="16.51" x2="105.41" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="116.84" y1="17.78" x2="118.11" y2="19.05" width="0.2032" layer="1"/>
+<wire x1="105.41" y1="17.78" x2="116.84" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="118.11" y1="19.05" x2="121.92" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="134.62" y1="10.795" x2="143.51" y2="1.905" width="0.2032" layer="1"/>
+<wire x1="121.92" y1="15.24" x2="121.92" y2="13.97" width="0.2032" layer="1"/>
+<wire x1="121.92" y1="13.97" x2="125.095" y2="10.795" width="0.2032" layer="1"/>
+<wire x1="125.095" y1="10.795" x2="134.62" y2="10.795" width="0.2032" layer="1"/>
 </signal>
 <signal name="A4">
 <contactref element="MS2" pad="9"/>
 <contactref element="J3" pad="1"/>
 <contactref element="U$45" pad="A4"/>
-<wire x1="100.33" y1="-1.27" x2="99.06" y2="0" width="0.2032" layer="1"/>
-<wire x1="99.06" y1="0" x2="97.79" y2="0" width="0.2032" layer="1"/>
-<wire x1="97.79" y1="0" x2="96.52" y2="1.27" width="0.2032" layer="1"/>
-<wire x1="96.52" y1="1.27" x2="99.695" y2="4.445" width="0.2032" layer="16"/>
-<wire x1="125.73" y1="4.445" x2="128.27" y2="1.905" width="0.2032" layer="16"/>
-<wire x1="99.695" y1="4.445" x2="125.73" y2="4.445" width="0.2032" layer="16"/>
+<wire x1="98.54446875" y1="0.0254" x2="99.0346" y2="0.0254" width="0.2032" layer="1"/>
+<wire x1="99.0346" y1="0.0254" x2="100.33" y2="-1.27" width="0.2032" layer="1"/>
+<wire x1="96.52" y1="1.27" x2="97.29986875" y2="1.27" width="0.2032" layer="1"/>
+<wire x1="97.29986875" y1="1.27" x2="98.54446875" y2="0.0254" width="0.2032" layer="1"/>
+<wire x1="96.52" y1="1.27" x2="97.79" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="111.125" y1="2.54" x2="111.76" y2="1.905" width="0.2032" layer="1"/>
+<wire x1="97.79" y1="2.54" x2="111.125" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="111.76" y1="1.905" x2="128.27" y2="1.905" width="0.2032" layer="1"/>
 </signal>
 <signal name="USB">
 <contactref element="JP1" pad="2"/>
 <contactref element="MS2" pad="26"/>
 <contactref element="U$45" pad="USB"/>
-<wire x1="94.0054" y1="20.2946" x2="85.0646" y2="20.2946" width="0.3048" layer="1"/>
-<wire x1="85.0646" y1="20.2946" x2="81.28" y2="16.51" width="0.3048" layer="1"/>
-<wire x1="94.361" y1="20.6502" x2="94.3229" y2="20.6121" width="0.3048" layer="1"/>
-<wire x1="94.0054" y1="20.2946" x2="94.3229" y2="20.6121" width="0.3048" layer="1"/>
-<wire x1="95.25" y1="19.05" x2="94.0054" y2="20.2946" width="0.3048" layer="1"/>
-<wire x1="94.361" y1="21.336" x2="94.361" y2="20.6502" width="0.3048" layer="1"/>
+<wire x1="94.361" y1="21.336" x2="95.25" y2="20.447" width="0.6096" layer="1"/>
+<wire x1="95.25" y1="20.447" x2="95.25" y2="19.05" width="0.6096" layer="1"/>
+<wire x1="95.25" y1="19.05" x2="94.0054" y2="17.8054" width="0.3048" layer="1"/>
+<wire x1="82.5754" y1="17.8054" x2="81.28" y2="16.51" width="0.3048" layer="1"/>
+<wire x1="94.0054" y1="17.8054" x2="82.5754" y2="17.8054" width="0.3048" layer="1"/>
 </signal>
-<signal name="N$28">
+<signal name="SER3">
 <contactref element="U4" pad="10"/>
 <contactref element="U3" pad="9"/>
-<wire x1="277.495" y1="10.16" x2="278.765" y2="8.89" width="0.2032" layer="1"/>
-<wire x1="278.765" y1="8.89" x2="280.67" y2="8.89" width="0.2032" layer="1"/>
-<wire x1="280.67" y1="8.89" x2="285.623" y2="13.843" width="0.2032" layer="1"/>
-<wire x1="285.623" y1="13.843" x2="329.057" y2="13.843" width="0.2032" layer="16"/>
-<wire x1="329.057" y1="13.843" x2="332.74" y2="10.16" width="0.2032" layer="16"/>
-<via x="285.623" y="13.843" extent="1-16" drill="0.3302"/>
+<wire x1="264.795" y1="10.16" x2="267.335" y2="7.62" width="0.2032" layer="16"/>
+<wire x1="310.515" y1="7.62" x2="313.055" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="267.335" y1="7.62" x2="310.515" y2="7.62" width="0.2032" layer="16"/>
 </signal>
 <signal name="P2">
 <contactref element="MS2" pad="22"/>
 <contactref element="Q6" pad="1"/>
 <contactref element="R13" pad="P$2"/>
 <contactref element="U$45" pad="D11"/>
-<wire x1="88.9" y1="16.51" x2="94.615" y2="10.795" width="0.2032" layer="1"/>
-<wire x1="94.615" y1="10.795" x2="104.14" y2="10.795" width="0.2032" layer="1"/>
-<wire x1="105.41" y1="19.05" x2="104.14" y2="17.78" width="0.2032" layer="1"/>
-<wire x1="104.14" y1="17.78" x2="90.17" y2="17.78" width="0.2032" layer="1"/>
-<wire x1="90.17" y1="17.78" x2="88.9" y2="16.51" width="0.2032" layer="1"/>
-<wire x1="105.41" y1="19.05" x2="107.95" y2="21.59" width="0.2032" layer="1"/>
-<wire x1="107.95" y1="21.59" x2="118.11" y2="21.59" width="0.2032" layer="1"/>
-<wire x1="118.11" y1="21.59" x2="123.825" y2="27.305" width="0.2032" layer="1"/>
-<wire x1="123.825" y1="27.305" x2="130.81" y2="27.305" width="0.2032" layer="1"/>
-<wire x1="130.81" y1="27.305" x2="132.08" y2="26.035" width="0.2032" layer="1"/>
+<wire x1="88.9" y1="16.51" x2="94.615" y2="10.795" width="0.2032" layer="16"/>
+<wire x1="94.615" y1="10.795" x2="104.14" y2="10.795" width="0.2032" layer="16"/>
+<wire x1="104.14" y1="10.795" x2="102.87" y2="12.065" width="0.2032" layer="1"/>
+<wire x1="104.775" y1="19.05" x2="105.41" y2="19.05" width="0.2032" layer="1"/>
+<wire x1="102.87" y1="12.065" x2="102.87" y2="17.145" width="0.2032" layer="1"/>
+<wire x1="102.87" y1="17.145" x2="104.775" y2="19.05" width="0.2032" layer="1"/>
+<wire x1="105.41" y1="19.05" x2="105.41" y2="27.305" width="0.2032" layer="16"/>
+<wire x1="105.41" y1="27.305" x2="109.22" y2="31.115" width="0.2032" layer="16"/>
+<wire x1="109.22" y1="31.115" x2="127" y2="31.115" width="0.2032" layer="16"/>
+<wire x1="127" y1="31.115" x2="132.08" y2="26.035" width="0.2032" layer="16"/>
 </signal>
-<signal name="1_CATHODE1">
-<via x="158.496" y="25.4" extent="1-16" drill="0.3302"/>
+<signal name="SRVO3">
+<contactref element="SERVO3" pad="3"/>
+<contactref element="MS2" pad="7"/>
+<wire x1="93.98" y1="0" x2="95.25" y2="-1.27" width="0.2032" layer="1"/>
+<wire x1="114.935" y1="4.445" x2="114.3" y2="3.81" width="0.2032" layer="16"/>
+<wire x1="128.905" y1="4.445" x2="129.54" y2="5.08" width="0.2032" layer="16"/>
+<wire x1="129.54" y1="5.08" x2="133.985" y2="5.08" width="0.2032" layer="16"/>
+<wire x1="133.985" y1="5.08" x2="137.795" y2="1.27" width="0.2032" layer="16"/>
+<wire x1="114.935" y1="4.445" x2="128.905" y2="4.445" width="0.2032" layer="16"/>
+<wire x1="137.795" y1="1.27" x2="140.335" y2="1.27" width="0.2032" layer="16"/>
+<wire x1="140.335" y1="1.27" x2="144.3228" y2="5.2578" width="0.2032" layer="16"/>
+<wire x1="171.6278" y1="5.2578" x2="172.72" y2="6.35" width="0.2032" layer="16"/>
+<wire x1="144.3228" y1="5.2578" x2="171.6278" y2="5.2578" width="0.2032" layer="16"/>
+<wire x1="410.21" y1="6.35" x2="411.48" y2="7.62" width="0.2032" layer="16"/>
+<via x="411.48" y="7.62" extent="1-16" drill="0.35"/>
+<wire x1="411.48" y1="7.62" x2="411.48" y2="14.605" width="0.2032" layer="1"/>
+<wire x1="411.48" y1="14.605" x2="410.845" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="410.845" y1="15.24" x2="409.194" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="172.72" y1="6.35" x2="410.21" y2="6.35" width="0.2032" layer="16"/>
+<contactref element="U$45" pad="A2"/>
+<wire x1="91.44" y1="1.27" x2="92.71" y2="0" width="0.2032" layer="1"/>
+<wire x1="92.71" y1="0" x2="93.98" y2="0" width="0.2032" layer="1"/>
+<wire x1="92.71" y1="3.81" x2="91.44" y2="2.54" width="0.2032" layer="16"/>
+<wire x1="91.44" y1="2.54" x2="91.44" y2="1.27" width="0.2032" layer="16"/>
+<wire x1="114.3" y1="3.81" x2="92.71" y2="3.81" width="0.2032" layer="16"/>
+</signal>
+<signal name="SRVO2">
+<contactref element="MS2" pad="6"/>
+<wire x1="91.44" y1="0" x2="92.71" y2="-1.27" width="0.2032" layer="1"/>
+<via x="130.175" y="3.81" extent="1-16" drill="0.3302"/>
+<wire x1="130.175" y1="3.81" x2="133.985" y2="3.81" width="0.2032" layer="16"/>
+<contactref element="SERVO2" pad="3"/>
+<wire x1="149.0566625" y1="0.4064" x2="153.5016625" y2="4.8514" width="0.2032" layer="16"/>
+<wire x1="133.985" y1="3.81" x2="137.3886" y2="0.4064" width="0.2032" layer="16"/>
+<wire x1="137.3886" y1="0.4064" x2="149.0566625" y2="0.4064" width="0.2032" layer="16"/>
+<wire x1="153.5016625" y1="4.8514" x2="172.4914" y2="4.8514" width="0.2032" layer="16"/>
+<wire x1="172.4914" y1="4.8514" x2="173.355" y2="5.715" width="0.2032" layer="16"/>
+<wire x1="415.925" y1="5.715" x2="417.195" y2="6.985" width="0.2032" layer="16"/>
+<via x="417.195" y="6.985" extent="1-16" drill="0.35"/>
+<wire x1="417.195" y1="6.985" x2="417.195" y2="13.335" width="0.2032" layer="1"/>
+<wire x1="417.195" y1="13.335" x2="419.1" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="419.1" y1="15.24" x2="420.37" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="173.355" y1="5.715" x2="415.925" y2="5.715" width="0.2032" layer="16"/>
+<contactref element="U$45" pad="A1"/>
+<wire x1="91.44" y1="0" x2="90.17" y2="0" width="0.2032" layer="1"/>
+<wire x1="90.17" y1="3.81" x2="88.9" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="88.9" y1="2.54" x2="88.9" y2="1.27" width="0.2032" layer="1"/>
+<wire x1="130.175" y1="3.81" x2="90.17" y2="3.81" width="0.2032" layer="1"/>
+<wire x1="90.17" y1="0" x2="88.9" y2="1.27" width="0.2032" layer="1"/>
+</signal>
+<signal name="SRVO4">
+<contactref element="U$45" pad="D13"/>
+<contactref element="MS2" pad="25"/>
+<wire x1="83.82" y1="16.51" x2="85.09" y2="17.78" width="0.2032" layer="16"/>
+<wire x1="96.52" y1="17.78" x2="97.79" y2="19.05" width="0.2032" layer="16"/>
+<wire x1="85.09" y1="17.78" x2="96.52" y2="17.78" width="0.2032" layer="16"/>
+<wire x1="83.82" y1="16.51" x2="84.455" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="84.455" y1="16.51" x2="96.52" y2="4.445" width="0.2032" layer="1"/>
+<wire x1="96.52" y1="4.445" x2="114.3" y2="4.445" width="0.2032" layer="1"/>
+<wire x1="114.3" y1="4.445" x2="114.935" y2="5.08" width="0.2032" layer="1"/>
+<contactref element="SERVO4" pad="3"/>
+<wire x1="123.19" y1="5.08" x2="123.825" y2="5.715" width="0.2032" layer="1"/>
+<via x="123.825" y="5.715" extent="1-16" drill="0.3302"/>
+<wire x1="114.935" y1="5.08" x2="123.19" y2="5.08" width="0.2032" layer="1"/>
+<wire x1="123.825" y1="5.715" x2="170.815" y2="5.715" width="0.2032" layer="16"/>
+<wire x1="170.815" y1="5.715" x2="172.085" y2="6.985" width="0.2032" layer="16"/>
+<wire x1="334.645" y1="6.985" x2="336.55" y2="8.89" width="0.2032" layer="16"/>
+<via x="336.55" y="8.89" extent="1-16" drill="0.35"/>
+<wire x1="336.55" y1="8.89" x2="336.55" y2="13.97" width="0.2032" layer="1"/>
+<wire x1="336.55" y1="13.97" x2="337.82" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="337.82" y1="15.24" x2="339.725" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="172.085" y1="6.985" x2="334.645" y2="6.985" width="0.2032" layer="16"/>
+</signal>
+<signal name="SRVO5">
+<contactref element="U$45" pad="D9"/>
+<contactref element="MS2" pad="24"/>
+<wire x1="93.98" y1="16.51" x2="95.885" y2="14.605" width="0.2032" layer="16"/>
+<wire x1="99.695" y1="14.605" x2="100.33" y2="15.24" width="0.2032" layer="16"/>
+<wire x1="100.33" y1="15.24" x2="100.33" y2="19.05" width="0.2032" layer="16"/>
+<wire x1="95.885" y1="14.605" x2="99.695" y2="14.605" width="0.2032" layer="16"/>
+<wire x1="93.98" y1="16.51" x2="93.98" y2="8.89" width="0.2032" layer="1"/>
+<wire x1="93.98" y1="8.89" x2="98.425" y2="4.445" width="0.2032" layer="16"/>
+<wire x1="98.425" y1="4.445" x2="114.3" y2="4.445" width="0.2032" layer="16"/>
+<via x="93.98" y="8.89" extent="1-16" drill="0.3302"/>
+<wire x1="114.3" y1="4.445" x2="115.57" y2="5.715" width="0.2032" layer="16"/>
+<contactref element="SERVO5" pad="3"/>
+<wire x1="121.285" y1="5.715" x2="122.555" y2="6.985" width="0.2032" layer="16"/>
+<wire x1="115.57" y1="5.715" x2="121.285" y2="5.715" width="0.2032" layer="16"/>
+<wire x1="122.555" y1="6.985" x2="170.815" y2="6.985" width="0.2032" layer="16"/>
+<wire x1="197.104" y1="9.906" x2="191.516" y2="9.906" width="0.2032" layer="16"/>
+<wire x1="191.516" y1="9.906" x2="191.135" y2="9.525" width="0.2032" layer="16"/>
+<wire x1="191.135" y1="9.525" x2="190.5" y2="8.89" width="0.2032" layer="1"/>
+<wire x1="190.5" y1="8.89" x2="172.72" y2="8.89" width="0.2032" layer="16"/>
+<wire x1="172.72" y1="8.89" x2="170.815" y2="6.985" width="0.2032" layer="1"/>
+<via x="191.135" y="9.525" extent="1-16" drill="0.35"/>
+<via x="170.815" y="6.985" extent="1-16" drill="0.35"/>
+<via x="190.5" y="8.89" extent="1-16" drill="0.35"/>
+<via x="172.72" y="8.89" extent="1-16" drill="0.35"/>
+</signal>
+<signal name="SRVO1">
+<contactref element="MS2" pad="5"/>
+<wire x1="97.7646" y1="0.75446875" x2="97.7646" y2="1.2446" width="0.2032" layer="16"/>
+<wire x1="97.7646" y1="1.2446" x2="97.79" y2="1.27" width="0.2032" layer="16"/>
+<wire x1="97.7646" y1="0.75446875" x2="97.01013125" y2="0" width="0.2032" layer="16"/>
+<wire x1="97.79" y1="1.27" x2="97.79" y2="1.905" width="0.2032" layer="16"/>
+<wire x1="97.79" y1="1.905" x2="99.06" y2="3.175" width="0.2032" layer="16"/>
+<wire x1="122.555" y1="3.175" x2="125.73" y2="0" width="0.2032" layer="16"/>
+<wire x1="125.73" y1="0" x2="149.225" y2="0" width="0.2032" layer="16"/>
+<wire x1="149.225" y1="0" x2="153.67" y2="4.445" width="0.2032" layer="16"/>
+<wire x1="153.67" y1="4.445" x2="173.355" y2="4.445" width="0.2032" layer="16"/>
+<wire x1="99.06" y1="3.175" x2="122.555" y2="3.175" width="0.2032" layer="16"/>
+<contactref element="SERVO1" pad="3"/>
+<wire x1="173.355" y1="4.445" x2="173.99" y2="5.08" width="0.2032" layer="16"/>
+<wire x1="431.8" y1="5.08" x2="433.07" y2="6.35" width="0.2032" layer="16"/>
+<via x="433.07" y="6.35" extent="1-16" drill="0.35"/>
+<wire x1="433.07" y1="6.35" x2="433.07" y2="13.97" width="0.2032" layer="1"/>
+<wire x1="433.07" y1="13.97" x2="434.34" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="434.34" y1="15.24" x2="436.88" y2="15.24" width="0.2032" layer="1"/>
+<wire x1="173.99" y1="5.08" x2="431.8" y2="5.08" width="0.2032" layer="16"/>
+<contactref element="U$45" pad="A0"/>
+<wire x1="86.36" y1="1.27" x2="87.63" y2="0" width="0.2032" layer="1"/>
+<wire x1="87.63" y1="0" x2="88.9" y2="0" width="0.2032" layer="1"/>
+<wire x1="97.01013125" y1="0" x2="92.202" y2="0" width="0.2032" layer="16"/>
+<wire x1="92.202" y1="0" x2="90.932" y2="-1.27" width="0.2032" layer="16"/>
+<wire x1="90.932" y1="-1.27" x2="90.17" y2="-1.27" width="0.2032" layer="16"/>
+<wire x1="88.9" y1="0" x2="90.17" y2="-1.27" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS07O">
+<contactref element="R11" pad="P$6"/>
+<contactref element="U07O" pad="4"/>
+<contactref element="U5" pad="14"/>
+<wire x1="215.9" y1="10.16" x2="215.9" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="215.9" y1="16.51" x2="215.9" y2="24.722" width="0.2032" layer="1"/>
+<wire x1="215.9" y1="24.722" x2="218.599" y2="27.421" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS06O">
+<contactref element="U06O" pad="4"/>
+<contactref element="R11" pad="P$4"/>
+<contactref element="U5" pad="5"/>
+<wire x1="220.98" y1="2.54" x2="215.9" y2="7.62" width="0.2032" layer="1"/>
+<wire x1="215.9" y1="7.62" x2="213.36" y2="7.62" width="0.2032" layer="1"/>
+<wire x1="213.36" y1="7.62" x2="212.09" y2="8.89" width="0.2032" layer="1"/>
+<wire x1="212.09" y1="8.89" x2="212.09" y2="11.43" width="0.2032" layer="1"/>
+<wire x1="212.09" y1="11.43" x2="210.82" y2="12.7" width="0.2032" layer="1"/>
+<wire x1="210.82" y1="12.7" x2="210.82" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="210.82" y1="16.51" x2="210.82" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="210.82" y1="17.78" x2="207.645" y2="20.955" width="0.2032" layer="1"/>
+<wire x1="205.359" y1="20.955" x2="203.835" y2="22.479" width="0.2032" layer="1"/>
+<wire x1="203.835" y1="22.479" x2="203.835" y2="25.357" width="0.2032" layer="1"/>
+<wire x1="203.835" y1="25.357" x2="205.899" y2="27.421" width="0.2032" layer="1"/>
+<wire x1="207.645" y1="20.955" x2="205.359" y2="20.955" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS05I">
+<contactref element="U05I" pad="4"/>
+<contactref element="R11" pad="P$3"/>
+<contactref element="U5" pad="4"/>
+<wire x1="218.44" y1="2.54" x2="214.63" y2="6.35" width="0.2032" layer="1"/>
+<wire x1="214.63" y1="6.35" x2="211.455" y2="6.35" width="0.2032" layer="1"/>
+<wire x1="209.55" y1="11.43" x2="208.28" y2="12.7" width="0.2032" layer="1"/>
+<wire x1="208.28" y1="12.7" x2="208.28" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="211.455" y1="6.35" x2="209.55" y2="8.255" width="0.2032" layer="1"/>
+<wire x1="209.55" y1="8.255" x2="209.55" y2="11.43" width="0.2032" layer="1"/>
+<wire x1="208.28" y1="16.51" x2="208.28" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="208.28" y1="17.78" x2="207.01" y2="19.05" width="0.2032" layer="1"/>
+<wire x1="197.252" y1="19.05" x2="193.199" y2="23.103" width="0.2032" layer="1"/>
+<wire x1="207.01" y1="19.05" x2="197.252" y2="19.05" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS05O">
+<contactref element="U05O" pad="4"/>
+<contactref element="R11" pad="P$2"/>
+<contactref element="U5" pad="3"/>
+<wire x1="215.9" y1="2.54" x2="213.36" y2="5.08" width="0.2032" layer="1"/>
+<wire x1="213.36" y1="5.08" x2="208.915" y2="5.08" width="0.2032" layer="1"/>
+<wire x1="208.915" y1="5.08" x2="206.375" y2="7.62" width="0.2032" layer="1"/>
+<wire x1="206.375" y1="11.43" x2="205.74" y2="12.065" width="0.2032" layer="1"/>
+<wire x1="205.74" y1="12.065" x2="205.74" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="206.375" y1="7.62" x2="206.375" y2="11.43" width="0.2032" layer="1"/>
+<wire x1="205.74" y1="16.51" x2="204.47" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="204.47" y1="17.78" x2="194.945" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="194.945" y1="17.78" x2="190.754" y2="21.971" width="0.2032" layer="1"/>
+<wire x1="190.754" y1="21.971" x2="190.754" y2="24.976" width="0.2032" layer="1"/>
+<wire x1="190.754" y1="24.976" x2="193.199" y2="27.421" width="0.2032" layer="1"/>
+</signal>
+<signal name="SNS07I">
+<contactref element="R11" pad="P$7"/>
+<contactref element="U07I" pad="4"/>
+<contactref element="U5" pad="13"/>
+<wire x1="218.44" y1="10.16" x2="218.44" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="218.44" y1="16.51" x2="218.44" y2="22.944" width="0.2032" layer="1"/>
+<wire x1="218.44" y1="22.944" x2="218.599" y2="23.103" width="0.2032" layer="1"/>
 </signal>
 </signals>
 <mfgpreviewcolors>
@@ -20033,13 +20337,12 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <mfgpreviewcolor name="substratecolor" color="0xFF786E46"/>
 </mfgpreviewcolors>
 <errors>
-<approved hash="19,1,adb7530152d153fc"/>
-<approved hash="19,1,b761dfd2b4e023c8"/>
-<approved hash="19,1,74087bc918cf170e"/>
-<approved hash="19,1,4484b4ae1b6ee484"/>
-<approved hash="19,1,abf594e38b5008d5"/>
-<approved hash="19,1,8005702f40efbf05"/>
-<approved hash="19,1,c7dac7a7d9358a89"/>
+<approved hash="19,1,1567e9badd7727a2"/>
+<approved hash="19,1,e2cadf23a5952d27"/>
+<approved hash="19,1,0dbbff6e35abc176"/>
+<approved hash="19,1,f0461f8881159888"/>
+<approved hash="19,1,fe5e94129a25063a"/>
+<approved hash="19,1,eef3eefb6bfb6bf3"/>
 </errors>
 </board>
 </drawing>

--- a/PCB_files/Eagle_v0.2/easy_bee_counter.brd
+++ b/PCB_files/Eagle_v0.2/easy_bee_counter.brd
@@ -18297,8 +18297,8 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <wire x1="101.6" y1="27.305" x2="101.6" y2="25.908" width="0.6096" layer="1"/>
 <wire x1="101.6" y1="25.908" x2="99.187" y2="23.495" width="0.6096" layer="1"/>
 <wire x1="111.76" y1="10.795" x2="111.76" y2="13.335" width="0.6096" layer="16"/>
-<wire x1="111.76" y1="13.335" x2="114.935" y2="16.51" width="0.6096" layer="16"/>
-<wire x1="114.935" y1="16.51" x2="126.365" y2="16.51" width="0.6096" layer="16"/>
+<wire x1="123.19" y1="13.335" x2="111.76" y2="13.335" width="0.6096" layer="16"/>
+<wire x1="123.19" y1="13.335" x2="126.365" y2="16.51" width="0.6096" layer="16"/>
 <wire x1="144.78" y1="16.51" x2="142.875" y2="14.605" width="0.2032" layer="16"/>
 <wire x1="142.875" y1="14.605" x2="137.16" y2="14.605" width="0.2032" layer="16"/>
 <wire x1="137.16" y1="14.605" x2="135.255" y2="16.51" width="0.2032" layer="16"/>
@@ -18670,9 +18670,8 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <wire x1="124.46" y1="18.923" x2="124.46" y2="15.875" width="0.6096" layer="1"/>
 <wire x1="124.46" y1="15.875" x2="125.73" y2="14.605" width="0.6096" layer="1"/>
 <wire x1="125.73" y1="14.605" x2="126.365" y2="14.605" width="0.6096" layer="1"/>
-<wire x1="111.76" y1="8.255" x2="116.205" y2="8.255" width="0.2032" layer="16"/>
-<wire x1="116.205" y1="8.255" x2="122.555" y2="14.605" width="0.2032" layer="16"/>
-<wire x1="122.555" y1="14.605" x2="126.365" y2="14.605" width="0.2032" layer="16"/>
+<wire x1="111.76" y1="8.255" x2="120.015" y2="8.255" width="0.2032" layer="16"/>
+<wire x1="120.015" y1="8.255" x2="126.365" y2="14.605" width="0.2032" layer="16"/>
 <wire x1="111.76" y1="5.715" x2="111.76" y2="8.255" width="0.2032" layer="16"/>
 <wire x1="155.575" y1="10.16" x2="155.575" y2="11.43" width="0.2032" layer="1"/>
 <wire x1="155.575" y1="11.43" x2="151.13" y2="15.875" width="0.2032" layer="1"/>
@@ -19485,10 +19484,11 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <contactref element="U$45" pad="SCL"/>
 <wire x1="104.14" y1="5.715" x2="101.6" y2="8.255" width="0.2032" layer="1"/>
 <wire x1="101.6" y1="8.255" x2="101.6" y2="16.51" width="0.2032" layer="1"/>
-<wire x1="101.6" y1="19.685" x2="102.235" y2="20.32" width="0.2032" layer="1"/>
-<wire x1="114.3" y1="20.32" x2="115.57" y2="19.05" width="0.2032" layer="1"/>
-<wire x1="101.6" y1="16.51" x2="101.6" y2="19.685" width="0.2032" layer="1"/>
-<wire x1="102.235" y1="20.32" x2="114.3" y2="20.32" width="0.2032" layer="1"/>
+<wire x1="114.3" y1="20.32" x2="115.57" y2="19.05" width="0.2032" layer="16"/>
+<wire x1="101.6" y1="16.51" x2="101.6" y2="20.32" width="0.2032" layer="16"/>
+<wire x1="113.665" y1="20.955" x2="102.235" y2="20.955" width="0.2032" layer="1"/>
+<wire x1="101.6" y1="20.32" x2="102.235" y2="20.955" width="0.2032" layer="1"/>
+<wire x1="113.665" y1="20.955" x2="114.3" y2="20.32" width="0.2032" layer="1"/>
 <wire x1="115.57" y1="19.05" x2="116.84" y2="20.32" width="0.2032" layer="16"/>
 <wire x1="116.84" y1="20.32" x2="122.555" y2="20.32" width="0.2032" layer="16"/>
 <wire x1="122.555" y1="20.32" x2="123.825" y2="19.05" width="0.2032" layer="16"/>
@@ -19499,6 +19499,8 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <wire x1="127.635" y1="19.05" x2="137.795" y2="8.89" width="0.2032" layer="16"/>
 <wire x1="137.795" y1="8.89" x2="140.335" y2="6.35" width="0.2032" layer="1"/>
 <via x="137.795" y="8.89" extent="1-16" drill="0.3302"/>
+<via x="101.6" y="20.32" extent="1-16" drill="0.35"/>
+<via x="114.3" y="20.32" extent="1-16" drill="0.35"/>
 </signal>
 <signal name="SNS12O">
 <contactref element="R7" pad="P$8"/>
@@ -20069,10 +20071,10 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <wire x1="104.14" y1="13.335" x2="106.68" y2="13.335" width="0.2032" layer="16"/>
 <wire x1="107.95" y1="14.605" x2="107.95" y2="19.05" width="0.2032" layer="16"/>
 <wire x1="106.68" y1="13.335" x2="107.95" y2="14.605" width="0.2032" layer="16"/>
-<wire x1="107.95" y1="19.05" x2="107.95" y2="27.305" width="0.2032" layer="16"/>
-<wire x1="107.95" y1="27.305" x2="110.49" y2="29.845" width="0.2032" layer="16"/>
-<wire x1="110.49" y1="29.845" x2="121.92" y2="29.845" width="0.2032" layer="16"/>
-<wire x1="121.92" y1="29.845" x2="125.73" y2="26.035" width="0.2032" layer="16"/>
+<wire x1="107.95" y1="19.05" x2="107.95" y2="23.495" width="0.2032" layer="16"/>
+<wire x1="107.95" y1="23.495" x2="109.474" y2="25.019" width="0.2032" layer="16"/>
+<wire x1="124.714" y1="25.019" x2="125.73" y2="26.035" width="0.2032" layer="16"/>
+<wire x1="109.474" y1="25.019" x2="124.714" y2="25.019" width="0.2032" layer="16"/>
 </signal>
 <signal name="SDA">
 <contactref element="MS2" pad="17"/>
@@ -20095,10 +20097,10 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <contactref element="MS2" pad="9"/>
 <contactref element="J3" pad="1"/>
 <contactref element="U$45" pad="A4"/>
-<wire x1="98.54446875" y1="0.0254" x2="99.0346" y2="0.0254" width="0.2032" layer="1"/>
+<wire x1="97.1296" y1="0.0254" x2="99.0346" y2="0.0254" width="0.2032" layer="1"/>
 <wire x1="99.0346" y1="0.0254" x2="100.33" y2="-1.27" width="0.2032" layer="1"/>
-<wire x1="96.52" y1="1.27" x2="97.29986875" y2="1.27" width="0.2032" layer="1"/>
-<wire x1="97.29986875" y1="1.27" x2="98.54446875" y2="0.0254" width="0.2032" layer="1"/>
+<wire x1="96.52" y1="1.27" x2="96.52" y2="0.635" width="0.2032" layer="1"/>
+<wire x1="97.1296" y1="0.0254" x2="96.52" y2="0.635" width="0.2032" layer="1"/>
 <wire x1="96.52" y1="1.27" x2="97.79" y2="2.54" width="0.2032" layer="1"/>
 <wire x1="111.125" y1="2.54" x2="111.76" y2="1.905" width="0.2032" layer="1"/>
 <wire x1="97.79" y1="2.54" x2="111.125" y2="2.54" width="0.2032" layer="1"/>
@@ -20110,9 +20112,10 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <contactref element="U$45" pad="USB"/>
 <wire x1="94.361" y1="21.336" x2="95.25" y2="20.447" width="0.6096" layer="1"/>
 <wire x1="95.25" y1="20.447" x2="95.25" y2="19.05" width="0.6096" layer="1"/>
-<wire x1="95.25" y1="19.05" x2="94.0054" y2="17.8054" width="0.3048" layer="1"/>
-<wire x1="82.5754" y1="17.8054" x2="81.28" y2="16.51" width="0.3048" layer="1"/>
-<wire x1="94.0054" y1="17.8054" x2="82.5754" y2="17.8054" width="0.3048" layer="1"/>
+<wire x1="94.361" y1="21.336" x2="94.361" y2="20.701" width="0.2032" layer="1"/>
+<wire x1="94.361" y1="20.701" x2="93.98" y2="20.32" width="0.2032" layer="1"/>
+<wire x1="85.09" y1="20.32" x2="81.28" y2="16.51" width="0.2032" layer="1"/>
+<wire x1="93.98" y1="20.32" x2="85.09" y2="20.32" width="0.2032" layer="1"/>
 </signal>
 <signal name="SER3">
 <contactref element="U4" pad="10"/>
@@ -20132,20 +20135,17 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <wire x1="104.775" y1="19.05" x2="105.41" y2="19.05" width="0.2032" layer="1"/>
 <wire x1="102.87" y1="12.065" x2="102.87" y2="17.145" width="0.2032" layer="1"/>
 <wire x1="102.87" y1="17.145" x2="104.775" y2="19.05" width="0.2032" layer="1"/>
-<wire x1="105.41" y1="19.05" x2="105.41" y2="27.305" width="0.2032" layer="16"/>
-<wire x1="105.41" y1="27.305" x2="109.22" y2="31.115" width="0.2032" layer="16"/>
-<wire x1="109.22" y1="31.115" x2="127" y2="31.115" width="0.2032" layer="16"/>
-<wire x1="127" y1="31.115" x2="132.08" y2="26.035" width="0.2032" layer="16"/>
+<wire x1="105.41" y1="19.05" x2="105.41" y2="23.495" width="0.2032" layer="16"/>
+<wire x1="105.41" y1="23.495" x2="107.569" y2="25.654" width="0.2032" layer="16"/>
+<wire x1="119.634" y1="25.654" x2="121.92" y2="27.94" width="0.2032" layer="16"/>
+<wire x1="121.92" y1="27.94" x2="130.175" y2="27.94" width="0.2032" layer="16"/>
+<wire x1="130.175" y1="27.94" x2="132.08" y2="26.035" width="0.2032" layer="16"/>
+<wire x1="107.569" y1="25.654" x2="119.634" y2="25.654" width="0.2032" layer="16"/>
 </signal>
 <signal name="SRVO3">
 <contactref element="SERVO3" pad="3"/>
-<contactref element="MS2" pad="7"/>
-<wire x1="93.98" y1="0" x2="95.25" y2="-1.27" width="0.2032" layer="1"/>
-<wire x1="114.935" y1="4.445" x2="114.3" y2="3.81" width="0.2032" layer="16"/>
-<wire x1="128.905" y1="4.445" x2="129.54" y2="5.08" width="0.2032" layer="16"/>
-<wire x1="129.54" y1="5.08" x2="133.985" y2="5.08" width="0.2032" layer="16"/>
+<wire x1="133.985" y1="5.08" x2="129.54" y2="5.08" width="0.2032" layer="16"/>
 <wire x1="133.985" y1="5.08" x2="137.795" y2="1.27" width="0.2032" layer="16"/>
-<wire x1="114.935" y1="4.445" x2="128.905" y2="4.445" width="0.2032" layer="16"/>
 <wire x1="137.795" y1="1.27" x2="140.335" y2="1.27" width="0.2032" layer="16"/>
 <wire x1="140.335" y1="1.27" x2="144.3228" y2="5.2578" width="0.2032" layer="16"/>
 <wire x1="171.6278" y1="5.2578" x2="172.72" y2="6.35" width="0.2032" layer="16"/>
@@ -20156,12 +20156,23 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <wire x1="411.48" y1="14.605" x2="410.845" y2="15.24" width="0.2032" layer="1"/>
 <wire x1="410.845" y1="15.24" x2="409.194" y2="15.24" width="0.2032" layer="1"/>
 <wire x1="172.72" y1="6.35" x2="410.21" y2="6.35" width="0.2032" layer="16"/>
-<contactref element="U$45" pad="A2"/>
-<wire x1="91.44" y1="1.27" x2="92.71" y2="0" width="0.2032" layer="1"/>
-<wire x1="92.71" y1="0" x2="93.98" y2="0" width="0.2032" layer="1"/>
-<wire x1="92.71" y1="3.81" x2="91.44" y2="2.54" width="0.2032" layer="16"/>
-<wire x1="91.44" y1="2.54" x2="91.44" y2="1.27" width="0.2032" layer="16"/>
-<wire x1="114.3" y1="3.81" x2="92.71" y2="3.81" width="0.2032" layer="16"/>
+<contactref element="MS2" pad="19"/>
+<contactref element="U$45" pad="D5"/>
+<wire x1="129.54" y1="5.08" x2="129.54" y2="5.0574" width="0.2032" layer="16"/>
+<via x="129.54" y="5.0574" extent="1-16" drill="0.35"/>
+<wire x1="129.54" y1="5.0574" x2="127.6124" y2="6.985" width="0.2032" layer="1"/>
+<wire x1="127.6124" y1="6.985" x2="125.095" y2="6.985" width="0.2032" layer="1"/>
+<wire x1="99.06" y1="16.51" x2="99.06" y2="13.335" width="0.2032" layer="1"/>
+<wire x1="99.06" y1="13.335" x2="100.33" y2="12.065" width="0.2032" layer="1"/>
+<via x="100.33" y="12.065" extent="1-16" drill="0.35"/>
+<wire x1="100.33" y1="12.065" x2="106.68" y2="12.065" width="0.2032" layer="16"/>
+<wire x1="106.68" y1="12.065" x2="111.125" y2="16.51" width="0.2032" layer="16"/>
+<wire x1="111.125" y1="17.78" x2="112.395" y2="19.05" width="0.2032" layer="16"/>
+<wire x1="112.395" y1="19.05" x2="113.03" y2="19.05" width="0.2032" layer="16"/>
+<wire x1="111.125" y1="16.51" x2="111.125" y2="17.78" width="0.2032" layer="16"/>
+<wire x1="125.095" y1="6.985" x2="116.84" y2="15.24" width="0.2032" layer="1"/>
+<via x="116.84" y="15.24" extent="1-16" drill="0.35"/>
+<wire x1="116.84" y1="15.24" x2="113.03" y2="19.05" width="0.2032" layer="16"/>
 </signal>
 <signal name="SRVO2">
 <contactref element="MS2" pad="6"/>
@@ -20182,9 +20193,11 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <wire x1="173.355" y1="5.715" x2="415.925" y2="5.715" width="0.2032" layer="16"/>
 <contactref element="U$45" pad="A1"/>
 <wire x1="91.44" y1="0" x2="90.17" y2="0" width="0.2032" layer="1"/>
-<wire x1="90.17" y1="3.81" x2="88.9" y2="2.54" width="0.2032" layer="1"/>
+<wire x1="89.535" y1="3.175" x2="88.9" y2="2.54" width="0.2032" layer="1"/>
 <wire x1="88.9" y1="2.54" x2="88.9" y2="1.27" width="0.2032" layer="1"/>
-<wire x1="130.175" y1="3.81" x2="90.17" y2="3.81" width="0.2032" layer="1"/>
+<wire x1="130.175" y1="3.81" x2="122.555" y2="3.81" width="0.2032" layer="1"/>
+<wire x1="122.555" y1="3.81" x2="121.92" y2="3.175" width="0.2032" layer="1"/>
+<wire x1="121.92" y1="3.175" x2="89.535" y2="3.175" width="0.2032" layer="1"/>
 <wire x1="90.17" y1="0" x2="88.9" y2="1.27" width="0.2032" layer="1"/>
 </signal>
 <signal name="SRVO4">
@@ -20194,13 +20207,11 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <wire x1="96.52" y1="17.78" x2="97.79" y2="19.05" width="0.2032" layer="16"/>
 <wire x1="85.09" y1="17.78" x2="96.52" y2="17.78" width="0.2032" layer="16"/>
 <wire x1="83.82" y1="16.51" x2="84.455" y2="16.51" width="0.2032" layer="1"/>
-<wire x1="84.455" y1="16.51" x2="96.52" y2="4.445" width="0.2032" layer="1"/>
-<wire x1="96.52" y1="4.445" x2="114.3" y2="4.445" width="0.2032" layer="1"/>
-<wire x1="114.3" y1="4.445" x2="114.935" y2="5.08" width="0.2032" layer="1"/>
+<wire x1="84.455" y1="16.51" x2="97.155" y2="3.81" width="0.2032" layer="1"/>
+<wire x1="97.155" y1="3.81" x2="121.92" y2="3.81" width="0.2032" layer="1"/>
 <contactref element="SERVO4" pad="3"/>
-<wire x1="123.19" y1="5.08" x2="123.825" y2="5.715" width="0.2032" layer="1"/>
+<wire x1="121.92" y1="3.81" x2="123.825" y2="5.715" width="0.2032" layer="1"/>
 <via x="123.825" y="5.715" extent="1-16" drill="0.3302"/>
-<wire x1="114.935" y1="5.08" x2="123.19" y2="5.08" width="0.2032" layer="1"/>
 <wire x1="123.825" y1="5.715" x2="170.815" y2="5.715" width="0.2032" layer="16"/>
 <wire x1="170.815" y1="5.715" x2="172.085" y2="6.985" width="0.2032" layer="16"/>
 <wire x1="334.645" y1="6.985" x2="336.55" y2="8.89" width="0.2032" layer="16"/>
@@ -20212,19 +20223,12 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 </signal>
 <signal name="SRVO5">
 <contactref element="U$45" pad="D9"/>
-<contactref element="MS2" pad="24"/>
-<wire x1="93.98" y1="16.51" x2="95.885" y2="14.605" width="0.2032" layer="16"/>
-<wire x1="99.695" y1="14.605" x2="100.33" y2="15.24" width="0.2032" layer="16"/>
-<wire x1="100.33" y1="15.24" x2="100.33" y2="19.05" width="0.2032" layer="16"/>
-<wire x1="95.885" y1="14.605" x2="99.695" y2="14.605" width="0.2032" layer="16"/>
 <wire x1="93.98" y1="16.51" x2="93.98" y2="8.89" width="0.2032" layer="1"/>
 <wire x1="93.98" y1="8.89" x2="98.425" y2="4.445" width="0.2032" layer="16"/>
-<wire x1="98.425" y1="4.445" x2="114.3" y2="4.445" width="0.2032" layer="16"/>
+<wire x1="98.425" y1="4.445" x2="120.015" y2="4.445" width="0.2032" layer="16"/>
 <via x="93.98" y="8.89" extent="1-16" drill="0.3302"/>
-<wire x1="114.3" y1="4.445" x2="115.57" y2="5.715" width="0.2032" layer="16"/>
 <contactref element="SERVO5" pad="3"/>
-<wire x1="121.285" y1="5.715" x2="122.555" y2="6.985" width="0.2032" layer="16"/>
-<wire x1="115.57" y1="5.715" x2="121.285" y2="5.715" width="0.2032" layer="16"/>
+<wire x1="120.015" y1="4.445" x2="122.555" y2="6.985" width="0.2032" layer="16"/>
 <wire x1="122.555" y1="6.985" x2="170.815" y2="6.985" width="0.2032" layer="16"/>
 <wire x1="197.104" y1="9.906" x2="191.516" y2="9.906" width="0.2032" layer="16"/>
 <wire x1="191.516" y1="9.906" x2="191.135" y2="9.525" width="0.2032" layer="16"/>
@@ -20235,6 +20239,10 @@ Please make sure your boards conform to these design rules. 15mill between pads 
 <via x="170.815" y="6.985" extent="1-16" drill="0.35"/>
 <via x="190.5" y="8.89" extent="1-16" drill="0.35"/>
 <via x="172.72" y="8.89" extent="1-16" drill="0.35"/>
+<contactref element="MS2" pad="23"/>
+<wire x1="93.98" y1="16.51" x2="95.25" y2="17.78" width="0.2032" layer="1"/>
+<wire x1="101.6" y1="17.78" x2="102.87" y2="19.05" width="0.2032" layer="1"/>
+<wire x1="95.25" y1="17.78" x2="101.6" y2="17.78" width="0.2032" layer="1"/>
 </signal>
 <signal name="SRVO1">
 <contactref element="MS2" pad="5"/>

--- a/PCB_files/Eagle_v0.2/easy_bee_counter.sch
+++ b/PCB_files/Eagle_v0.2/easy_bee_counter.sch
@@ -29638,10 +29638,10 @@ https://www.mouser.com/ProductDetail/661-APSC6R3L561MH08S
 <text x="-195.58" y="1000.76" size="1.778" layer="91">Shift-IN</text>
 <text x="-195.58" y="993.14" size="1.778" layer="91">Shift-IN</text>
 <text x="-195.58" y="995.68" size="1.778" layer="91">Shift-IN</text>
+<text x="-274.32" y="998.22" size="1.778" layer="91" align="bottom-right">LED Power</text>
 <text x="-274.32" y="995.68" size="1.778" layer="91" align="bottom-right">LED Power</text>
-<text x="-274.32" y="993.14" size="1.778" layer="91" align="bottom-right">LED Power</text>
-<text x="-274.32" y="1003.3" size="1.778" layer="91" align="bottom-right">SCREW Term.</text>
-<text x="-274.32" y="1000.76" size="1.778" layer="91" align="bottom-right">SCREW Term.</text>
+<text x="-274.32" y="1008.38" size="1.778" layer="91" align="bottom-right">SCREW Term.</text>
+<text x="-274.32" y="1005.84" size="1.778" layer="91" align="bottom-right">SCREW Term.</text>
 <text x="-182.88" y="990.6" size="1.778" layer="91" align="bottom-right">SCREW Term.</text>
 <text x="-246.38" y="922.02" size="1.778" layer="91" align="bottom-right">SCREW Term.</text>
 <text x="-218.44" y="922.02" size="1.778" layer="91" align="bottom-right">SCREW Term.</text>
@@ -32173,11 +32173,9 @@ Thomas Hudson</text>
 </net>
 <net name="SCL" class="0">
 <segment>
-<label x="-271.78" y="1000.76" size="1.778" layer="95"/>
-<wire x1="-269.24" y1="1000.76" x2="-259.08" y2="1000.76" width="0.1524" layer="91"/>
-<wire x1="-259.08" y1="1000.76" x2="-259.08" y2="1005.84" width="0.1524" layer="91"/>
+<label x="-271.78" y="1005.84" size="1.778" layer="95"/>
+<wire x1="-269.24" y1="1005.84" x2="-254" y2="1005.84" width="0.1524" layer="91"/>
 <pinref part="MS2" gate="G$1" pin="GPIOSCL"/>
-<wire x1="-259.08" y1="1005.84" x2="-254" y2="1005.84" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="J4" gate="G$1" pin="2"/>
@@ -32721,11 +32719,9 @@ Thomas Hudson</text>
 </net>
 <net name="P1" class="0">
 <segment>
-<label x="-271.78" y="995.68" size="1.778" layer="95"/>
-<wire x1="-269.24" y1="995.68" x2="-261.62" y2="995.68" width="0.1524" layer="91"/>
-<wire x1="-261.62" y1="995.68" x2="-261.62" y2="998.22" width="0.1524" layer="91"/>
+<label x="-271.78" y="998.22" size="1.778" layer="95"/>
 <pinref part="MS2" gate="G$1" pin="GPIO9"/>
-<wire x1="-261.62" y1="998.22" x2="-254" y2="998.22" width="0.1524" layer="91"/>
+<wire x1="-269.24" y1="998.22" x2="-254" y2="998.22" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="Q7" gate="NMOS" pin="G"/>
@@ -32745,11 +32741,9 @@ Thomas Hudson</text>
 </net>
 <net name="SDA" class="0">
 <segment>
-<wire x1="-261.62" y1="1003.3" x2="-269.24" y2="1003.3" width="0.1524" layer="91"/>
-<label x="-271.78" y="1003.3" size="1.778" layer="95"/>
+<label x="-271.78" y="1008.38" size="1.778" layer="95"/>
 <pinref part="MS2" gate="G$1" pin="GPIOSDA"/>
-<wire x1="-261.62" y1="1003.3" x2="-261.62" y2="1008.38" width="0.1524" layer="91"/>
-<wire x1="-261.62" y1="1008.38" x2="-254" y2="1008.38" width="0.1524" layer="91"/>
+<wire x1="-269.24" y1="1008.38" x2="-254" y2="1008.38" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="J4" gate="G$1" pin="1"/>
@@ -32812,11 +32806,9 @@ Thomas Hudson</text>
 </net>
 <net name="P2" class="0">
 <segment>
-<label x="-271.78" y="993.14" size="1.778" layer="95"/>
+<label x="-271.78" y="995.68" size="1.778" layer="95"/>
 <pinref part="MS2" gate="G$1" pin="GPIO10"/>
-<wire x1="-254" y1="995.68" x2="-259.08" y2="995.68" width="0.1524" layer="91"/>
-<wire x1="-259.08" y1="995.68" x2="-259.08" y2="993.14" width="0.1524" layer="91"/>
-<wire x1="-259.08" y1="993.14" x2="-269.24" y2="993.14" width="0.1524" layer="91"/>
+<wire x1="-254" y1="995.68" x2="-269.24" y2="995.68" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <wire x1="-213.36" y1="1054.1" x2="-208.28" y2="1054.1" width="0.1524" layer="91"/>
@@ -32841,14 +32833,14 @@ Thomas Hudson</text>
 <label x="-347.98" y="812.8" size="1.778" layer="95" rot="R90"/>
 </segment>
 <segment>
-<pinref part="MS2" gate="G$1" pin="GPIOA2"/>
-<wire x1="-210.82" y1="985.52" x2="-185.42" y2="985.52" width="0.1524" layer="91"/>
-<label x="-200.66" y="985.52" size="1.778" layer="95"/>
+<label x="-271.78" y="1003.3" size="1.778" layer="95"/>
+<pinref part="MS2" gate="G$1" pin="GPIO5"/>
+<wire x1="-254" y1="1003.3" x2="-269.24" y2="1003.3" width="0.1524" layer="91"/>
 </segment>
 <segment>
-<pinref part="U$45" gate="G$1" pin="A2"/>
-<wire x1="-246.38" y1="1051.56" x2="-254" y2="1051.56" width="0.1524" layer="91"/>
-<label x="-254" y="1051.56" size="1.778" layer="95"/>
+<label x="-213.36" y="1043.94" size="1.778" layer="95"/>
+<pinref part="U$45" gate="G$1" pin="D5"/>
+<wire x1="-213.36" y1="1043.94" x2="-203.2" y2="1043.94" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="SRVO2" class="0">
@@ -32892,9 +32884,9 @@ Thomas Hudson</text>
 <label x="-213.36" y="1049.02" size="1.778" layer="95"/>
 </segment>
 <segment>
-<pinref part="MS2" gate="G$1" pin="GPIO12"/>
-<wire x1="-254" y1="990.6" x2="-269.24" y2="990.6" width="0.1524" layer="91"/>
-<label x="-271.78" y="990.6" size="1.778" layer="95"/>
+<label x="-271.78" y="993.14" size="1.778" layer="95"/>
+<pinref part="MS2" gate="G$1" pin="GPIO11"/>
+<wire x1="-254" y1="993.14" x2="-269.24" y2="993.14" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="SERVO5" gate="A" pin="3"/>

--- a/PCB_files/Eagle_v0.2/easy_bee_counter.sch
+++ b/PCB_files/Eagle_v0.2/easy_bee_counter.sch
@@ -3,7 +3,7 @@
 <eagle version="9.6.0">
 <drawing>
 <settings>
-<setting alwaysvectorfont="no"/>
+<setting alwaysvectorfont="yes"/>
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
@@ -31750,21 +31750,29 @@ Thomas Hudson</text>
 <net name="SNS16O" class="0">
 <segment>
 <wire x1="-50.8" y1="756.92" x2="-50.8" y2="871.22" width="0.1524" layer="91"/>
-<wire x1="-50.8" y1="871.22" x2="-175.26" y2="871.22" width="0.1524" layer="91"/>
+<wire x1="-50.8" y1="871.22" x2="-91.44" y2="871.22" width="0.1524" layer="91"/>
 <pinref part="R6" gate="G$1" pin="8"/>
 <label x="-142.24" y="871.22" size="1.778" layer="95"/>
 <pinref part="U3" gate="U1" pin="B"/>
+<wire x1="-91.44" y1="871.22" x2="-175.26" y2="871.22" width="0.1524" layer="91"/>
 <wire x1="-50.8" y1="756.92" x2="-27.94" y2="756.92" width="0.1524" layer="91"/>
+<pinref part="U16O" gate="G$1" pin="E"/>
+<wire x1="-91.44" y1="878.84" x2="-91.44" y2="871.22" width="0.1524" layer="91"/>
+<junction x="-91.44" y="871.22"/>
 </segment>
 </net>
 <net name="SNS16I" class="0">
 <segment>
 <wire x1="-48.26" y1="873.76" x2="-48.26" y2="754.38" width="0.1524" layer="91"/>
-<wire x1="-175.26" y1="873.76" x2="-48.26" y2="873.76" width="0.1524" layer="91"/>
+<wire x1="-175.26" y1="873.76" x2="-109.22" y2="873.76" width="0.1524" layer="91"/>
 <pinref part="R6" gate="G$1" pin="9"/>
 <label x="-142.24" y="873.76" size="1.778" layer="95"/>
 <pinref part="U3" gate="U1" pin="A"/>
+<wire x1="-109.22" y1="873.76" x2="-48.26" y2="873.76" width="0.1524" layer="91"/>
 <wire x1="-48.26" y1="754.38" x2="-27.94" y2="754.38" width="0.1524" layer="91"/>
+<pinref part="U16I" gate="G$1" pin="E"/>
+<wire x1="-109.22" y1="878.84" x2="-109.22" y2="873.76" width="0.1524" layer="91"/>
+<junction x="-109.22" y="873.76"/>
 </segment>
 </net>
 <net name="SNS15O" class="0">
@@ -31834,11 +31842,15 @@ Thomas Hudson</text>
 <net name="SNS20O" class="0">
 <segment>
 <wire x1="-48.26" y1="919.48" x2="-48.26" y2="1038.86" width="0.1524" layer="91"/>
-<wire x1="-48.26" y1="1038.86" x2="-172.72" y2="1038.86" width="0.1524" layer="91"/>
+<wire x1="-48.26" y1="1038.86" x2="-91.44" y2="1038.86" width="0.1524" layer="91"/>
 <pinref part="R5" gate="G$1" pin="8"/>
 <label x="-142.24" y="1038.86" size="1.778" layer="95"/>
 <pinref part="U2" gate="U1" pin="B"/>
+<wire x1="-91.44" y1="1038.86" x2="-172.72" y2="1038.86" width="0.1524" layer="91"/>
 <wire x1="-48.26" y1="919.48" x2="-30.48" y2="919.48" width="0.1524" layer="91"/>
+<pinref part="U20O" gate="G$1" pin="E"/>
+<wire x1="-91.44" y1="1046.48" x2="-91.44" y2="1038.86" width="0.1524" layer="91"/>
+<junction x="-91.44" y="1038.86"/>
 </segment>
 </net>
 <net name="SNS19O" class="0">
@@ -31937,7 +31949,8 @@ Thomas Hudson</text>
 </net>
 <net name="SNS24O" class="0">
 <segment>
-<wire x1="-144.78" y1="1188.72" x2="-50.8" y2="1188.72" width="0.1524" layer="91"/>
+<wire x1="-144.78" y1="1188.72" x2="-91.44" y2="1188.72" width="0.1524" layer="91"/>
+<wire x1="-91.44" y1="1188.72" x2="-50.8" y2="1188.72" width="0.1524" layer="91"/>
 <wire x1="-50.8" y1="1074.42" x2="-50.8" y2="1188.72" width="0.1524" layer="91"/>
 <pinref part="R2" gate="G$1" pin="8"/>
 <wire x1="-144.78" y1="1181.1" x2="-144.78" y2="1188.72" width="0.1524" layer="91"/>
@@ -31945,11 +31958,15 @@ Thomas Hudson</text>
 <label x="-137.16" y="1188.72" size="1.778" layer="95"/>
 <pinref part="U1" gate="U1" pin="B"/>
 <wire x1="-50.8" y1="1074.42" x2="-30.48" y2="1074.42" width="0.1524" layer="91"/>
+<pinref part="U24O" gate="G$1" pin="E"/>
+<wire x1="-91.44" y1="1196.34" x2="-91.44" y2="1188.72" width="0.1524" layer="91"/>
+<junction x="-91.44" y="1188.72"/>
 </segment>
 </net>
 <net name="SNS23O" class="0">
 <segment>
-<wire x1="-152.4" y1="1155.7" x2="-55.88" y2="1155.7" width="0.1524" layer="91"/>
+<wire x1="-152.4" y1="1155.7" x2="-91.44" y2="1155.7" width="0.1524" layer="91"/>
+<wire x1="-91.44" y1="1155.7" x2="-55.88" y2="1155.7" width="0.1524" layer="91"/>
 <wire x1="-55.88" y1="1079.5" x2="-55.88" y2="1155.7" width="0.1524" layer="91"/>
 <pinref part="R2" gate="G$1" pin="6"/>
 <wire x1="-152.4" y1="1155.7" x2="-152.4" y2="1176.02" width="0.1524" layer="91"/>
@@ -31957,18 +31974,25 @@ Thomas Hudson</text>
 <label x="-137.16" y="1155.7" size="1.778" layer="95"/>
 <pinref part="U1" gate="U1" pin="D"/>
 <wire x1="-55.88" y1="1079.5" x2="-30.48" y2="1079.5" width="0.1524" layer="91"/>
+<pinref part="U23O" gate="G$1" pin="E"/>
+<wire x1="-91.44" y1="1163.32" x2="-91.44" y2="1155.7" width="0.1524" layer="91"/>
+<junction x="-91.44" y="1155.7"/>
 </segment>
 </net>
 <net name="SNS23I" class="0">
 <segment>
 <wire x1="-53.34" y1="1158.24" x2="-53.34" y2="1076.96" width="0.1524" layer="91"/>
-<wire x1="-53.34" y1="1158.24" x2="-149.86" y2="1158.24" width="0.1524" layer="91"/>
+<wire x1="-53.34" y1="1158.24" x2="-109.22" y2="1158.24" width="0.1524" layer="91"/>
 <pinref part="R2" gate="G$1" pin="7"/>
+<wire x1="-109.22" y1="1158.24" x2="-149.86" y2="1158.24" width="0.1524" layer="91"/>
 <wire x1="-170.18" y1="1178.56" x2="-149.86" y2="1178.56" width="0.1524" layer="91"/>
 <wire x1="-149.86" y1="1178.56" x2="-149.86" y2="1158.24" width="0.1524" layer="91"/>
 <label x="-137.16" y="1158.24" size="1.778" layer="95"/>
 <pinref part="U1" gate="U1" pin="C"/>
 <wire x1="-53.34" y1="1076.96" x2="-30.48" y2="1076.96" width="0.1524" layer="91"/>
+<pinref part="U23I" gate="G$1" pin="E"/>
+<wire x1="-109.22" y1="1163.32" x2="-109.22" y2="1158.24" width="0.1524" layer="91"/>
+<junction x="-109.22" y="1158.24"/>
 </segment>
 </net>
 <net name="SNS21I" class="0">
@@ -32456,23 +32480,31 @@ Thomas Hudson</text>
 <net name="SNS20I" class="0">
 <segment>
 <wire x1="-45.72" y1="1041.4" x2="-45.72" y2="916.94" width="0.1524" layer="91"/>
-<wire x1="-45.72" y1="1041.4" x2="-172.72" y2="1041.4" width="0.1524" layer="91"/>
+<wire x1="-45.72" y1="1041.4" x2="-109.22" y2="1041.4" width="0.1524" layer="91"/>
 <pinref part="R5" gate="G$1" pin="9"/>
 <label x="-142.24" y="1041.4" size="1.778" layer="95"/>
 <pinref part="U2" gate="U1" pin="A"/>
+<wire x1="-109.22" y1="1041.4" x2="-172.72" y2="1041.4" width="0.1524" layer="91"/>
 <wire x1="-45.72" y1="916.94" x2="-30.48" y2="916.94" width="0.1524" layer="91"/>
+<pinref part="U20I" gate="G$1" pin="E"/>
+<wire x1="-109.22" y1="1046.48" x2="-109.22" y2="1041.4" width="0.1524" layer="91"/>
+<junction x="-109.22" y="1041.4"/>
 </segment>
 </net>
 <net name="SNS24I" class="0">
 <segment>
 <wire x1="-48.26" y1="1191.26" x2="-48.26" y2="1071.88" width="0.1524" layer="91"/>
-<wire x1="-48.26" y1="1191.26" x2="-147.32" y2="1191.26" width="0.1524" layer="91"/>
+<wire x1="-48.26" y1="1191.26" x2="-109.22" y2="1191.26" width="0.1524" layer="91"/>
 <pinref part="R2" gate="G$1" pin="9"/>
+<wire x1="-109.22" y1="1191.26" x2="-147.32" y2="1191.26" width="0.1524" layer="91"/>
 <wire x1="-170.18" y1="1183.64" x2="-147.32" y2="1183.64" width="0.1524" layer="91"/>
 <wire x1="-147.32" y1="1183.64" x2="-147.32" y2="1191.26" width="0.1524" layer="91"/>
 <label x="-137.16" y="1191.26" size="1.778" layer="95"/>
 <pinref part="U1" gate="U1" pin="A"/>
 <wire x1="-48.26" y1="1071.88" x2="-30.48" y2="1071.88" width="0.1524" layer="91"/>
+<pinref part="U24I" gate="G$1" pin="E"/>
+<wire x1="-109.22" y1="1196.34" x2="-109.22" y2="1191.26" width="0.1524" layer="91"/>
+<junction x="-109.22" y="1191.26"/>
 </segment>
 </net>
 <net name="PWR_13-24" class="0">
@@ -32514,6 +32546,7 @@ Thomas Hudson</text>
 <pinref part="U5" gate="U1" pin="QH"/>
 <wire x1="5.08" y1="436.88" x2="-5.08" y2="436.88" width="0.1524" layer="91"/>
 <label x="5.08" y="274.32" size="1.778" layer="95"/>
+<label x="5.08" y="360.68" size="1.778" layer="95"/>
 </segment>
 </net>
 <net name="SER2" class="0">
@@ -32524,19 +32557,20 @@ Thomas Hudson</text>
 <pinref part="U4" gate="U1" pin="QH"/>
 <wire x1="-7.62" y1="591.82" x2="0" y2="591.82" width="0.1524" layer="91"/>
 <label x="2.54" y="449.58" size="1.778" layer="95"/>
+<label x="0" y="500.38" size="1.778" layer="95"/>
 </segment>
 </net>
-<net name="SER3" class="0">
+<net name="SER4" class="0">
 <segment>
 <pinref part="U3" gate="U1" pin="SER"/>
 <wire x1="-7.62" y1="764.54" x2="2.54" y2="764.54" width="0.1524" layer="91"/>
 <wire x1="2.54" y1="764.54" x2="2.54" y2="929.64" width="0.1524" layer="91"/>
 <pinref part="U2" gate="U1" pin="QH"/>
 <wire x1="2.54" y1="929.64" x2="-10.16" y2="929.64" width="0.1524" layer="91"/>
-<label x="5.08" y="769.62" size="1.778" layer="95"/>
+<label x="2.54" y="802.64" size="1.778" layer="95" rot="R90"/>
 </segment>
 </net>
-<net name="SER4" class="0">
+<net name="SER5" class="0">
 <segment>
 <pinref part="U2" gate="U1" pin="SER"/>
 <wire x1="-10.16" y1="927.1" x2="0" y2="927.1" width="0.1524" layer="91"/>
@@ -32765,7 +32799,7 @@ Thomas Hudson</text>
 <pinref part="U$45" gate="G$1" pin="USB"/>
 </segment>
 </net>
-<net name="N$28" class="0">
+<net name="SER3" class="0">
 <segment>
 <pinref part="U4" gate="U1" pin="SER"/>
 <wire x1="-7.62" y1="589.28" x2="2.54" y2="589.28" width="0.1524" layer="91"/>
@@ -32802,11 +32836,6 @@ Thomas Hudson</text>
 </net>
 <net name="SRVO3" class="0">
 <segment>
-<pinref part="U$45" gate="G$1" pin="A3"/>
-<wire x1="-246.38" y1="1049.02" x2="-254" y2="1049.02" width="0.1524" layer="91"/>
-<label x="-254" y="1049.02" size="1.778" layer="95"/>
-</segment>
-<segment>
 <pinref part="SERVO3" gate="A" pin="3"/>
 <wire x1="-347.98" y1="830.58" x2="-347.98" y2="807.72" width="0.1524" layer="91"/>
 <label x="-347.98" y="812.8" size="1.778" layer="95" rot="R90"/>
@@ -32816,13 +32845,13 @@ Thomas Hudson</text>
 <wire x1="-210.82" y1="985.52" x2="-185.42" y2="985.52" width="0.1524" layer="91"/>
 <label x="-200.66" y="985.52" size="1.778" layer="95"/>
 </segment>
-</net>
-<net name="SRVO2" class="0">
 <segment>
 <pinref part="U$45" gate="G$1" pin="A2"/>
 <wire x1="-246.38" y1="1051.56" x2="-254" y2="1051.56" width="0.1524" layer="91"/>
 <label x="-254" y="1051.56" size="1.778" layer="95"/>
 </segment>
+</net>
+<net name="SRVO2" class="0">
 <segment>
 <pinref part="MS2" gate="G$1" pin="GPIOA1"/>
 <wire x1="-210.82" y1="982.98" x2="-185.42" y2="982.98" width="0.1524" layer="91"/>
@@ -32832,6 +32861,11 @@ Thomas Hudson</text>
 <pinref part="SERVO2" gate="A" pin="3"/>
 <wire x1="-335.28" y1="830.58" x2="-335.28" y2="807.72" width="0.1524" layer="91"/>
 <label x="-335.28" y="812.8" size="1.778" layer="95" rot="R90"/>
+</segment>
+<segment>
+<pinref part="U$45" gate="G$1" pin="A1"/>
+<wire x1="-246.38" y1="1054.1" x2="-254" y2="1054.1" width="0.1524" layer="91"/>
+<label x="-254" y="1054.1" size="1.778" layer="95"/>
 </segment>
 </net>
 <net name="SRVO4" class="0">
@@ -32870,11 +32904,6 @@ Thomas Hudson</text>
 </net>
 <net name="SRVO1" class="0">
 <segment>
-<pinref part="U$45" gate="G$1" pin="A1"/>
-<wire x1="-246.38" y1="1054.1" x2="-254" y2="1054.1" width="0.1524" layer="91"/>
-<label x="-254" y="1054.1" size="1.778" layer="95"/>
-</segment>
-<segment>
 <pinref part="MS2" gate="G$1" pin="GPIOA0"/>
 <wire x1="-210.82" y1="980.44" x2="-185.42" y2="980.44" width="0.1524" layer="91"/>
 <label x="-200.66" y="980.44" size="1.778" layer="95"/>
@@ -32883,6 +32912,11 @@ Thomas Hudson</text>
 <pinref part="SERVO1" gate="A" pin="3"/>
 <wire x1="-322.58" y1="830.58" x2="-322.58" y2="807.72" width="0.1524" layer="91"/>
 <label x="-322.58" y="812.8" size="1.778" layer="95" rot="R90"/>
+</segment>
+<segment>
+<pinref part="U$45" gate="G$1" pin="A(0)"/>
+<wire x1="-246.38" y1="1056.64" x2="-254" y2="1056.64" width="0.1524" layer="91"/>
+<label x="-254" y="1056.64" size="1.778" layer="95"/>
 </segment>
 </net>
 <net name="SNS02O" class="0">
@@ -33057,15 +33091,15 @@ Thomas Hudson</text>
 <approved hash="101,1,-220.98,731.52,U$59,6,,,,"/>
 <approved hash="101,1,-304.8,690.88,U$60,1,,,,"/>
 <approved hash="101,1,-292.1,690.88,U$61,1,,,,"/>
-<approved hash="202,1,-10.16,1097.28,U1,!QH,,,,"/>
-<approved hash="202,1,-10.16,1092.2,U1,SER,,,,"/>
-<approved hash="104,1,-10.16,1079.5,U1,VCC,3.3V,,,"/>
-<approved hash="202,1,-10.16,942.34,U2,!QH,,,,"/>
-<approved hash="104,1,-10.16,924.56,U2,VCC,3.3V,,,"/>
-<approved hash="202,1,-7.62,767.08,U3,!QH,,,,"/>
-<approved hash="104,1,-7.62,749.3,U3,VCC,3.3V,,,"/>
-<approved hash="202,1,-7.62,604.52,U4,!QH,,,,"/>
-<approved hash="104,1,-7.62,586.74,U4,VCC,3.3V,,,"/>
+<approved hash="202,1,-10.16,1087.12,U1,!QH,,,,"/>
+<approved hash="202,1,-10.16,1082.04,U1,SER,,,,"/>
+<approved hash="104,1,-10.16,1069.34,U1,VCC,3.3V,,,"/>
+<approved hash="202,1,-10.16,932.18,U2,!QH,,,,"/>
+<approved hash="104,1,-10.16,914.4,U2,VCC,3.3V,,,"/>
+<approved hash="202,1,-7.62,769.62,U3,!QH,,,,"/>
+<approved hash="104,1,-7.62,751.84,U3,VCC,3.3V,,,"/>
+<approved hash="202,1,-7.62,594.36,U4,!QH,,,,"/>
+<approved hash="104,1,-7.62,576.58,U4,VCC,3.3V,,,"/>
 <approved hash="202,1,-5.08,439.42,U5,!QH,,,,"/>
 <approved hash="104,1,-5.08,421.64,U5,VCC,3.3V,,,"/>
 <approved hash="202,1,-5.08,274.32,U6,!QH,,,,"/>
@@ -33073,11 +33107,11 @@ Thomas Hudson</text>
 <approved hash="202,1,-210.82,970.28,MS2,!RESET,,,,"/>
 <approved hash="117,1,-210.82,972.82,3V,,,,,"/>
 <approved hash="117,1,-254,980.44,VBAT,,,,,"/>
-<approved hash="113,1,-372.053,834.586,SERVO5,,,,,"/>
-<approved hash="113,1,-359.353,834.586,SERVO4,,,,,"/>
-<approved hash="113,1,-346.653,834.586,SERVO3,,,,,"/>
-<approved hash="113,1,-333.953,834.586,SERVO2,,,,,"/>
-<approved hash="113,1,-321.253,834.586,SERVO1,,,,,"/>
+<approved hash="113,1,-372.279,834.521,SERVO5,,,,,"/>
+<approved hash="113,1,-359.579,834.521,SERVO4,,,,,"/>
+<approved hash="113,1,-346.879,834.521,SERVO3,,,,,"/>
+<approved hash="113,1,-334.179,834.521,SERVO2,,,,,"/>
+<approved hash="113,1,-321.479,834.521,SERVO1,,,,,"/>
 </errors>
 </schematic>
 </drawing>

--- a/PCB_files/Eagle_v0.2/easy_bee_counter.sch
+++ b/PCB_files/Eagle_v0.2/easy_bee_counter.sch
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="9.4.2">
+<eagle version="9.6.0">
 <drawing>
 <settings>
-<setting alwaysvectorfont="yes"/>
+<setting alwaysvectorfont="no"/>
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
@@ -1113,158 +1113,6 @@ Warning: This is the KIT version of this package. This package has a smaller dia
 <device name="38MILL" package="1X01-40MILL">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-</devicesets>
-</library>
-<library name="QRE1113">
-<packages>
-<package name="DIP400W50P180L360H200Q4">
-<wire x1="-1.8" y1="-1.45" x2="-1.8" y2="1.45" width="0.127" layer="51"/>
-<wire x1="-1.8" y1="1.45" x2="1.8" y2="1.45" width="0.127" layer="51"/>
-<wire x1="1.8" y1="1.45" x2="1.8" y2="-1.45" width="0.127" layer="51"/>
-<wire x1="1.8" y1="-1.45" x2="-1.8" y2="-1.45" width="0.127" layer="51"/>
-<text x="-2.07676875" y="3.075759375" size="1.271940625" layer="25">&gt;NAME</text>
-<text x="-2.08306875" y="-3.581009375" size="1.2732" layer="27" align="top-left">&gt;VALUE</text>
-<wire x1="1.8" y1="1.45" x2="1.8" y2="-1.45" width="0.0508" layer="21"/>
-<wire x1="-1.8" y1="-1.45" x2="-1.8" y2="0.6118" width="0.0508" layer="21"/>
-<wire x1="-2.05" y1="2.84" x2="-2.05" y2="-2.84" width="0.05" layer="39"/>
-<wire x1="-2.05" y1="-2.84" x2="2.05" y2="-2.84" width="0.05" layer="39"/>
-<wire x1="2.05" y1="-2.84" x2="2.05" y2="2.84" width="0.05" layer="39"/>
-<wire x1="2.05" y1="2.84" x2="-2.05" y2="2.84" width="0.05" layer="39"/>
-<circle x="-2.4" y="2.2" radius="0.0508" width="0.2" layer="21"/>
-<circle x="-2.4" y="2.2" radius="0.1" width="0.2" layer="51"/>
-<pad name="1" x="-0.9" y="2" drill="0.78" shape="square" rot="R270" stop="no"/>
-<pad name="4" x="0.9" y="2" drill="0.78" diameter="1.524" rot="R270" stop="no"/>
-<pad name="2" x="-0.9" y="-2" drill="0.78" diameter="1.524" rot="R270" stop="no"/>
-<pad name="3" x="0.9" y="-2" drill="0.78" diameter="1.524" rot="R270" stop="no"/>
-<polygon width="0.127" layer="29">
-<vertex x="-0.9271" y="1.6764" curve="-90.012891"/>
-<vertex x="-1.2319" y="2.0117" curve="-90"/>
-<vertex x="-0.9017" y="2.3266" curve="-90"/>
-<vertex x="-0.5741" y="1.9838" curve="-90.012967"/>
-</polygon>
-<rectangle x1="-1.5494" y1="1.3589" x2="-0.254" y2="2.6416" layer="30"/>
-<polygon width="0.127" layer="30">
-<vertex x="0.9677" y="1.2954" curve="-90"/>
-<vertex x="0.2033" y="1.9584" curve="-90.011749"/>
-<vertex x="0.8509" y="2.7052" curve="-90"/>
-<vertex x="1.5977" y="2.0447" curve="-90.024193"/>
-</polygon>
-<polygon width="0.127" layer="30">
-<vertex x="-0.8611" y="-2.7051" curve="-90"/>
-<vertex x="-1.6128" y="-2.0294" curve="-90.011749"/>
-<vertex x="-0.9017" y="-1.2953" curve="-90"/>
-<vertex x="-0.193" y="-1.9939" curve="-90.024193"/>
-</polygon>
-<polygon width="0.127" layer="30">
-<vertex x="0.9042" y="-2.7051" curve="-90"/>
-<vertex x="0.2033" y="-2.0421" curve="-90.011749"/>
-<vertex x="0.8636" y="-1.2953" curve="-90"/>
-<vertex x="1.6104" y="-1.9812" curve="-90.024193"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="0.8763" y="1.6764" curve="-90.012891"/>
-<vertex x="0.5715" y="2.0117" curve="-90"/>
-<vertex x="0.9017" y="2.3266" curve="-90"/>
-<vertex x="1.2293" y="1.9838" curve="-90.012967"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="-0.9144" y="-2.3241" curve="-90.012891"/>
-<vertex x="-1.2319" y="-1.9888" curve="-90"/>
-<vertex x="-0.889" y="-1.6739" curve="-90"/>
-<vertex x="-0.5614" y="-2.0167" curve="-90.012967"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="0.8763" y="-2.3241" curve="-90.012891"/>
-<vertex x="0.5715" y="-1.9888" curve="-90"/>
-<vertex x="0.9017" y="-1.6739" curve="-90"/>
-<vertex x="1.2293" y="-2.0167" curve="-90.012967"/>
-</polygon>
-<wire x1="-1.8034" y1="0.6096" x2="-1.27" y2="1.27" width="0.0508" layer="21"/>
-</package>
-<package name="QRE1113">
-<wire x1="1.35" y1="1.7" x2="-1.35" y2="1.7" width="0.127" layer="51"/>
-<wire x1="-1.35" y1="1.7" x2="-1.35" y2="-1.7" width="0.127" layer="51"/>
-<wire x1="-1.35" y1="-1.7" x2="1.35" y2="-1.7" width="0.127" layer="51"/>
-<wire x1="1.35" y1="-1.7" x2="1.35" y2="1.7" width="0.127" layer="51"/>
-<wire x1="1.627" y1="1.427" x2="1.7" y2="1.427" width="0.2032" layer="21"/>
-<wire x1="1.7" y1="1.427" x2="1.7" y2="-1.4" width="0.2032" layer="21"/>
-<wire x1="1.7" y1="-1.4" x2="1.654" y2="-1.4" width="0.2032" layer="21"/>
-<wire x1="-1.424" y1="1.37" x2="-1.7" y2="1.1" width="0.2032" layer="21"/>
-<wire x1="-1.7" y1="1.1" x2="-1.7" y2="-1.4" width="0.2032" layer="21"/>
-<wire x1="-1.7" y1="-1.4" x2="-1.627" y2="-1.4" width="0.2032" layer="21"/>
-<smd name="1" x="-0.9" y="1.8" dx="1.2" dy="0.6" layer="1" rot="R270"/>
-<smd name="2" x="-0.9" y="-1.8" dx="1.2" dy="0.6" layer="1" rot="R270"/>
-<smd name="3" x="0.9" y="-1.8" dx="1.2" dy="0.6" layer="1" rot="R270"/>
-<smd name="4" x="0.9" y="1.8" dx="1.2" dy="0.6" layer="1" rot="R270"/>
-</package>
-</packages>
-<symbols>
-<symbol name="QRE1113-1">
-<wire x1="-5.08" y1="2.54" x2="-5.08" y2="-5.08" width="0.254" layer="94"/>
-<wire x1="-5.08" y1="-5.08" x2="-2.54" y2="-5.08" width="0.254" layer="94"/>
-<wire x1="-2.54" y1="-5.08" x2="5.08" y2="-5.08" width="0.254" layer="94"/>
-<wire x1="5.08" y1="-5.08" x2="7.62" y2="-5.08" width="0.254" layer="94"/>
-<wire x1="7.62" y1="-5.08" x2="7.62" y2="2.54" width="0.254" layer="94"/>
-<wire x1="7.62" y1="2.54" x2="5.08" y2="2.54" width="0.254" layer="94"/>
-<wire x1="5.08" y1="2.54" x2="-2.54" y2="2.54" width="0.254" layer="94"/>
-<wire x1="-2.54" y1="2.54" x2="-5.08" y2="2.54" width="0.254" layer="94"/>
-<wire x1="-2.54" y1="2.54" x2="0" y2="0" width="0.254" layer="94"/>
-<wire x1="0" y1="0" x2="0" y2="-2.54" width="0.254" layer="94"/>
-<wire x1="0" y1="-2.54" x2="-1.524" y2="-4.064" width="0.254" layer="94"/>
-<wire x1="-1.524" y1="-4.064" x2="-2.54" y2="-5.08" width="0.254" layer="94"/>
-<wire x1="0" y1="0" x2="0" y2="1.27" width="0.254" layer="94"/>
-<wire x1="0" y1="-2.54" x2="0" y2="-4.064" width="0.254" layer="94"/>
-<wire x1="5.08" y1="2.54" x2="5.08" y2="-2.54" width="0.254" layer="94"/>
-<wire x1="5.08" y1="-2.54" x2="5.08" y2="-5.08" width="0.254" layer="94"/>
-<wire x1="3.81" y1="-2.54" x2="5.08" y2="-2.54" width="0.254" layer="94"/>
-<wire x1="5.08" y1="-2.54" x2="6.604" y2="-2.54" width="0.254" layer="94"/>
-<wire x1="-1.524" y1="-4.064" x2="-0.508" y2="-4.064" width="0.254" layer="94"/>
-<wire x1="-1.524" y1="-4.064" x2="-1.524" y2="-3.048" width="0.254" layer="94"/>
-<text x="-1.778" y="3.048" size="1.778" layer="96">&gt;Value</text>
-<text x="-1.27" y="-7.112" size="1.778" layer="95">&gt;Name</text>
-<pin name="A" x="5.08" y="5.08" visible="off" length="short" rot="R270"/>
-<pin name="E" x="-2.54" y="-7.62" visible="off" length="short" rot="R90"/>
-<pin name="C" x="-2.54" y="5.08" visible="off" length="short" rot="R270"/>
-<pin name="K" x="5.08" y="-7.62" visible="off" length="short" rot="R90"/>
-<polygon width="0.254" layer="94">
-<vertex x="5.08" y="-2.54"/>
-<vertex x="6.604" y="-1.016"/>
-<vertex x="3.81" y="-1.016"/>
-<vertex x="4.826" y="-2.032"/>
-</polygon>
-</symbol>
-</symbols>
-<devicesets>
-<deviceset name="QRE1113_">
-<description>Reflective object sensor</description>
-<gates>
-<gate name="G$1" symbol="QRE1113-1" x="0" y="0"/>
-</gates>
-<devices>
-<device name="QA" package="QRE1113">
-<connects>
-<connect gate="G$1" pin="A" pad="1"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="4"/>
-<connect gate="G$1" pin="K" pad="2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="" package="DIP400W50P180L360H200Q4">
-<connects>
-<connect gate="G$1" pin="A" pad="1"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="4"/>
-<connect gate="G$1" pin="K" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -13664,6 +13512,86 @@ by exp-lbrs.ulp</description>
 <text x="4.064" y="-8.89" size="1.016" layer="51" font="vector" ratio="15">RX</text>
 <text x="-6.35" y="-9.017" size="1.016" layer="51" font="vector" ratio="15">2</text>
 </package>
+<package name="QRE1113_DIP400W50P180L360H200Q4">
+<circle x="-2.4" y="2.2" radius="0.0508" width="0.2" layer="21"/>
+<circle x="-2.4" y="2.2" radius="0.1" width="0.2" layer="51"/>
+<wire x1="-1.8" y1="-1.45" x2="-1.8" y2="1.45" width="0.127" layer="51"/>
+<wire x1="-1.8" y1="1.45" x2="1.8" y2="1.45" width="0.127" layer="51"/>
+<wire x1="1.8" y1="1.45" x2="1.8" y2="-1.45" width="0.127" layer="51"/>
+<wire x1="1.8" y1="-1.45" x2="-1.8" y2="-1.45" width="0.127" layer="51"/>
+<wire x1="1.8" y1="1.45" x2="1.8" y2="-1.45" width="0.0508" layer="21"/>
+<wire x1="-1.8" y1="-1.45" x2="-1.8" y2="0.6118" width="0.0508" layer="21"/>
+<wire x1="-2.05" y1="2.84" x2="-2.05" y2="-2.84" width="0.05" layer="39"/>
+<wire x1="-2.05" y1="-2.84" x2="2.05" y2="-2.84" width="0.05" layer="39"/>
+<wire x1="2.05" y1="-2.84" x2="2.05" y2="2.84" width="0.05" layer="39"/>
+<wire x1="2.05" y1="2.84" x2="-2.05" y2="2.84" width="0.05" layer="39"/>
+<wire x1="-1.8034" y1="0.6096" x2="-1.27" y2="1.27" width="0.0508" layer="21"/>
+<rectangle x1="-1.5494" y1="1.3589" x2="-0.254" y2="2.6416" layer="30"/>
+<pad name="1" x="-0.9" y="2" drill="0.78" shape="square" rot="R270" stop="no"/>
+<pad name="2" x="-0.9" y="-2" drill="0.78" diameter="1.524" rot="R270" stop="no"/>
+<pad name="3" x="0.9" y="-2" drill="0.78" diameter="1.524" rot="R270" stop="no"/>
+<pad name="4" x="0.9" y="2" drill="0.78" diameter="1.524" rot="R270" stop="no"/>
+<text x="-2.07676875" y="3.075759375" size="1.271940625" layer="25">&gt;NAME</text>
+<text x="-2.08306875" y="-3.581009375" size="1.2732" layer="27" align="top-left">&gt;VALUE</text>
+<polygon width="0.127" layer="29">
+<vertex x="-0.9271" y="1.6764" curve="-90.012891"/>
+<vertex x="-1.2319" y="2.0117" curve="-90"/>
+<vertex x="-0.9017" y="2.3266" curve="-90"/>
+<vertex x="-0.5741" y="1.9838" curve="-90.012967"/>
+</polygon>
+<polygon width="0.127" layer="30">
+<vertex x="0.9677" y="1.2954" curve="-90"/>
+<vertex x="0.2033" y="1.9584" curve="-90.011749"/>
+<vertex x="0.8509" y="2.7052" curve="-90"/>
+<vertex x="1.5977" y="2.0447" curve="-90.024193"/>
+</polygon>
+<polygon width="0.127" layer="30">
+<vertex x="-0.8611" y="-2.7051" curve="-90"/>
+<vertex x="-1.6128" y="-2.0294" curve="-90.011749"/>
+<vertex x="-0.9017" y="-1.2953" curve="-90"/>
+<vertex x="-0.193" y="-1.9939" curve="-90.024193"/>
+</polygon>
+<polygon width="0.127" layer="30">
+<vertex x="0.9042" y="-2.7051" curve="-90"/>
+<vertex x="0.2033" y="-2.0421" curve="-90.011749"/>
+<vertex x="0.8636" y="-1.2953" curve="-90"/>
+<vertex x="1.6104" y="-1.9812" curve="-90.024193"/>
+</polygon>
+<polygon width="0.127" layer="29">
+<vertex x="0.8763" y="1.6764" curve="-90.012891"/>
+<vertex x="0.5715" y="2.0117" curve="-90"/>
+<vertex x="0.9017" y="2.3266" curve="-90"/>
+<vertex x="1.2293" y="1.9838" curve="-90.012967"/>
+</polygon>
+<polygon width="0.127" layer="29">
+<vertex x="-0.9144" y="-2.3241" curve="-90.012891"/>
+<vertex x="-1.2319" y="-1.9888" curve="-90"/>
+<vertex x="-0.889" y="-1.6739" curve="-90"/>
+<vertex x="-0.5614" y="-2.0167" curve="-90.012967"/>
+</polygon>
+<polygon width="0.127" layer="29">
+<vertex x="0.8763" y="-2.3241" curve="-90.012891"/>
+<vertex x="0.5715" y="-1.9888" curve="-90"/>
+<vertex x="0.9017" y="-1.6739" curve="-90"/>
+<vertex x="1.2293" y="-2.0167" curve="-90.012967"/>
+</polygon>
+</package>
+<package name="QRE1113_QRE1113">
+<wire x1="1.35" y1="1.7" x2="-1.35" y2="1.7" width="0.127" layer="51"/>
+<wire x1="-1.35" y1="1.7" x2="-1.35" y2="-1.7" width="0.127" layer="51"/>
+<wire x1="-1.35" y1="-1.7" x2="1.35" y2="-1.7" width="0.127" layer="51"/>
+<wire x1="1.35" y1="-1.7" x2="1.35" y2="1.7" width="0.127" layer="51"/>
+<wire x1="1.627" y1="1.427" x2="1.7" y2="1.427" width="0.2032" layer="21"/>
+<wire x1="1.7" y1="1.427" x2="1.7" y2="-1.4" width="0.2032" layer="21"/>
+<wire x1="1.7" y1="-1.4" x2="1.654" y2="-1.4" width="0.2032" layer="21"/>
+<wire x1="-1.424" y1="1.37" x2="-1.7" y2="1.1" width="0.2032" layer="21"/>
+<wire x1="-1.7" y1="1.1" x2="-1.7" y2="-1.4" width="0.2032" layer="21"/>
+<wire x1="-1.7" y1="-1.4" x2="-1.627" y2="-1.4" width="0.2032" layer="21"/>
+<smd name="1" x="-0.9" y="1.8" dx="1.2" dy="0.6" layer="1" rot="R270"/>
+<smd name="2" x="-0.9" y="-1.8" dx="1.2" dy="0.6" layer="1" rot="R270"/>
+<smd name="3" x="0.9" y="-1.8" dx="1.2" dy="0.6" layer="1" rot="R270"/>
+<smd name="4" x="0.9" y="1.8" dx="1.2" dy="0.6" layer="1" rot="R270"/>
+</package>
 </packages>
 <symbols>
 <symbol name="ADAFRUIT_ITSY_MO_28">
@@ -13702,6 +13630,40 @@ by exp-lbrs.ulp</description>
 <text x="-14.732" y="23.622" size="1.778" layer="95">&gt;Name</text>
 <text x="-16.51" y="-20.32" size="1.778" layer="96">&gt;Value</text>
 </symbol>
+<symbol name="QRE1113_QRE1113-1">
+<wire x1="-5.08" y1="2.54" x2="-5.08" y2="-5.08" width="0.254" layer="94"/>
+<wire x1="-5.08" y1="-5.08" x2="-2.54" y2="-5.08" width="0.254" layer="94"/>
+<wire x1="-2.54" y1="-5.08" x2="5.08" y2="-5.08" width="0.254" layer="94"/>
+<wire x1="5.08" y1="-5.08" x2="7.62" y2="-5.08" width="0.254" layer="94"/>
+<wire x1="7.62" y1="-5.08" x2="7.62" y2="2.54" width="0.254" layer="94"/>
+<wire x1="7.62" y1="2.54" x2="5.08" y2="2.54" width="0.254" layer="94"/>
+<wire x1="5.08" y1="2.54" x2="-2.54" y2="2.54" width="0.254" layer="94"/>
+<wire x1="-2.54" y1="2.54" x2="-5.08" y2="2.54" width="0.254" layer="94"/>
+<wire x1="-2.54" y1="2.54" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="0" y2="-2.54" width="0.254" layer="94"/>
+<wire x1="0" y1="-2.54" x2="-1.524" y2="-4.064" width="0.254" layer="94"/>
+<wire x1="-1.524" y1="-4.064" x2="-2.54" y2="-5.08" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="0" y2="1.27" width="0.254" layer="94"/>
+<wire x1="0" y1="-2.54" x2="0" y2="-4.064" width="0.254" layer="94"/>
+<wire x1="5.08" y1="2.54" x2="5.08" y2="-2.54" width="0.254" layer="94"/>
+<wire x1="5.08" y1="-2.54" x2="5.08" y2="-5.08" width="0.254" layer="94"/>
+<wire x1="3.81" y1="-2.54" x2="5.08" y2="-2.54" width="0.254" layer="94"/>
+<wire x1="5.08" y1="-2.54" x2="6.604" y2="-2.54" width="0.254" layer="94"/>
+<wire x1="-1.524" y1="-4.064" x2="-0.508" y2="-4.064" width="0.254" layer="94"/>
+<wire x1="-1.524" y1="-4.064" x2="-1.524" y2="-3.048" width="0.254" layer="94"/>
+<pin name="A" x="5.08" y="5.08" visible="off" length="short" rot="R270"/>
+<pin name="C" x="-2.54" y="5.08" visible="off" length="short" rot="R270"/>
+<pin name="E" x="-2.54" y="-7.62" visible="off" length="short" rot="R90"/>
+<pin name="K" x="5.08" y="-7.62" visible="off" length="short" rot="R90"/>
+<text x="-1.778" y="3.048" size="1.778" layer="96">&gt;Value</text>
+<text x="-1.27" y="-7.112" size="1.778" layer="95">&gt;Name</text>
+<polygon width="0.254" layer="94">
+<vertex x="5.08" y="-2.54"/>
+<vertex x="6.604" y="-1.016"/>
+<vertex x="3.81" y="-1.016"/>
+<vertex x="4.826" y="-2.032"/>
+</polygon>
+</symbol>
 </symbols>
 <devicesets>
 <deviceset name="ADAFRUIT_ITSY_M0_28">
@@ -13739,6 +13701,36 @@ by exp-lbrs.ulp</description>
 <connect gate="G$1" pin="USB" pad="USB"/>
 <connect gate="G$1" pin="VHI" pad="VHI"/>
 <connect gate="G$1" pin="VIN" pad="VIN"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="QRE1113_QRE1113_">
+<description>Reflective object sensor</description>
+<gates>
+<gate name="G$1" symbol="QRE1113_QRE1113-1" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="QRE1113_DIP400W50P180L360H200Q4">
+<connects>
+<connect gate="G$1" pin="A" pad="1"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="4"/>
+<connect gate="G$1" pin="K" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="QA" package="QRE1113_QRE1113">
+<connects>
+<connect gate="G$1" pin="A" pad="1"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="4"/>
+<connect gate="G$1" pin="K" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -29226,6 +29218,139 @@ LOGO</text>
 </deviceset>
 </devicesets>
 </library>
+<library name="pinhead" urn="urn:adsk.eagle:library:325">
+<description>&lt;b&gt;Pin Header Connectors&lt;/b&gt;&lt;p&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
+<packages>
+<package name="1X03" urn="urn:adsk.eagle:footprint:22340/1" library_version="4">
+<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
+<wire x1="-3.175" y1="1.27" x2="-1.905" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-1.905" y1="1.27" x2="-1.27" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="0.635" x2="-1.27" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="-0.635" x2="-1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="0.635" x2="-0.635" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="0.635" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="1.27" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="0.635" x2="1.27" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="-0.635" x2="0.635" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="0.635" y1="-1.27" x2="-0.635" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-0.635" y1="-1.27" x2="-1.27" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-3.81" y1="0.635" x2="-3.81" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="1.27" x2="-3.81" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-3.81" y1="-0.635" x2="-3.175" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-1.905" y1="-1.27" x2="-3.175" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="0.635" x2="1.905" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="3.175" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="3.175" y1="1.27" x2="3.81" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="3.81" y1="0.635" x2="3.81" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="3.81" y1="-0.635" x2="3.175" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="3.175" y1="-1.27" x2="1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="1.905" y1="-1.27" x2="1.27" y2="-0.635" width="0.1524" layer="21"/>
+<pad name="1" x="-2.54" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="0" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="3" x="2.54" y="0" drill="1.016" shape="long" rot="R90"/>
+<text x="-3.8862" y="1.8288" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-3.81" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<rectangle x1="-2.794" y1="-0.254" x2="-2.286" y2="0.254" layer="51"/>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+</package>
+<package name="1X03/90" urn="urn:adsk.eagle:footprint:22341/1" library_version="4">
+<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
+<wire x1="-3.81" y1="-1.905" x2="-1.27" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="-1.905" x2="-1.27" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="0.635" x2="-3.81" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-3.81" y1="0.635" x2="-3.81" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="-2.54" y1="6.985" x2="-2.54" y2="1.27" width="0.762" layer="21"/>
+<wire x1="-1.27" y1="-1.905" x2="1.27" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="-1.905" x2="1.27" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="0.635" x2="-1.27" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="0" y1="6.985" x2="0" y2="1.27" width="0.762" layer="21"/>
+<wire x1="1.27" y1="-1.905" x2="3.81" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="3.81" y1="-1.905" x2="3.81" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="3.81" y1="0.635" x2="1.27" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="2.54" y1="6.985" x2="2.54" y2="1.27" width="0.762" layer="21"/>
+<pad name="1" x="-2.54" y="-3.81" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="0" y="-3.81" drill="1.016" shape="long" rot="R90"/>
+<pad name="3" x="2.54" y="-3.81" drill="1.016" shape="long" rot="R90"/>
+<text x="-4.445" y="-3.81" size="1.27" layer="25" ratio="10" rot="R90">&gt;NAME</text>
+<text x="5.715" y="-3.81" size="1.27" layer="27" rot="R90">&gt;VALUE</text>
+<rectangle x1="-2.921" y1="0.635" x2="-2.159" y2="1.143" layer="21"/>
+<rectangle x1="-0.381" y1="0.635" x2="0.381" y2="1.143" layer="21"/>
+<rectangle x1="2.159" y1="0.635" x2="2.921" y2="1.143" layer="21"/>
+<rectangle x1="-2.921" y1="-2.921" x2="-2.159" y2="-1.905" layer="21"/>
+<rectangle x1="-0.381" y1="-2.921" x2="0.381" y2="-1.905" layer="21"/>
+<rectangle x1="2.159" y1="-2.921" x2="2.921" y2="-1.905" layer="21"/>
+</package>
+</packages>
+<packages3d>
+<package3d name="1X03" urn="urn:adsk.eagle:package:22458/2" type="model" library_version="4">
+<description>PIN HEADER</description>
+<packageinstances>
+<packageinstance name="1X03"/>
+</packageinstances>
+</package3d>
+<package3d name="1X03/90" urn="urn:adsk.eagle:package:22459/2" type="model" library_version="4">
+<description>PIN HEADER</description>
+<packageinstances>
+<packageinstance name="1X03/90"/>
+</packageinstances>
+</package3d>
+</packages3d>
+<symbols>
+<symbol name="PINHD3" urn="urn:adsk.eagle:symbol:22339/1" library_version="4">
+<wire x1="-6.35" y1="-5.08" x2="1.27" y2="-5.08" width="0.4064" layer="94"/>
+<wire x1="1.27" y1="-5.08" x2="1.27" y2="5.08" width="0.4064" layer="94"/>
+<wire x1="1.27" y1="5.08" x2="-6.35" y2="5.08" width="0.4064" layer="94"/>
+<wire x1="-6.35" y1="5.08" x2="-6.35" y2="-5.08" width="0.4064" layer="94"/>
+<text x="-6.35" y="5.715" size="1.778" layer="95">&gt;NAME</text>
+<text x="-6.35" y="-7.62" size="1.778" layer="96">&gt;VALUE</text>
+<pin name="1" x="-2.54" y="2.54" visible="pad" length="short" direction="pas" function="dot"/>
+<pin name="2" x="-2.54" y="0" visible="pad" length="short" direction="pas" function="dot"/>
+<pin name="3" x="-2.54" y="-2.54" visible="pad" length="short" direction="pas" function="dot"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="PINHD-1X3" urn="urn:adsk.eagle:component:22524/4" prefix="JP" uservalue="yes" library_version="4">
+<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
+<gates>
+<gate name="A" symbol="PINHD3" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="1X03">
+<connects>
+<connect gate="A" pin="1" pad="1"/>
+<connect gate="A" pin="2" pad="2"/>
+<connect gate="A" pin="3" pad="3"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:22458/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="POPULARITY" value="92" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="/90" package="1X03/90">
+<connects>
+<connect gate="A" pin="1" pad="1"/>
+<connect gate="A" pin="2" pad="2"/>
+<connect gate="A" pin="3" pad="3"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:22459/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="POPULARITY" value="17" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
 </libraries>
 <attributes>
 </attributes>
@@ -29327,54 +29452,53 @@ LOGO</text>
 <part name="U$59" library="Bee Counter 3" deviceset="M06_BEE" device=""/>
 <part name="U$60" library="th_libraries3" deviceset="CONN_01" device="38MILL"/>
 <part name="U$61" library="th_libraries3" deviceset="CONN_01" device="38MILL"/>
-<part name="U$68" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$69" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$70" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$71" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$72" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$73" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$74" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$75" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$76" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$77" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$78" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$79" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$80" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$81" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$82" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$83" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$84" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$85" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$86" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$87" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$88" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$89" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$90" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$91" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$92" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$93" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$94" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$95" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$96" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$97" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$98" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$99" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$100" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$101" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$102" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$103" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$104" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$105" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$106" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$107" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$108" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$109" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$110" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$111" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$112" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$113" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$114" library="QRE1113" deviceset="QRE1113_" device=""/>
-<part name="U$115" library="QRE1113" deviceset="QRE1113_" device=""/>
+<part name="U24I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U24O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U23I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U23O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U22I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U22O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U21I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U21O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U20I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U20O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U19I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U19O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U18I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U18O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U17I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U17O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U16I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U16O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U15I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U15O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U14I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U14O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U13I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U13O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U12I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U12O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U11I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U11O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U10I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U10O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U09O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U08I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U08O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U07I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U07O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U06I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U06O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U05I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U05O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U04I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U04O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U03I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U03O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U02I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U02O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U01I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
+<part name="U01O" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
 <part name="U$34" library="th_libraries" deviceset="RPACK-BUSSED-9" device="" value="22Ω"/>
 <part name="U$35" library="th_libraries" deviceset="RPACK-BUSSED-9" device="" value="22Ω"/>
 <part name="U$36" library="th_libraries" deviceset="RPACK-BUSSED-9" device="" value="22Ω"/>
@@ -29464,6 +29588,14 @@ LOGO</text>
 <part name="GND23" library="SparkFun" deviceset="GND" device=""/>
 <part name="U$45" library="easy_bee_counter" deviceset="ADAFRUIT_ITSY_M0_28" device=""/>
 <part name="U$44" library="owen_desktop" deviceset="BEE_LOGO" device=""/>
+<part name="SERVO5" library="pinhead" library_urn="urn:adsk.eagle:library:325" deviceset="PINHD-1X3" device="" package3d_urn="urn:adsk.eagle:package:22458/2"/>
+<part name="SERVO4" library="pinhead" library_urn="urn:adsk.eagle:library:325" deviceset="PINHD-1X3" device="" package3d_urn="urn:adsk.eagle:package:22458/2"/>
+<part name="SERVO3" library="pinhead" library_urn="urn:adsk.eagle:library:325" deviceset="PINHD-1X3" device="" package3d_urn="urn:adsk.eagle:package:22458/2"/>
+<part name="SERVO2" library="pinhead" library_urn="urn:adsk.eagle:library:325" deviceset="PINHD-1X3" device="" package3d_urn="urn:adsk.eagle:package:22458/2"/>
+<part name="SERVO1" library="pinhead" library_urn="urn:adsk.eagle:library:325" deviceset="PINHD-1X3" device="" package3d_urn="urn:adsk.eagle:package:22458/2"/>
+<part name="SUPPLY58" library="SparkFun-Aesthetics" library_urn="urn:adsk.eagle:library:507" deviceset="5V" device=""/>
+<part name="GND35" library="SparkFun-Aesthetics" library_urn="urn:adsk.eagle:library:507" deviceset="GND" device=""/>
+<part name="U09I" library="easy_bee_counter" deviceset="QRE1113_QRE1113_" device=""/>
 </parts>
 <sheets>
 <sheet>
@@ -29506,8 +29638,8 @@ https://www.mouser.com/ProductDetail/661-APSC6R3L561MH08S
 <text x="-195.58" y="1000.76" size="1.778" layer="91">Shift-IN</text>
 <text x="-195.58" y="993.14" size="1.778" layer="91">Shift-IN</text>
 <text x="-195.58" y="995.68" size="1.778" layer="91">Shift-IN</text>
+<text x="-274.32" y="995.68" size="1.778" layer="91" align="bottom-right">LED Power</text>
 <text x="-274.32" y="993.14" size="1.778" layer="91" align="bottom-right">LED Power</text>
-<text x="-274.32" y="990.6" size="1.778" layer="91" align="bottom-right">LED Power</text>
 <text x="-274.32" y="1003.3" size="1.778" layer="91" align="bottom-right">SCREW Term.</text>
 <text x="-274.32" y="1000.76" size="1.778" layer="91" align="bottom-right">SCREW Term.</text>
 <text x="-182.88" y="990.6" size="1.778" layer="91" align="bottom-right">SCREW Term.</text>
@@ -29816,195 +29948,191 @@ Thomas Hudson</text>
 <attribute name="VALUE" x="-287.274" y="680.72" size="1.778" layer="96" font="vector" rot="R90"/>
 <attribute name="NAME" x="-297.688" y="680.72" size="1.778" layer="95" font="vector" rot="R90"/>
 </instance>
-<instance part="U$68" gate="G$1" x="-106.68" y="1203.96" smashed="yes">
+<instance part="U24I" gate="G$1" x="-106.68" y="1203.96" smashed="yes">
 <attribute name="VALUE" x="-108.458" y="1207.008" size="1.778" layer="96"/>
 <attribute name="NAME" x="-107.95" y="1196.848" size="1.778" layer="95"/>
 </instance>
-<instance part="U$69" gate="G$1" x="-88.9" y="1203.96" smashed="yes">
+<instance part="U24O" gate="G$1" x="-88.9" y="1203.96" smashed="yes">
 <attribute name="VALUE" x="-90.678" y="1207.008" size="1.778" layer="96"/>
 <attribute name="NAME" x="-90.17" y="1196.848" size="1.778" layer="95"/>
 </instance>
-<instance part="U$70" gate="G$1" x="-106.68" y="1170.94" smashed="yes">
+<instance part="U23I" gate="G$1" x="-106.68" y="1170.94" smashed="yes">
 <attribute name="VALUE" x="-108.458" y="1173.988" size="1.778" layer="96"/>
 <attribute name="NAME" x="-107.95" y="1163.828" size="1.778" layer="95"/>
 </instance>
-<instance part="U$71" gate="G$1" x="-88.9" y="1170.94" smashed="yes">
+<instance part="U23O" gate="G$1" x="-88.9" y="1170.94" smashed="yes">
 <attribute name="VALUE" x="-90.678" y="1173.988" size="1.778" layer="96"/>
 <attribute name="NAME" x="-90.17" y="1163.828" size="1.778" layer="95"/>
 </instance>
-<instance part="U$72" gate="G$1" x="-106.68" y="1137.92" smashed="yes">
+<instance part="U22I" gate="G$1" x="-106.68" y="1137.92" smashed="yes">
 <attribute name="VALUE" x="-108.458" y="1140.968" size="1.778" layer="96"/>
 <attribute name="NAME" x="-107.95" y="1130.808" size="1.778" layer="95"/>
 </instance>
-<instance part="U$73" gate="G$1" x="-88.9" y="1137.92" smashed="yes">
+<instance part="U22O" gate="G$1" x="-88.9" y="1137.92" smashed="yes">
 <attribute name="VALUE" x="-90.678" y="1140.968" size="1.778" layer="96"/>
 <attribute name="NAME" x="-90.17" y="1130.808" size="1.778" layer="95"/>
 </instance>
-<instance part="U$74" gate="G$1" x="-106.68" y="1102.36" smashed="yes">
+<instance part="U21I" gate="G$1" x="-106.68" y="1102.36" smashed="yes">
 <attribute name="VALUE" x="-108.458" y="1105.408" size="1.778" layer="96"/>
 <attribute name="NAME" x="-107.95" y="1095.248" size="1.778" layer="95"/>
 </instance>
-<instance part="U$75" gate="G$1" x="-88.9" y="1102.36" smashed="yes">
+<instance part="U21O" gate="G$1" x="-88.9" y="1102.36" smashed="yes">
 <attribute name="VALUE" x="-90.678" y="1105.408" size="1.778" layer="96"/>
 <attribute name="NAME" x="-90.17" y="1095.248" size="1.778" layer="95"/>
 </instance>
-<instance part="U$76" gate="G$1" x="-106.68" y="1054.1" smashed="yes">
+<instance part="U20I" gate="G$1" x="-106.68" y="1054.1" smashed="yes">
 <attribute name="VALUE" x="-108.458" y="1057.148" size="1.778" layer="96"/>
 <attribute name="NAME" x="-107.95" y="1046.988" size="1.778" layer="95"/>
 </instance>
-<instance part="U$77" gate="G$1" x="-88.9" y="1054.1" smashed="yes">
+<instance part="U20O" gate="G$1" x="-88.9" y="1054.1" smashed="yes">
 <attribute name="VALUE" x="-90.678" y="1057.148" size="1.778" layer="96"/>
 <attribute name="NAME" x="-90.17" y="1046.988" size="1.778" layer="95"/>
 </instance>
-<instance part="U$78" gate="G$1" x="-106.68" y="1018.54" smashed="yes">
+<instance part="U19I" gate="G$1" x="-106.68" y="1018.54" smashed="yes">
 <attribute name="VALUE" x="-108.458" y="1021.588" size="1.778" layer="96"/>
 <attribute name="NAME" x="-107.95" y="1011.428" size="1.778" layer="95"/>
 </instance>
-<instance part="U$79" gate="G$1" x="-88.9" y="1018.54" smashed="yes">
+<instance part="U19O" gate="G$1" x="-88.9" y="1018.54" smashed="yes">
 <attribute name="VALUE" x="-90.678" y="1021.588" size="1.778" layer="96"/>
 <attribute name="NAME" x="-90.17" y="1011.428" size="1.778" layer="95"/>
 </instance>
-<instance part="U$80" gate="G$1" x="-106.68" y="982.98" smashed="yes">
+<instance part="U18I" gate="G$1" x="-106.68" y="982.98" smashed="yes">
 <attribute name="VALUE" x="-108.458" y="986.028" size="1.778" layer="96"/>
 <attribute name="NAME" x="-107.95" y="975.868" size="1.778" layer="95"/>
 </instance>
-<instance part="U$81" gate="G$1" x="-88.9" y="982.98" smashed="yes">
+<instance part="U18O" gate="G$1" x="-88.9" y="982.98" smashed="yes">
 <attribute name="VALUE" x="-90.678" y="986.028" size="1.778" layer="96"/>
 <attribute name="NAME" x="-90.17" y="975.868" size="1.778" layer="95"/>
 </instance>
-<instance part="U$82" gate="G$1" x="-106.68" y="949.96" smashed="yes">
+<instance part="U17I" gate="G$1" x="-106.68" y="949.96" smashed="yes">
 <attribute name="VALUE" x="-108.458" y="953.008" size="1.778" layer="96"/>
 <attribute name="NAME" x="-107.95" y="942.848" size="1.778" layer="95"/>
 </instance>
-<instance part="U$83" gate="G$1" x="-88.9" y="949.96" smashed="yes">
+<instance part="U17O" gate="G$1" x="-88.9" y="949.96" smashed="yes">
 <attribute name="VALUE" x="-90.678" y="953.008" size="1.778" layer="96"/>
 <attribute name="NAME" x="-90.17" y="942.848" size="1.778" layer="95"/>
 </instance>
-<instance part="U$84" gate="G$1" x="-106.68" y="886.46" smashed="yes">
+<instance part="U16I" gate="G$1" x="-106.68" y="886.46" smashed="yes">
 <attribute name="VALUE" x="-108.458" y="889.508" size="1.778" layer="96"/>
 <attribute name="NAME" x="-107.95" y="879.348" size="1.778" layer="95"/>
 </instance>
-<instance part="U$85" gate="G$1" x="-88.9" y="886.46" smashed="yes">
+<instance part="U16O" gate="G$1" x="-88.9" y="886.46" smashed="yes">
 <attribute name="VALUE" x="-90.678" y="889.508" size="1.778" layer="96"/>
 <attribute name="NAME" x="-90.17" y="879.348" size="1.778" layer="95"/>
 </instance>
-<instance part="U$86" gate="G$1" x="-106.68" y="850.9" smashed="yes">
+<instance part="U15I" gate="G$1" x="-106.68" y="850.9" smashed="yes">
 <attribute name="VALUE" x="-108.458" y="853.948" size="1.778" layer="96"/>
 <attribute name="NAME" x="-107.95" y="843.788" size="1.778" layer="95"/>
 </instance>
-<instance part="U$87" gate="G$1" x="-88.9" y="850.9" smashed="yes">
+<instance part="U15O" gate="G$1" x="-88.9" y="850.9" smashed="yes">
 <attribute name="VALUE" x="-90.678" y="853.948" size="1.778" layer="96"/>
 <attribute name="NAME" x="-90.17" y="843.788" size="1.778" layer="95"/>
 </instance>
-<instance part="U$88" gate="G$1" x="-106.68" y="815.34" smashed="yes">
+<instance part="U14I" gate="G$1" x="-106.68" y="815.34" smashed="yes">
 <attribute name="VALUE" x="-108.458" y="818.388" size="1.778" layer="96"/>
 <attribute name="NAME" x="-107.95" y="808.228" size="1.778" layer="95"/>
 </instance>
-<instance part="U$89" gate="G$1" x="-88.9" y="815.34" smashed="yes">
+<instance part="U14O" gate="G$1" x="-88.9" y="815.34" smashed="yes">
 <attribute name="VALUE" x="-90.678" y="818.388" size="1.778" layer="96"/>
 <attribute name="NAME" x="-90.17" y="808.228" size="1.778" layer="95"/>
 </instance>
-<instance part="U$90" gate="G$1" x="-106.68" y="782.32" smashed="yes">
+<instance part="U13I" gate="G$1" x="-106.68" y="782.32" smashed="yes">
 <attribute name="VALUE" x="-108.458" y="785.368" size="1.778" layer="96"/>
 <attribute name="NAME" x="-107.95" y="775.208" size="1.778" layer="95"/>
 </instance>
-<instance part="U$91" gate="G$1" x="-88.9" y="782.32" smashed="yes">
+<instance part="U13O" gate="G$1" x="-88.9" y="782.32" smashed="yes">
 <attribute name="VALUE" x="-90.678" y="785.368" size="1.778" layer="96"/>
 <attribute name="NAME" x="-90.17" y="775.208" size="1.778" layer="95"/>
 </instance>
-<instance part="U$92" gate="G$1" x="-104.14" y="711.2" smashed="yes">
+<instance part="U12I" gate="G$1" x="-104.14" y="711.2" smashed="yes">
 <attribute name="VALUE" x="-105.918" y="714.248" size="1.778" layer="96"/>
 <attribute name="NAME" x="-105.41" y="704.088" size="1.778" layer="95"/>
 </instance>
-<instance part="U$93" gate="G$1" x="-86.36" y="711.2" smashed="yes">
+<instance part="U12O" gate="G$1" x="-86.36" y="711.2" smashed="yes">
 <attribute name="VALUE" x="-88.138" y="714.248" size="1.778" layer="96"/>
 <attribute name="NAME" x="-87.63" y="704.088" size="1.778" layer="95"/>
 </instance>
-<instance part="U$94" gate="G$1" x="-104.14" y="678.18" smashed="yes">
+<instance part="U11I" gate="G$1" x="-104.14" y="678.18" smashed="yes">
 <attribute name="VALUE" x="-105.918" y="681.228" size="1.778" layer="96"/>
 <attribute name="NAME" x="-105.41" y="671.068" size="1.778" layer="95"/>
 </instance>
-<instance part="U$95" gate="G$1" x="-86.36" y="678.18" smashed="yes">
+<instance part="U11O" gate="G$1" x="-86.36" y="678.18" smashed="yes">
 <attribute name="VALUE" x="-88.138" y="681.228" size="1.778" layer="96"/>
 <attribute name="NAME" x="-87.63" y="671.068" size="1.778" layer="95"/>
 </instance>
-<instance part="U$96" gate="G$1" x="-104.14" y="645.16" smashed="yes">
+<instance part="U10I" gate="G$1" x="-104.14" y="645.16" smashed="yes">
 <attribute name="VALUE" x="-105.918" y="648.208" size="1.778" layer="96"/>
 <attribute name="NAME" x="-105.41" y="638.048" size="1.778" layer="95"/>
 </instance>
-<instance part="U$97" gate="G$1" x="-86.36" y="645.16" smashed="yes">
+<instance part="U10O" gate="G$1" x="-86.36" y="645.16" smashed="yes">
 <attribute name="VALUE" x="-88.138" y="648.208" size="1.778" layer="96"/>
 <attribute name="NAME" x="-87.63" y="638.048" size="1.778" layer="95"/>
 </instance>
-<instance part="U$98" gate="G$1" x="-104.14" y="609.6" smashed="yes">
-<attribute name="VALUE" x="-105.918" y="612.648" size="1.778" layer="96"/>
-<attribute name="NAME" x="-105.41" y="602.488" size="1.778" layer="95"/>
-</instance>
-<instance part="U$99" gate="G$1" x="-86.36" y="609.6" smashed="yes">
-<attribute name="VALUE" x="-88.138" y="612.648" size="1.778" layer="96"/>
+<instance part="U09O" gate="G$1" x="-86.36" y="609.6" smashed="yes">
+<attribute name="VALUE" x="-70.358" y="620.268" size="1.778" layer="96"/>
 <attribute name="NAME" x="-87.63" y="602.488" size="1.778" layer="95"/>
 </instance>
-<instance part="U$100" gate="G$1" x="-101.6" y="561.34" smashed="yes">
+<instance part="U08I" gate="G$1" x="-101.6" y="561.34" smashed="yes">
 <attribute name="VALUE" x="-103.378" y="564.388" size="1.778" layer="96"/>
 <attribute name="NAME" x="-102.87" y="554.228" size="1.778" layer="95"/>
 </instance>
-<instance part="U$101" gate="G$1" x="-83.82" y="561.34" smashed="yes">
+<instance part="U08O" gate="G$1" x="-83.82" y="561.34" smashed="yes">
 <attribute name="VALUE" x="-85.598" y="564.388" size="1.778" layer="96"/>
 <attribute name="NAME" x="-85.09" y="554.228" size="1.778" layer="95"/>
 </instance>
-<instance part="U$102" gate="G$1" x="-101.6" y="525.78" smashed="yes">
+<instance part="U07I" gate="G$1" x="-101.6" y="525.78" smashed="yes">
 <attribute name="VALUE" x="-103.378" y="528.828" size="1.778" layer="96"/>
 <attribute name="NAME" x="-102.87" y="518.668" size="1.778" layer="95"/>
 </instance>
-<instance part="U$103" gate="G$1" x="-83.82" y="525.78" smashed="yes">
+<instance part="U07O" gate="G$1" x="-83.82" y="525.78" smashed="yes">
 <attribute name="VALUE" x="-85.598" y="528.828" size="1.778" layer="96"/>
 <attribute name="NAME" x="-85.09" y="518.668" size="1.778" layer="95"/>
 </instance>
-<instance part="U$104" gate="G$1" x="-101.6" y="490.22" smashed="yes">
+<instance part="U06I" gate="G$1" x="-101.6" y="490.22" smashed="yes">
 <attribute name="VALUE" x="-103.378" y="493.268" size="1.778" layer="96"/>
 <attribute name="NAME" x="-102.87" y="483.108" size="1.778" layer="95"/>
 </instance>
-<instance part="U$105" gate="G$1" x="-83.82" y="490.22" smashed="yes">
+<instance part="U06O" gate="G$1" x="-83.82" y="490.22" smashed="yes">
 <attribute name="VALUE" x="-85.598" y="493.268" size="1.778" layer="96"/>
 <attribute name="NAME" x="-85.09" y="483.108" size="1.778" layer="95"/>
 </instance>
-<instance part="U$106" gate="G$1" x="-101.6" y="457.2" smashed="yes">
+<instance part="U05I" gate="G$1" x="-101.6" y="457.2" smashed="yes">
 <attribute name="VALUE" x="-103.378" y="460.248" size="1.778" layer="96"/>
 <attribute name="NAME" x="-102.87" y="450.088" size="1.778" layer="95"/>
 </instance>
-<instance part="U$107" gate="G$1" x="-83.82" y="457.2" smashed="yes">
+<instance part="U05O" gate="G$1" x="-83.82" y="457.2" smashed="yes">
 <attribute name="VALUE" x="-85.598" y="460.248" size="1.778" layer="96"/>
 <attribute name="NAME" x="-85.09" y="450.088" size="1.778" layer="95"/>
 </instance>
-<instance part="U$108" gate="G$1" x="-104.14" y="393.7" smashed="yes">
+<instance part="U04I" gate="G$1" x="-104.14" y="393.7" smashed="yes">
 <attribute name="VALUE" x="-105.918" y="396.748" size="1.778" layer="96"/>
 <attribute name="NAME" x="-105.41" y="386.588" size="1.778" layer="95"/>
 </instance>
-<instance part="U$109" gate="G$1" x="-86.36" y="393.7" smashed="yes">
+<instance part="U04O" gate="G$1" x="-86.36" y="393.7" smashed="yes">
 <attribute name="VALUE" x="-88.138" y="396.748" size="1.778" layer="96"/>
 <attribute name="NAME" x="-87.63" y="386.588" size="1.778" layer="95"/>
 </instance>
-<instance part="U$110" gate="G$1" x="-104.14" y="358.14" smashed="yes">
+<instance part="U03I" gate="G$1" x="-104.14" y="358.14" smashed="yes">
 <attribute name="VALUE" x="-105.918" y="361.188" size="1.778" layer="96"/>
 <attribute name="NAME" x="-105.41" y="351.028" size="1.778" layer="95"/>
 </instance>
-<instance part="U$111" gate="G$1" x="-86.36" y="358.14" smashed="yes">
+<instance part="U03O" gate="G$1" x="-86.36" y="358.14" smashed="yes">
 <attribute name="VALUE" x="-88.138" y="361.188" size="1.778" layer="96"/>
 <attribute name="NAME" x="-87.63" y="351.028" size="1.778" layer="95"/>
 </instance>
-<instance part="U$112" gate="G$1" x="-104.14" y="322.58" smashed="yes">
+<instance part="U02I" gate="G$1" x="-104.14" y="322.58" smashed="yes">
 <attribute name="VALUE" x="-105.918" y="325.628" size="1.778" layer="96"/>
 <attribute name="NAME" x="-105.41" y="315.468" size="1.778" layer="95"/>
 </instance>
-<instance part="U$113" gate="G$1" x="-86.36" y="322.58" smashed="yes">
+<instance part="U02O" gate="G$1" x="-86.36" y="322.58" smashed="yes">
 <attribute name="VALUE" x="-88.138" y="325.628" size="1.778" layer="96"/>
 <attribute name="NAME" x="-87.63" y="315.468" size="1.778" layer="95"/>
 </instance>
-<instance part="U$114" gate="G$1" x="-104.14" y="289.56" smashed="yes">
+<instance part="U01I" gate="G$1" x="-104.14" y="289.56" smashed="yes">
 <attribute name="VALUE" x="-105.918" y="292.608" size="1.778" layer="96"/>
 <attribute name="NAME" x="-105.41" y="282.448" size="1.778" layer="95"/>
 </instance>
-<instance part="U$115" gate="G$1" x="-86.36" y="289.56" smashed="yes">
+<instance part="U01O" gate="G$1" x="-86.36" y="289.56" smashed="yes">
 <attribute name="VALUE" x="-88.138" y="292.608" size="1.778" layer="96"/>
 <attribute name="NAME" x="-87.63" y="282.448" size="1.778" layer="95"/>
 </instance>
@@ -30070,70 +30198,70 @@ Thomas Hudson</text>
 <attribute name="NAME" x="-298.2214" y="1035.05" size="1.778" layer="95" rot="R270"/>
 <attribute name="VALUE" x="-303.022" y="1035.05" size="1.778" layer="96" rot="R270"/>
 </instance>
-<instance part="U1" gate="U1" x="-20.32" y="1092.2" smashed="yes" rot="R180">
-<attribute name="NAME" x="-12.7" y="1076.198" size="1.778" layer="95" font="vector" rot="R180"/>
-<attribute name="VALUE" x="-12.7" y="1107.44" size="1.778" layer="95" font="vector" rot="R180"/>
+<instance part="U1" gate="U1" x="-20.32" y="1082.04" smashed="yes" rot="R180">
+<attribute name="NAME" x="-12.7" y="1066.038" size="1.778" layer="95" font="vector" rot="R180"/>
+<attribute name="VALUE" x="-12.7" y="1097.28" size="1.778" layer="95" font="vector" rot="R180"/>
 </instance>
-<instance part="GND8" gate="1" x="-7.62" y="1109.98" smashed="yes" rot="MR180">
-<attribute name="VALUE" x="-10.16" y="1112.52" size="1.778" layer="96" rot="MR180"/>
+<instance part="GND8" gate="1" x="-7.62" y="1099.82" smashed="yes" rot="MR180">
+<attribute name="VALUE" x="-10.16" y="1102.36" size="1.778" layer="96" rot="MR180"/>
 </instance>
-<instance part="SUPPLY52" gate="G$1" x="-15.24" y="1066.8" smashed="yes" rot="R90">
-<attribute name="VALUE" x="-18.034" y="1066.8" size="1.778" layer="96" rot="R90" align="bottom-center"/>
+<instance part="SUPPLY52" gate="G$1" x="-15.24" y="1056.64" smashed="yes" rot="R90">
+<attribute name="VALUE" x="-18.034" y="1056.64" size="1.778" layer="96" rot="R90" align="bottom-center"/>
 </instance>
-<instance part="GND10" gate="1" x="-10.16" y="1049.02" smashed="yes" rot="MR0">
-<attribute name="VALUE" x="-7.62" y="1046.48" size="1.778" layer="96" rot="MR0"/>
+<instance part="GND10" gate="1" x="-10.16" y="1038.86" smashed="yes" rot="MR0">
+<attribute name="VALUE" x="-7.62" y="1036.32" size="1.778" layer="96" rot="MR0"/>
 </instance>
-<instance part="U2" gate="U1" x="-20.32" y="937.26" smashed="yes" rot="R180">
-<attribute name="NAME" x="-12.7" y="921.258" size="1.778" layer="95" font="vector" rot="R180"/>
-<attribute name="VALUE" x="-12.7" y="952.5" size="1.778" layer="95" font="vector" rot="R180"/>
+<instance part="U2" gate="U1" x="-20.32" y="927.1" smashed="yes" rot="R180">
+<attribute name="NAME" x="-12.7" y="911.098" size="1.778" layer="95" font="vector" rot="R180"/>
+<attribute name="VALUE" x="-12.7" y="942.34" size="1.778" layer="95" font="vector" rot="R180"/>
 </instance>
-<instance part="GND12" gate="1" x="-7.62" y="955.04" smashed="yes" rot="MR180">
-<attribute name="VALUE" x="-10.16" y="957.58" size="1.778" layer="96" rot="MR180"/>
+<instance part="GND12" gate="1" x="-7.62" y="944.88" smashed="yes" rot="MR180">
+<attribute name="VALUE" x="-10.16" y="947.42" size="1.778" layer="96" rot="MR180"/>
 </instance>
-<instance part="SUPPLY53" gate="G$1" x="-15.24" y="911.86" smashed="yes" rot="R90">
-<attribute name="VALUE" x="-18.034" y="911.86" size="1.778" layer="96" rot="R90" align="bottom-center"/>
+<instance part="SUPPLY53" gate="G$1" x="-15.24" y="901.7" smashed="yes" rot="R90">
+<attribute name="VALUE" x="-18.034" y="901.7" size="1.778" layer="96" rot="R90" align="bottom-center"/>
 </instance>
-<instance part="GND13" gate="1" x="-10.16" y="894.08" smashed="yes" rot="MR0">
-<attribute name="VALUE" x="-7.62" y="891.54" size="1.778" layer="96" rot="MR0"/>
+<instance part="GND13" gate="1" x="-10.16" y="883.92" smashed="yes" rot="MR0">
+<attribute name="VALUE" x="-7.62" y="881.38" size="1.778" layer="96" rot="MR0"/>
 </instance>
-<instance part="U3" gate="U1" x="-17.78" y="762" smashed="yes" rot="R180">
-<attribute name="NAME" x="-10.16" y="745.998" size="1.778" layer="95" font="vector" rot="R180"/>
-<attribute name="VALUE" x="-10.16" y="777.24" size="1.778" layer="95" font="vector" rot="R180"/>
+<instance part="U3" gate="U1" x="-17.78" y="764.54" smashed="yes" rot="R180">
+<attribute name="NAME" x="-10.16" y="748.538" size="1.778" layer="95" font="vector" rot="R180"/>
+<attribute name="VALUE" x="-10.16" y="779.78" size="1.778" layer="95" font="vector" rot="R180"/>
 </instance>
-<instance part="GND15" gate="1" x="-5.08" y="779.78" smashed="yes" rot="MR180">
-<attribute name="VALUE" x="-7.62" y="782.32" size="1.778" layer="96" rot="MR180"/>
+<instance part="GND15" gate="1" x="-5.08" y="782.32" smashed="yes" rot="MR180">
+<attribute name="VALUE" x="-7.62" y="784.86" size="1.778" layer="96" rot="MR180"/>
 </instance>
-<instance part="SUPPLY54" gate="G$1" x="-12.7" y="736.6" smashed="yes" rot="R90">
-<attribute name="VALUE" x="-15.494" y="736.6" size="1.778" layer="96" rot="R90" align="bottom-center"/>
+<instance part="SUPPLY54" gate="G$1" x="-12.7" y="739.14" smashed="yes" rot="R90">
+<attribute name="VALUE" x="-15.494" y="739.14" size="1.778" layer="96" rot="R90" align="bottom-center"/>
 </instance>
-<instance part="GND16" gate="1" x="-7.62" y="718.82" smashed="yes" rot="MR0">
-<attribute name="VALUE" x="-5.08" y="716.28" size="1.778" layer="96" rot="MR0"/>
+<instance part="GND16" gate="1" x="-7.62" y="721.36" smashed="yes" rot="MR0">
+<attribute name="VALUE" x="-5.08" y="718.82" size="1.778" layer="96" rot="MR0"/>
 </instance>
-<instance part="U4" gate="U1" x="-17.78" y="599.44" smashed="yes" rot="R180">
-<attribute name="NAME" x="-10.16" y="583.438" size="1.778" layer="95" font="vector" rot="R180"/>
-<attribute name="VALUE" x="-10.16" y="614.68" size="1.778" layer="95" font="vector" rot="R180"/>
+<instance part="U4" gate="U1" x="-17.78" y="589.28" smashed="yes" rot="R180">
+<attribute name="NAME" x="-10.16" y="573.278" size="1.778" layer="95" font="vector" rot="R180"/>
+<attribute name="VALUE" x="-10.16" y="604.52" size="1.778" layer="95" font="vector" rot="R180"/>
 </instance>
-<instance part="GND18" gate="1" x="-5.08" y="617.22" smashed="yes" rot="MR180">
-<attribute name="VALUE" x="-7.62" y="619.76" size="1.778" layer="96" rot="MR180"/>
+<instance part="GND18" gate="1" x="-2.54" y="601.98" smashed="yes" rot="MR180">
+<attribute name="VALUE" x="-5.08" y="604.52" size="1.778" layer="96" rot="MR180"/>
 </instance>
-<instance part="SUPPLY55" gate="G$1" x="-12.7" y="574.04" smashed="yes" rot="R90">
-<attribute name="VALUE" x="-15.494" y="574.04" size="1.778" layer="96" rot="R90" align="bottom-center"/>
+<instance part="SUPPLY55" gate="G$1" x="-12.7" y="553.72" smashed="yes" rot="R90">
+<attribute name="VALUE" x="-15.494" y="553.72" size="1.778" layer="96" rot="R90" align="bottom-center"/>
 </instance>
-<instance part="GND19" gate="1" x="-7.62" y="556.26" smashed="yes" rot="MR0">
-<attribute name="VALUE" x="-5.08" y="553.72" size="1.778" layer="96" rot="MR0"/>
+<instance part="GND19" gate="1" x="-7.62" y="538.48" smashed="yes" rot="MR0">
+<attribute name="VALUE" x="-5.08" y="535.94" size="1.778" layer="96" rot="MR0"/>
 </instance>
-<instance part="U5" gate="U1" x="-15.24" y="444.5" smashed="yes" rot="R180">
-<attribute name="NAME" x="-7.62" y="428.498" size="1.778" layer="95" font="vector" rot="R180"/>
-<attribute name="VALUE" x="-7.62" y="459.74" size="1.778" layer="95" font="vector" rot="R180"/>
+<instance part="U5" gate="U1" x="-15.24" y="434.34" smashed="yes" rot="R180">
+<attribute name="NAME" x="-7.62" y="418.338" size="1.778" layer="95" font="vector" rot="R180"/>
+<attribute name="VALUE" x="-7.62" y="449.58" size="1.778" layer="95" font="vector" rot="R180"/>
 </instance>
 <instance part="GND21" gate="1" x="-2.54" y="462.28" smashed="yes" rot="MR180">
 <attribute name="VALUE" x="-5.08" y="464.82" size="1.778" layer="96" rot="MR180"/>
 </instance>
-<instance part="SUPPLY56" gate="G$1" x="-10.16" y="419.1" smashed="yes" rot="R90">
-<attribute name="VALUE" x="-12.954" y="419.1" size="1.778" layer="96" rot="R90" align="bottom-center"/>
+<instance part="SUPPLY56" gate="G$1" x="-7.62" y="403.86" smashed="yes" rot="R90">
+<attribute name="VALUE" x="-10.414" y="403.86" size="1.778" layer="96" rot="R90" align="bottom-center"/>
 </instance>
-<instance part="GND22" gate="1" x="-5.08" y="401.32" smashed="yes" rot="MR0">
-<attribute name="VALUE" x="-2.54" y="398.78" size="1.778" layer="96" rot="MR0"/>
+<instance part="GND22" gate="1" x="-5.08" y="388.62" smashed="yes" rot="MR0">
+<attribute name="VALUE" x="-2.54" y="386.08" size="1.778" layer="96" rot="MR0"/>
 </instance>
 <instance part="U6" gate="U1" x="-15.24" y="269.24" smashed="yes" rot="R180">
 <attribute name="NAME" x="-7.62" y="253.238" size="1.778" layer="95" font="vector" rot="R180"/>
@@ -30164,25 +30292,25 @@ Thomas Hudson</text>
 <attribute name="NAME" x="-304.8" y="873.76" size="1.778" layer="95"/>
 <attribute name="VALUE" x="-304.8" y="871.22" size="1.778" layer="96"/>
 </instance>
-<instance part="C1" gate="G$1" x="-10.16" y="1056.64" smashed="yes">
-<attribute name="NAME" x="-8.636" y="1059.561" size="1.778" layer="95" font="vector"/>
-<attribute name="VALUE" x="-8.636" y="1054.481" size="1.778" layer="96" font="vector"/>
+<instance part="C1" gate="G$1" x="-10.16" y="1046.48" smashed="yes">
+<attribute name="NAME" x="-8.636" y="1049.401" size="1.778" layer="95" font="vector"/>
+<attribute name="VALUE" x="-8.636" y="1044.321" size="1.778" layer="96" font="vector"/>
 </instance>
-<instance part="C2" gate="G$1" x="-10.16" y="901.7" smashed="yes">
-<attribute name="NAME" x="-8.636" y="904.621" size="1.778" layer="95" font="vector"/>
-<attribute name="VALUE" x="-8.636" y="899.541" size="1.778" layer="96" font="vector"/>
+<instance part="C2" gate="G$1" x="-10.16" y="891.54" smashed="yes">
+<attribute name="NAME" x="-8.636" y="894.461" size="1.778" layer="95" font="vector"/>
+<attribute name="VALUE" x="-8.636" y="889.381" size="1.778" layer="96" font="vector"/>
 </instance>
-<instance part="C3" gate="G$1" x="-7.62" y="726.44" smashed="yes">
-<attribute name="NAME" x="-6.096" y="729.361" size="1.778" layer="95" font="vector"/>
-<attribute name="VALUE" x="-6.096" y="724.281" size="1.778" layer="96" font="vector"/>
+<instance part="C3" gate="G$1" x="-7.62" y="728.98" smashed="yes">
+<attribute name="NAME" x="-6.096" y="731.901" size="1.778" layer="95" font="vector"/>
+<attribute name="VALUE" x="-6.096" y="726.821" size="1.778" layer="96" font="vector"/>
 </instance>
-<instance part="C4" gate="G$1" x="-7.62" y="563.88" smashed="yes">
-<attribute name="NAME" x="-6.096" y="566.801" size="1.778" layer="95" font="vector"/>
-<attribute name="VALUE" x="-6.096" y="561.721" size="1.778" layer="96" font="vector"/>
+<instance part="C4" gate="G$1" x="-7.62" y="546.1" smashed="yes">
+<attribute name="NAME" x="-6.096" y="549.021" size="1.778" layer="95" font="vector"/>
+<attribute name="VALUE" x="-6.096" y="543.941" size="1.778" layer="96" font="vector"/>
 </instance>
-<instance part="C5" gate="G$1" x="-5.08" y="408.94" smashed="yes">
-<attribute name="NAME" x="-3.556" y="411.861" size="1.778" layer="95" font="vector"/>
-<attribute name="VALUE" x="-3.556" y="406.781" size="1.778" layer="96" font="vector"/>
+<instance part="C5" gate="G$1" x="-5.08" y="396.24" smashed="yes">
+<attribute name="NAME" x="-3.556" y="399.161" size="1.778" layer="95" font="vector"/>
+<attribute name="VALUE" x="-3.556" y="394.081" size="1.778" layer="96" font="vector"/>
 </instance>
 <instance part="C6" gate="G$1" x="-5.08" y="233.68" smashed="yes">
 <attribute name="NAME" x="-3.556" y="236.601" size="1.778" layer="95" font="vector"/>
@@ -30263,23 +30391,23 @@ Thomas Hudson</text>
 <instance part="GND20" gate="1" x="-193.04" y="970.28" smashed="yes" rot="R90">
 <attribute name="VALUE" x="-190.5" y="967.74" size="1.778" layer="96" rot="R90"/>
 </instance>
-<instance part="GND9" gate="1" x="15.24" y="1089.66" smashed="yes" rot="MR270">
-<attribute name="VALUE" x="17.78" y="1092.2" size="1.778" layer="96" rot="MR270"/>
+<instance part="GND9" gate="1" x="15.24" y="1079.5" smashed="yes" rot="MR270">
+<attribute name="VALUE" x="17.78" y="1082.04" size="1.778" layer="96" rot="MR270"/>
 </instance>
 <instance part="GND30" gate="1" x="15.24" y="266.7" smashed="yes" rot="MR270">
 <attribute name="VALUE" x="17.78" y="269.24" size="1.778" layer="96" rot="MR270"/>
 </instance>
-<instance part="GND31" gate="1" x="15.24" y="441.96" smashed="yes" rot="MR270">
-<attribute name="VALUE" x="17.78" y="444.5" size="1.778" layer="96" rot="MR270"/>
+<instance part="GND31" gate="1" x="15.24" y="431.8" smashed="yes" rot="MR270">
+<attribute name="VALUE" x="17.78" y="434.34" size="1.778" layer="96" rot="MR270"/>
 </instance>
-<instance part="GND32" gate="1" x="10.16" y="596.9" smashed="yes" rot="MR270">
-<attribute name="VALUE" x="12.7" y="599.44" size="1.778" layer="96" rot="MR270"/>
+<instance part="GND32" gate="1" x="10.16" y="586.74" smashed="yes" rot="MR270">
+<attribute name="VALUE" x="12.7" y="589.28" size="1.778" layer="96" rot="MR270"/>
 </instance>
-<instance part="GND33" gate="1" x="12.7" y="759.46" smashed="yes" rot="MR270">
-<attribute name="VALUE" x="15.24" y="762" size="1.778" layer="96" rot="MR270"/>
+<instance part="GND33" gate="1" x="12.7" y="762" smashed="yes" rot="MR270">
+<attribute name="VALUE" x="15.24" y="764.54" size="1.778" layer="96" rot="MR270"/>
 </instance>
-<instance part="GND34" gate="1" x="17.78" y="934.72" smashed="yes" rot="MR270">
-<attribute name="VALUE" x="20.32" y="937.26" size="1.778" layer="96" rot="MR270"/>
+<instance part="GND34" gate="1" x="17.78" y="924.56" smashed="yes" rot="MR270">
+<attribute name="VALUE" x="20.32" y="927.1" size="1.778" layer="96" rot="MR270"/>
 </instance>
 <instance part="R1" gate="G$1" x="-198.12" y="909.32" smashed="yes" rot="R270">
 <attribute name="NAME" x="-196.6214" y="913.13" size="1.778" layer="95" rot="R270"/>
@@ -30303,6 +30431,36 @@ Thomas Hudson</text>
 <attribute name="VALUE" x="-245.11" y="1026.16" size="1.778" layer="96"/>
 </instance>
 <instance part="U$44" gate="G$1" x="-370.84" y="886.46" smashed="yes"/>
+<instance part="SERVO5" gate="A" x="-370.84" y="833.12" smashed="yes">
+<attribute name="NAME" x="-377.19" y="838.835" size="1.778" layer="95"/>
+<attribute name="VALUE" x="-377.19" y="825.5" size="1.778" layer="96"/>
+</instance>
+<instance part="SERVO4" gate="A" x="-358.14" y="833.12" smashed="yes">
+<attribute name="NAME" x="-364.49" y="838.835" size="1.778" layer="95"/>
+<attribute name="VALUE" x="-364.49" y="825.5" size="1.778" layer="96"/>
+</instance>
+<instance part="SERVO3" gate="A" x="-345.44" y="833.12" smashed="yes">
+<attribute name="NAME" x="-351.79" y="838.835" size="1.778" layer="95"/>
+<attribute name="VALUE" x="-351.79" y="825.5" size="1.778" layer="96"/>
+</instance>
+<instance part="SERVO2" gate="A" x="-332.74" y="833.12" smashed="yes">
+<attribute name="NAME" x="-339.09" y="838.835" size="1.778" layer="95"/>
+<attribute name="VALUE" x="-339.09" y="825.5" size="1.778" layer="96"/>
+</instance>
+<instance part="SERVO1" gate="A" x="-320.04" y="833.12" smashed="yes">
+<attribute name="NAME" x="-326.39" y="838.835" size="1.778" layer="95"/>
+<attribute name="VALUE" x="-326.39" y="825.5" size="1.778" layer="96"/>
+</instance>
+<instance part="SUPPLY58" gate="G$1" x="-386.08" y="833.12" smashed="yes" rot="R90">
+<attribute name="VALUE" x="-389.636" y="832.104" size="1.778" layer="96" rot="R90"/>
+</instance>
+<instance part="GND35" gate="1" x="-396.24" y="835.66" smashed="yes" rot="R270">
+<attribute name="VALUE" x="-398.78" y="838.2" size="1.778" layer="96" rot="R270"/>
+</instance>
+<instance part="U09I" gate="G$1" x="-104.14" y="609.6" smashed="yes">
+<attribute name="VALUE" x="-105.918" y="612.648" size="1.778" layer="96"/>
+<attribute name="NAME" x="-105.41" y="602.488" size="1.778" layer="95"/>
+</instance>
 </instances>
 <busses>
 </busses>
@@ -30354,56 +30512,55 @@ Thomas Hudson</text>
 </segment>
 <segment>
 <pinref part="U1" gate="U1" pin="GND"/>
-<wire x1="-10.16" y1="1102.36" x2="-7.62" y2="1102.36" width="0.1524" layer="91"/>
-<wire x1="-7.62" y1="1102.36" x2="-7.62" y2="1107.44" width="0.1524" layer="91"/>
+<wire x1="-10.16" y1="1092.2" x2="-7.62" y2="1092.2" width="0.1524" layer="91"/>
+<wire x1="-7.62" y1="1092.2" x2="-7.62" y2="1097.28" width="0.1524" layer="91"/>
 <pinref part="GND8" gate="1" pin="GND"/>
 </segment>
 <segment>
-<wire x1="-10.16" y1="1054.1" x2="-10.16" y2="1051.56" width="0.1524" layer="91"/>
+<wire x1="-10.16" y1="1043.94" x2="-10.16" y2="1041.4" width="0.1524" layer="91"/>
 <pinref part="GND10" gate="1" pin="GND"/>
 <pinref part="C1" gate="G$1" pin="2"/>
 </segment>
 <segment>
 <pinref part="U2" gate="U1" pin="GND"/>
-<wire x1="-10.16" y1="947.42" x2="-7.62" y2="947.42" width="0.1524" layer="91"/>
-<wire x1="-7.62" y1="947.42" x2="-7.62" y2="952.5" width="0.1524" layer="91"/>
+<wire x1="-10.16" y1="937.26" x2="-7.62" y2="937.26" width="0.1524" layer="91"/>
+<wire x1="-7.62" y1="937.26" x2="-7.62" y2="942.34" width="0.1524" layer="91"/>
 <pinref part="GND12" gate="1" pin="GND"/>
 </segment>
 <segment>
-<wire x1="-10.16" y1="899.16" x2="-10.16" y2="896.62" width="0.1524" layer="91"/>
+<wire x1="-10.16" y1="889" x2="-10.16" y2="886.46" width="0.1524" layer="91"/>
 <pinref part="GND13" gate="1" pin="GND"/>
 <pinref part="C2" gate="G$1" pin="2"/>
 </segment>
 <segment>
 <pinref part="U3" gate="U1" pin="GND"/>
-<wire x1="-7.62" y1="772.16" x2="-5.08" y2="772.16" width="0.1524" layer="91"/>
-<wire x1="-5.08" y1="772.16" x2="-5.08" y2="777.24" width="0.1524" layer="91"/>
+<wire x1="-7.62" y1="774.7" x2="-5.08" y2="774.7" width="0.1524" layer="91"/>
+<wire x1="-5.08" y1="774.7" x2="-5.08" y2="779.78" width="0.1524" layer="91"/>
 <pinref part="GND15" gate="1" pin="GND"/>
 </segment>
 <segment>
-<wire x1="-7.62" y1="723.9" x2="-7.62" y2="721.36" width="0.1524" layer="91"/>
+<wire x1="-7.62" y1="726.44" x2="-7.62" y2="723.9" width="0.1524" layer="91"/>
 <pinref part="GND16" gate="1" pin="GND"/>
 <pinref part="C3" gate="G$1" pin="2"/>
 </segment>
 <segment>
 <pinref part="U4" gate="U1" pin="GND"/>
-<wire x1="-7.62" y1="609.6" x2="-5.08" y2="609.6" width="0.1524" layer="91"/>
-<wire x1="-5.08" y1="609.6" x2="-5.08" y2="614.68" width="0.1524" layer="91"/>
+<wire x1="-7.62" y1="599.44" x2="-2.54" y2="599.44" width="0.1524" layer="91"/>
 <pinref part="GND18" gate="1" pin="GND"/>
 </segment>
 <segment>
-<wire x1="-7.62" y1="561.34" x2="-7.62" y2="558.8" width="0.1524" layer="91"/>
+<wire x1="-7.62" y1="543.56" x2="-7.62" y2="541.02" width="0.1524" layer="91"/>
 <pinref part="GND19" gate="1" pin="GND"/>
 <pinref part="C4" gate="G$1" pin="2"/>
 </segment>
 <segment>
 <pinref part="U5" gate="U1" pin="GND"/>
-<wire x1="-5.08" y1="454.66" x2="-2.54" y2="454.66" width="0.1524" layer="91"/>
-<wire x1="-2.54" y1="454.66" x2="-2.54" y2="459.74" width="0.1524" layer="91"/>
+<wire x1="-5.08" y1="444.5" x2="-2.54" y2="444.5" width="0.1524" layer="91"/>
+<wire x1="-2.54" y1="444.5" x2="-2.54" y2="459.74" width="0.1524" layer="91"/>
 <pinref part="GND21" gate="1" pin="GND"/>
 </segment>
 <segment>
-<wire x1="-5.08" y1="406.4" x2="-5.08" y2="403.86" width="0.1524" layer="91"/>
+<wire x1="-5.08" y1="393.7" x2="-5.08" y2="391.16" width="0.1524" layer="91"/>
 <pinref part="GND22" gate="1" pin="GND"/>
 <pinref part="C5" gate="G$1" pin="2"/>
 </segment>
@@ -30459,7 +30616,7 @@ Thomas Hudson</text>
 <segment>
 <pinref part="U1" gate="U1" pin="CLK_INH"/>
 <pinref part="GND9" gate="1" pin="GND"/>
-<wire x1="12.7" y1="1089.66" x2="-10.16" y2="1089.66" width="0.1524" layer="91"/>
+<wire x1="12.7" y1="1079.5" x2="-10.16" y2="1079.5" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="U6" gate="U1" pin="CLK_INH"/>
@@ -30469,239 +30626,227 @@ Thomas Hudson</text>
 <segment>
 <pinref part="U5" gate="U1" pin="CLK_INH"/>
 <pinref part="GND31" gate="1" pin="GND"/>
-<wire x1="12.7" y1="441.96" x2="-5.08" y2="441.96" width="0.1524" layer="91"/>
+<wire x1="12.7" y1="431.8" x2="-5.08" y2="431.8" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="U4" gate="U1" pin="CLK_INH"/>
 <pinref part="GND32" gate="1" pin="GND"/>
-<wire x1="7.62" y1="596.9" x2="-7.62" y2="596.9" width="0.1524" layer="91"/>
+<wire x1="7.62" y1="586.74" x2="-7.62" y2="586.74" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="U3" gate="U1" pin="CLK_INH"/>
 <pinref part="GND33" gate="1" pin="GND"/>
-<wire x1="10.16" y1="759.46" x2="-7.62" y2="759.46" width="0.1524" layer="91"/>
+<wire x1="10.16" y1="762" x2="-7.62" y2="762" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="U2" gate="U1" pin="CLK_INH"/>
 <pinref part="GND34" gate="1" pin="GND"/>
-<wire x1="15.24" y1="934.72" x2="-10.16" y2="934.72" width="0.1524" layer="91"/>
+<wire x1="15.24" y1="924.56" x2="-10.16" y2="924.56" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <wire x1="-213.36" y1="1064.26" x2="-200.66" y2="1064.26" width="0.1524" layer="91"/>
 <pinref part="GND23" gate="1" pin="GND"/>
 <pinref part="U$45" gate="G$1" pin="GND"/>
 </segment>
-</net>
-<net name="N$30" class="0">
 <segment>
-<wire x1="-106.68" y1="281.94" x2="-106.68" y2="259.08" width="0.1524" layer="91"/>
+<pinref part="GND35" gate="1" pin="GND"/>
+<pinref part="SERVO5" gate="A" pin="1"/>
+<wire x1="-393.7" y1="835.66" x2="-373.38" y2="835.66" width="0.1524" layer="91"/>
+<pinref part="SERVO4" gate="A" pin="1"/>
+<wire x1="-373.38" y1="835.66" x2="-360.68" y2="835.66" width="0.1524" layer="91"/>
+<junction x="-373.38" y="835.66"/>
+<pinref part="SERVO3" gate="A" pin="1"/>
+<wire x1="-360.68" y1="835.66" x2="-347.98" y2="835.66" width="0.1524" layer="91"/>
+<junction x="-360.68" y="835.66"/>
+<pinref part="SERVO2" gate="A" pin="1"/>
+<wire x1="-347.98" y1="835.66" x2="-335.28" y2="835.66" width="0.1524" layer="91"/>
+<junction x="-347.98" y="835.66"/>
+<pinref part="SERVO1" gate="A" pin="1"/>
+<wire x1="-335.28" y1="835.66" x2="-322.58" y2="835.66" width="0.1524" layer="91"/>
+<junction x="-335.28" y="835.66"/>
+</segment>
+</net>
+<net name="SNS01I" class="0">
+<segment>
+<wire x1="-106.68" y1="281.94" x2="-106.68" y2="271.78" width="0.1524" layer="91"/>
 <wire x1="-106.68" y1="281.94" x2="-162.56" y2="281.94" width="0.1524" layer="91"/>
 <wire x1="-162.56" y1="281.94" x2="-162.56" y2="365.76" width="0.1524" layer="91"/>
 <wire x1="-162.56" y1="365.76" x2="-172.72" y2="365.76" width="0.1524" layer="91"/>
 <junction x="-106.68" y="281.94"/>
-<wire x1="-106.68" y1="259.08" x2="-25.4" y2="259.08" width="0.1524" layer="91"/>
-<pinref part="U$114" gate="G$1" pin="E"/>
+<pinref part="U01I" gate="G$1" pin="E"/>
 <pinref part="R12" gate="G$1" pin="3"/>
-<pinref part="U6" gate="U1" pin="A"/>
-</segment>
-</net>
-<net name="N$101" class="0">
-<segment>
-<wire x1="-106.68" y1="314.96" x2="-106.68" y2="307.34" width="0.1524" layer="91"/>
-<wire x1="-106.68" y1="307.34" x2="-58.42" y2="307.34" width="0.1524" layer="91"/>
-<wire x1="-58.42" y1="307.34" x2="-58.42" y2="264.16" width="0.1524" layer="91"/>
-<wire x1="-106.68" y1="307.34" x2="-160.02" y2="307.34" width="0.1524" layer="91"/>
-<wire x1="-160.02" y1="307.34" x2="-160.02" y2="368.3" width="0.1524" layer="91"/>
-<wire x1="-160.02" y1="368.3" x2="-172.72" y2="368.3" width="0.1524" layer="91"/>
-<junction x="-106.68" y="307.34"/>
-<wire x1="-58.42" y1="264.16" x2="-25.4" y2="264.16" width="0.1524" layer="91"/>
-<pinref part="U$112" gate="G$1" pin="E"/>
-<junction x="-106.68" y="314.96"/>
-<pinref part="R12" gate="G$1" pin="4"/>
-<pinref part="U6" gate="U1" pin="C"/>
-</segment>
-</net>
-<net name="N$102" class="0">
-<segment>
-<wire x1="-88.9" y1="314.96" x2="-88.9" y2="309.88" width="0.1524" layer="91"/>
-<wire x1="-88.9" y1="309.88" x2="-55.88" y2="309.88" width="0.1524" layer="91"/>
-<wire x1="-55.88" y1="309.88" x2="-55.88" y2="266.7" width="0.1524" layer="91"/>
-<wire x1="-88.9" y1="309.88" x2="-157.48" y2="309.88" width="0.1524" layer="91"/>
-<wire x1="-157.48" y1="309.88" x2="-157.48" y2="370.84" width="0.1524" layer="91"/>
-<wire x1="-157.48" y1="370.84" x2="-172.72" y2="370.84" width="0.1524" layer="91"/>
-<junction x="-88.9" y="309.88"/>
-<wire x1="-25.4" y1="266.7" x2="-55.88" y2="266.7" width="0.1524" layer="91"/>
-<pinref part="U$113" gate="G$1" pin="E"/>
-<junction x="-88.9" y="314.96"/>
-<pinref part="R12" gate="G$1" pin="5"/>
-<pinref part="U6" gate="U1" pin="D"/>
-</segment>
-</net>
-<net name="N$108" class="0">
-<segment>
-<wire x1="-106.68" y1="386.08" x2="-106.68" y2="378.46" width="0.1524" layer="91"/>
-<wire x1="-106.68" y1="378.46" x2="-48.26" y2="378.46" width="0.1524" layer="91"/>
-<wire x1="-48.26" y1="274.32" x2="-48.26" y2="378.46" width="0.1524" layer="91"/>
-<wire x1="-106.68" y1="378.46" x2="-172.72" y2="378.46" width="0.1524" layer="91"/>
-<junction x="-106.68" y="378.46"/>
-<wire x1="-48.26" y1="274.32" x2="-25.4" y2="274.32" width="0.1524" layer="91"/>
-<pinref part="U$108" gate="G$1" pin="E"/>
-<junction x="-106.68" y="386.08"/>
-<pinref part="R12" gate="G$1" pin="8"/>
-<pinref part="U6" gate="U1" pin="G"/>
-</segment>
-</net>
-<net name="N$109" class="0">
-<segment>
-<wire x1="-88.9" y1="386.08" x2="-88.9" y2="381" width="0.1524" layer="91"/>
-<wire x1="-88.9" y1="381" x2="-45.72" y2="381" width="0.1524" layer="91"/>
-<wire x1="-45.72" y1="381" x2="-45.72" y2="276.86" width="0.1524" layer="91"/>
-<wire x1="-172.72" y1="381" x2="-88.9" y2="381" width="0.1524" layer="91"/>
-<junction x="-88.9" y="381"/>
-<wire x1="-25.4" y1="276.86" x2="-45.72" y2="276.86" width="0.1524" layer="91"/>
-<pinref part="U$109" gate="G$1" pin="E"/>
-<junction x="-88.9" y="386.08"/>
-<pinref part="R12" gate="G$1" pin="9"/>
-<pinref part="U6" gate="U1" pin="H"/>
-</segment>
-</net>
-<net name="N$18" class="0">
-<segment>
-<wire x1="-106.68" y1="350.52" x2="-106.68" y2="342.9" width="0.1524" layer="91"/>
-<wire x1="-106.68" y1="342.9" x2="-53.34" y2="342.9" width="0.1524" layer="91"/>
-<wire x1="-106.68" y1="342.9" x2="-154.94" y2="342.9" width="0.1524" layer="91"/>
-<junction x="-106.68" y="342.9"/>
-<wire x1="-53.34" y1="269.24" x2="-53.34" y2="342.9" width="0.1524" layer="91"/>
-<wire x1="-154.94" y1="342.9" x2="-154.94" y2="373.38" width="0.1524" layer="91"/>
-<wire x1="-154.94" y1="373.38" x2="-172.72" y2="373.38" width="0.1524" layer="91"/>
-<wire x1="-53.34" y1="269.24" x2="-25.4" y2="269.24" width="0.1524" layer="91"/>
-<pinref part="U$110" gate="G$1" pin="E"/>
-<junction x="-106.68" y="350.52"/>
-<pinref part="R12" gate="G$1" pin="6"/>
-<pinref part="U6" gate="U1" pin="E"/>
-</segment>
-</net>
-<net name="N$58" class="0">
-<segment>
-<wire x1="-88.9" y1="350.52" x2="-88.9" y2="345.44" width="0.1524" layer="91"/>
-<wire x1="-88.9" y1="345.44" x2="-50.8" y2="345.44" width="0.1524" layer="91"/>
-<wire x1="-50.8" y1="345.44" x2="-50.8" y2="271.78" width="0.1524" layer="91"/>
-<wire x1="-88.9" y1="345.44" x2="-152.4" y2="345.44" width="0.1524" layer="91"/>
-<junction x="-88.9" y="345.44"/>
-<wire x1="-152.4" y1="345.44" x2="-152.4" y2="375.92" width="0.1524" layer="91"/>
-<wire x1="-152.4" y1="375.92" x2="-172.72" y2="375.92" width="0.1524" layer="91"/>
-<wire x1="-25.4" y1="271.78" x2="-50.8" y2="271.78" width="0.1524" layer="91"/>
-<pinref part="U$111" gate="G$1" pin="E"/>
-<junction x="-88.9" y="350.52"/>
-<pinref part="R12" gate="G$1" pin="7"/>
 <pinref part="U6" gate="U1" pin="F"/>
+<wire x1="-25.4" y1="271.78" x2="-106.68" y2="271.78" width="0.1524" layer="91"/>
+<label x="-124.46" y="281.94" size="1.778" layer="95"/>
+<label x="-38.1" y="271.78" size="1.778" layer="95"/>
 </segment>
 </net>
-<net name="N$105" class="0">
+<net name="SNS02I" class="0">
 <segment>
-<wire x1="-86.36" y1="482.6" x2="-86.36" y2="477.52" width="0.1524" layer="91"/>
-<wire x1="-86.36" y1="477.52" x2="-53.34" y2="477.52" width="0.1524" layer="91"/>
-<wire x1="-53.34" y1="477.52" x2="-53.34" y2="441.96" width="0.1524" layer="91"/>
-<wire x1="-53.34" y1="441.96" x2="-154.94" y2="441.96" width="0.1524" layer="91"/>
-<junction x="-53.34" y="441.96"/>
-<wire x1="-154.94" y1="441.96" x2="-154.94" y2="538.48" width="0.1524" layer="91"/>
-<wire x1="-154.94" y1="538.48" x2="-170.18" y2="538.48" width="0.1524" layer="91"/>
-<wire x1="-53.34" y1="441.96" x2="-25.4" y2="441.96" width="0.1524" layer="91"/>
-<pinref part="U$105" gate="G$1" pin="E"/>
-<junction x="-86.36" y="482.6"/>
-<pinref part="R11" gate="G$1" pin="5"/>
-<pinref part="U5" gate="U1" pin="D"/>
+<wire x1="-106.68" y1="314.96" x2="-106.68" y2="309.88" width="0.1524" layer="91"/>
+<wire x1="-106.68" y1="309.88" x2="-55.88" y2="309.88" width="0.1524" layer="91"/>
+<wire x1="-55.88" y1="309.88" x2="-55.88" y2="276.86" width="0.1524" layer="91"/>
+<wire x1="-106.68" y1="309.88" x2="-157.48" y2="309.88" width="0.1524" layer="91"/>
+<junction x="-106.68" y="309.88"/>
+<pinref part="U02I" gate="G$1" pin="E"/>
+<junction x="-106.68" y="314.96"/>
+<wire x1="-157.48" y1="370.84" x2="-172.72" y2="370.84" width="0.1524" layer="91"/>
+<pinref part="R12" gate="G$1" pin="5"/>
+<wire x1="-157.48" y1="309.88" x2="-157.48" y2="370.84" width="0.1524" layer="91"/>
+<pinref part="U6" gate="U1" pin="H"/>
+<wire x1="-25.4" y1="276.86" x2="-55.88" y2="276.86" width="0.1524" layer="91"/>
+<label x="-124.46" y="309.88" size="1.778" layer="95"/>
+<label x="-38.1" y="276.86" size="1.778" layer="95"/>
 </segment>
 </net>
-<net name="N$112" class="0">
+<net name="SNS04I" class="0">
 <segment>
-<wire x1="-86.36" y1="553.72" x2="-86.36" y2="548.64" width="0.1524" layer="91"/>
-<wire x1="-86.36" y1="548.64" x2="-43.18" y2="548.64" width="0.1524" layer="91"/>
-<wire x1="-43.18" y1="548.64" x2="-43.18" y2="452.12" width="0.1524" layer="91"/>
-<wire x1="-86.36" y1="548.64" x2="-170.18" y2="548.64" width="0.1524" layer="91"/>
-<junction x="-86.36" y="548.64"/>
-<wire x1="-25.4" y1="452.12" x2="-43.18" y2="452.12" width="0.1524" layer="91"/>
-<pinref part="U$101" gate="G$1" pin="E"/>
-<junction x="-86.36" y="553.72"/>
+<wire x1="-106.68" y1="386.08" x2="-106.68" y2="381" width="0.1524" layer="91"/>
+<wire x1="-106.68" y1="381" x2="-45.72" y2="381" width="0.1524" layer="91"/>
+<wire x1="-45.72" y1="259.08" x2="-45.72" y2="381" width="0.1524" layer="91"/>
+<pinref part="U04I" gate="G$1" pin="E"/>
+<junction x="-106.68" y="386.08"/>
+<label x="-124.46" y="381" size="1.778" layer="95"/>
+<pinref part="U6" gate="U1" pin="A"/>
+<wire x1="-45.72" y1="259.08" x2="-25.4" y2="259.08" width="0.1524" layer="91"/>
+<label x="-38.1" y="259.08" size="1.778" layer="95"/>
+<pinref part="R12" gate="G$1" pin="9"/>
+<wire x1="-172.72" y1="381" x2="-106.68" y2="381" width="0.1524" layer="91"/>
+<junction x="-106.68" y="381"/>
+</segment>
+</net>
+<net name="SNS04O" class="0">
+<segment>
+<wire x1="-88.9" y1="386.08" x2="-88.9" y2="378.46" width="0.1524" layer="91"/>
+<wire x1="-88.9" y1="378.46" x2="-48.26" y2="378.46" width="0.1524" layer="91"/>
+<wire x1="-48.26" y1="378.46" x2="-48.26" y2="261.62" width="0.1524" layer="91"/>
+<pinref part="U04O" gate="G$1" pin="E"/>
+<junction x="-88.9" y="386.08"/>
+<label x="-124.46" y="378.46" size="1.778" layer="95"/>
+<pinref part="U6" gate="U1" pin="B"/>
+<wire x1="-25.4" y1="261.62" x2="-48.26" y2="261.62" width="0.1524" layer="91"/>
+<label x="-38.1" y="261.62" size="1.778" layer="95"/>
+<pinref part="R12" gate="G$1" pin="8"/>
+<wire x1="-172.72" y1="378.46" x2="-88.9" y2="378.46" width="0.1524" layer="91"/>
+<junction x="-88.9" y="378.46"/>
+</segment>
+</net>
+<net name="SNS03I" class="0">
+<segment>
+<wire x1="-106.68" y1="350.52" x2="-106.68" y2="345.44" width="0.1524" layer="91"/>
+<wire x1="-106.68" y1="345.44" x2="-50.8" y2="345.44" width="0.1524" layer="91"/>
+<wire x1="-50.8" y1="264.16" x2="-50.8" y2="345.44" width="0.1524" layer="91"/>
+<pinref part="U03I" gate="G$1" pin="E"/>
+<junction x="-106.68" y="350.52"/>
+<pinref part="U6" gate="U1" pin="C"/>
+<wire x1="-25.4" y1="264.16" x2="-50.8" y2="264.16" width="0.1524" layer="91"/>
+<label x="-38.1" y="264.16" size="1.778" layer="95"/>
+<pinref part="R12" gate="G$1" pin="7"/>
+<wire x1="-152.4" y1="375.92" x2="-172.72" y2="375.92" width="0.1524" layer="91"/>
+<wire x1="-152.4" y1="345.44" x2="-152.4" y2="375.92" width="0.1524" layer="91"/>
+<wire x1="-152.4" y1="345.44" x2="-106.68" y2="345.44" width="0.1524" layer="91"/>
+<junction x="-106.68" y="345.44"/>
+<label x="-124.46" y="345.44" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="SNS03O" class="0">
+<segment>
+<wire x1="-88.9" y1="350.52" x2="-88.9" y2="342.9" width="0.1524" layer="91"/>
+<wire x1="-88.9" y1="342.9" x2="-53.34" y2="342.9" width="0.1524" layer="91"/>
+<wire x1="-53.34" y1="342.9" x2="-53.34" y2="266.7" width="0.1524" layer="91"/>
+<pinref part="U03O" gate="G$1" pin="E"/>
+<junction x="-88.9" y="350.52"/>
+<pinref part="U6" gate="U1" pin="D"/>
+<wire x1="-25.4" y1="266.7" x2="-53.34" y2="266.7" width="0.1524" layer="91"/>
+<label x="-38.1" y="266.7" size="1.778" layer="95"/>
+<pinref part="R12" gate="G$1" pin="6"/>
+<wire x1="-154.94" y1="373.38" x2="-172.72" y2="373.38" width="0.1524" layer="91"/>
+<wire x1="-154.94" y1="342.9" x2="-154.94" y2="373.38" width="0.1524" layer="91"/>
+<wire x1="-154.94" y1="342.9" x2="-88.9" y2="342.9" width="0.1524" layer="91"/>
+<junction x="-88.9" y="342.9"/>
+<label x="-124.46" y="342.9" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="SNS08I" class="0">
+<segment>
+<wire x1="-43.18" y1="548.64" x2="-43.18" y2="424.18" width="0.1524" layer="91"/>
+<pinref part="U08I" gate="G$1" pin="E"/>
+<junction x="-104.14" y="553.72"/>
+<wire x1="-104.14" y1="553.72" x2="-104.14" y2="548.64" width="0.1524" layer="91"/>
 <pinref part="R11" gate="G$1" pin="9"/>
-<pinref part="U5" gate="U1" pin="H"/>
+<wire x1="-170.18" y1="548.64" x2="-104.14" y2="548.64" width="0.1524" layer="91"/>
+<label x="-124.46" y="548.64" size="1.778" layer="95"/>
+<wire x1="-104.14" y1="548.64" x2="-43.18" y2="548.64" width="0.1524" layer="91"/>
+<junction x="-104.14" y="548.64"/>
+<pinref part="U5" gate="U1" pin="A"/>
+<wire x1="-25.4" y1="424.18" x2="-43.18" y2="424.18" width="0.1524" layer="91"/>
+<label x="-38.1" y="424.18" size="1.778" layer="95"/>
 </segment>
 </net>
-<net name="N$117" class="0">
+<net name="SNS10I" class="0">
 <segment>
-<wire x1="-86.36" y1="518.16" x2="-86.36" y2="513.08" width="0.1524" layer="91"/>
-<wire x1="-86.36" y1="513.08" x2="-48.26" y2="513.08" width="0.1524" layer="91"/>
-<wire x1="-48.26" y1="513.08" x2="-48.26" y2="447.04" width="0.1524" layer="91"/>
-<wire x1="-86.36" y1="513.08" x2="-149.86" y2="513.08" width="0.1524" layer="91"/>
-<junction x="-86.36" y="513.08"/>
-<wire x1="-170.18" y1="543.56" x2="-149.86" y2="543.56" width="0.1524" layer="91"/>
-<wire x1="-149.86" y1="543.56" x2="-149.86" y2="513.08" width="0.1524" layer="91"/>
-<wire x1="-25.4" y1="447.04" x2="-48.26" y2="447.04" width="0.1524" layer="91"/>
-<pinref part="U$103" gate="G$1" pin="E"/>
-<junction x="-86.36" y="518.16"/>
-<pinref part="R11" gate="G$1" pin="7"/>
-<pinref part="U5" gate="U1" pin="F"/>
-</segment>
-</net>
-<net name="N$131" class="0">
-<segment>
-<wire x1="-88.9" y1="637.54" x2="-88.9" y2="632.46" width="0.1524" layer="91"/>
-<wire x1="-88.9" y1="632.46" x2="-55.88" y2="632.46" width="0.1524" layer="91"/>
-<wire x1="-55.88" y1="632.46" x2="-55.88" y2="596.9" width="0.1524" layer="91"/>
-<wire x1="-55.88" y1="596.9" x2="-152.4" y2="596.9" width="0.1524" layer="91"/>
-<junction x="-55.88" y="596.9"/>
+<wire x1="-58.42" y1="596.9" x2="-152.4" y2="596.9" width="0.1524" layer="91"/>
 <wire x1="-152.4" y1="596.9" x2="-152.4" y2="680.72" width="0.1524" layer="91"/>
 <wire x1="-152.4" y1="680.72" x2="-167.64" y2="680.72" width="0.1524" layer="91"/>
-<wire x1="-27.94" y1="596.9" x2="-55.88" y2="596.9" width="0.1524" layer="91"/>
-<pinref part="U$97" gate="G$1" pin="E"/>
-<junction x="-88.9" y="637.54"/>
 <pinref part="R7" gate="G$1" pin="5"/>
-<pinref part="U4" gate="U1" pin="D"/>
-</segment>
-</net>
-<net name="N$135" class="0">
-<segment>
-<wire x1="-88.9" y1="703.58" x2="-88.9" y2="698.5" width="0.1524" layer="91"/>
-<wire x1="-88.9" y1="698.5" x2="-45.72" y2="698.5" width="0.1524" layer="91"/>
-<wire x1="-45.72" y1="698.5" x2="-45.72" y2="607.06" width="0.1524" layer="91"/>
-<wire x1="-88.9" y1="698.5" x2="-167.64" y2="698.5" width="0.1524" layer="91"/>
-<junction x="-88.9" y="698.5"/>
-<wire x1="-167.64" y1="698.5" x2="-167.64" y2="690.88" width="0.1524" layer="91"/>
-<wire x1="-27.94" y1="607.06" x2="-45.72" y2="607.06" width="0.1524" layer="91"/>
-<pinref part="U$93" gate="G$1" pin="E"/>
-<junction x="-88.9" y="703.58"/>
-<pinref part="R7" gate="G$1" pin="9"/>
+<label x="-147.32" y="596.9" size="1.778" layer="95"/>
+<pinref part="U10I" gate="G$1" pin="E"/>
+<junction x="-106.68" y="637.54"/>
+<wire x1="-106.68" y1="637.54" x2="-106.68" y2="629.92" width="0.1524" layer="91"/>
+<wire x1="-106.68" y1="629.92" x2="-58.42" y2="629.92" width="0.1524" layer="91"/>
+<wire x1="-58.42" y1="629.92" x2="-58.42" y2="596.9" width="0.1524" layer="91"/>
+<wire x1="-58.42" y1="596.9" x2="-27.94" y2="596.9" width="0.1524" layer="91"/>
+<junction x="-58.42" y="596.9"/>
 <pinref part="U4" gate="U1" pin="H"/>
+<label x="-38.1" y="596.9" size="1.778" layer="95"/>
 </segment>
 </net>
-<net name="N$140" class="0">
+<net name="SNS12I" class="0">
 <segment>
-<wire x1="-88.9" y1="670.56" x2="-88.9" y2="665.48" width="0.1524" layer="91"/>
-<wire x1="-88.9" y1="665.48" x2="-50.8" y2="665.48" width="0.1524" layer="91"/>
-<wire x1="-50.8" y1="665.48" x2="-50.8" y2="601.98" width="0.1524" layer="91"/>
-<wire x1="-88.9" y1="665.48" x2="-147.32" y2="665.48" width="0.1524" layer="91"/>
+<wire x1="-43.18" y1="698.5" x2="-43.18" y2="579.12" width="0.1524" layer="91"/>
+<wire x1="-43.18" y1="698.5" x2="-106.68" y2="698.5" width="0.1524" layer="91"/>
+<wire x1="-106.68" y1="698.5" x2="-167.64" y2="698.5" width="0.1524" layer="91"/>
+<wire x1="-167.64" y1="698.5" x2="-167.64" y2="690.88" width="0.1524" layer="91"/>
+<pinref part="R7" gate="G$1" pin="9"/>
+<label x="-139.7" y="698.5" size="1.778" layer="95"/>
+<pinref part="U12I" gate="G$1" pin="E"/>
+<wire x1="-106.68" y1="703.58" x2="-106.68" y2="698.5" width="0.1524" layer="91"/>
+<junction x="-106.68" y="698.5"/>
+<pinref part="U4" gate="U1" pin="A"/>
+<wire x1="-43.18" y1="579.12" x2="-27.94" y2="579.12" width="0.1524" layer="91"/>
+<label x="-38.1" y="579.12" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="SNS11I" class="0">
+<segment>
+<wire x1="-48.26" y1="665.48" x2="-48.26" y2="584.2" width="0.1524" layer="91"/>
+<wire x1="-48.26" y1="665.48" x2="-106.68" y2="665.48" width="0.1524" layer="91"/>
+<wire x1="-106.68" y1="665.48" x2="-147.32" y2="665.48" width="0.1524" layer="91"/>
 <wire x1="-147.32" y1="665.48" x2="-147.32" y2="685.8" width="0.1524" layer="91"/>
-<junction x="-88.9" y="665.48"/>
 <wire x1="-167.64" y1="685.8" x2="-147.32" y2="685.8" width="0.1524" layer="91"/>
-<wire x1="-27.94" y1="601.98" x2="-50.8" y2="601.98" width="0.1524" layer="91"/>
-<pinref part="U$95" gate="G$1" pin="E"/>
-<junction x="-88.9" y="670.56"/>
 <pinref part="R7" gate="G$1" pin="7"/>
-<pinref part="U4" gate="U1" pin="F"/>
+<label x="-142.24" y="665.48" size="1.778" layer="95"/>
+<pinref part="U11I" gate="G$1" pin="E"/>
+<wire x1="-106.68" y1="670.56" x2="-106.68" y2="665.48" width="0.1524" layer="91"/>
+<junction x="-106.68" y="665.48"/>
+<pinref part="U4" gate="U1" pin="C"/>
+<wire x1="-48.26" y1="584.2" x2="-27.94" y2="584.2" width="0.1524" layer="91"/>
+<label x="-38.1" y="584.2" size="1.778" layer="95"/>
 </segment>
 </net>
-<net name="N$141" class="0">
+<net name="SNS09O" class="0">
 <segment>
-<wire x1="-88.9" y1="591.82" x2="-88.9" y2="601.98" width="0.1524" layer="91"/>
-<wire x1="-157.48" y1="591.82" x2="-88.9" y2="591.82" width="0.1524" layer="91"/>
-<junction x="-88.9" y="591.82"/>
-<wire x1="-157.48" y1="591.82" x2="-157.48" y2="675.64" width="0.1524" layer="91"/>
-<wire x1="-157.48" y1="675.64" x2="-167.64" y2="675.64" width="0.1524" layer="91"/>
-<wire x1="-27.94" y1="591.82" x2="-88.9" y2="591.82" width="0.1524" layer="91"/>
-<pinref part="U$99" gate="G$1" pin="E"/>
-<junction x="-88.9" y="601.98"/>
-<pinref part="R7" gate="G$1" pin="3"/>
-<pinref part="U4" gate="U1" pin="B"/>
+<wire x1="-160.02" y1="589.28" x2="-160.02" y2="673.1" width="0.1524" layer="91"/>
+<label x="-147.32" y="589.28" size="1.778" layer="95"/>
+<wire x1="-160.02" y1="589.28" x2="-88.9" y2="589.28" width="0.1524" layer="91"/>
+<pinref part="U4" gate="U1" pin="E"/>
+<pinref part="R7" gate="G$1" pin="2"/>
+<wire x1="-88.9" y1="589.28" x2="-27.94" y2="589.28" width="0.1524" layer="91"/>
+<wire x1="-167.64" y1="673.1" x2="-160.02" y2="673.1" width="0.1524" layer="91"/>
+<label x="-38.1" y="589.28" size="1.778" layer="95"/>
+<pinref part="U09O" gate="G$1" pin="E"/>
+<wire x1="-88.9" y1="601.98" x2="-88.9" y2="589.28" width="0.1524" layer="91"/>
+<junction x="-88.9" y="589.28"/>
 </segment>
 </net>
 <net name="3.3V" class="0">
@@ -30712,15 +30857,15 @@ Thomas Hudson</text>
 <wire x1="-99.06" y1="716.28" x2="-99.06" y2="718.82" width="0.1524" layer="91"/>
 <wire x1="-99.06" y1="718.82" x2="-106.68" y2="718.82" width="0.1524" layer="91"/>
 <junction x="-106.68" y="718.82"/>
-<pinref part="U$92" gate="G$1" pin="A"/>
+<pinref part="U12I" gate="G$1" pin="A"/>
 <junction x="-99.06" y="716.28"/>
-<pinref part="U$92" gate="G$1" pin="C"/>
+<pinref part="U12I" gate="G$1" pin="C"/>
 <junction x="-106.68" y="716.28"/>
 </segment>
 <segment>
 <wire x1="-88.9" y1="716.28" x2="-88.9" y2="723.9" width="0.1524" layer="91"/>
 <pinref part="SUPPLY2" gate="G$1" pin="3.3V"/>
-<pinref part="U$93" gate="G$1" pin="C"/>
+<pinref part="U12O" gate="G$1" pin="C"/>
 <junction x="-88.9" y="716.28"/>
 </segment>
 <segment>
@@ -30730,15 +30875,15 @@ Thomas Hudson</text>
 <wire x1="-106.68" y1="685.8" x2="-99.06" y2="685.8" width="0.1524" layer="91"/>
 <junction x="-106.68" y="685.8"/>
 <wire x1="-99.06" y1="685.8" x2="-99.06" y2="683.26" width="0.1524" layer="91"/>
-<pinref part="U$94" gate="G$1" pin="A"/>
+<pinref part="U11I" gate="G$1" pin="A"/>
 <junction x="-99.06" y="683.26"/>
-<pinref part="U$94" gate="G$1" pin="C"/>
+<pinref part="U11I" gate="G$1" pin="C"/>
 <junction x="-106.68" y="683.26"/>
 </segment>
 <segment>
 <wire x1="-88.9" y1="683.26" x2="-88.9" y2="688.34" width="0.1524" layer="91"/>
 <pinref part="SUPPLY4" gate="G$1" pin="3.3V"/>
-<pinref part="U$95" gate="G$1" pin="C"/>
+<pinref part="U11O" gate="G$1" pin="C"/>
 <junction x="-88.9" y="683.26"/>
 </segment>
 <segment>
@@ -30748,15 +30893,15 @@ Thomas Hudson</text>
 <wire x1="-106.68" y1="652.78" x2="-99.06" y2="652.78" width="0.1524" layer="91"/>
 <junction x="-106.68" y="652.78"/>
 <wire x1="-99.06" y1="652.78" x2="-99.06" y2="650.24" width="0.1524" layer="91"/>
-<pinref part="U$96" gate="G$1" pin="A"/>
+<pinref part="U10I" gate="G$1" pin="A"/>
 <junction x="-99.06" y="650.24"/>
-<pinref part="U$96" gate="G$1" pin="C"/>
+<pinref part="U10I" gate="G$1" pin="C"/>
 <junction x="-106.68" y="650.24"/>
 </segment>
 <segment>
 <wire x1="-88.9" y1="650.24" x2="-88.9" y2="655.32" width="0.1524" layer="91"/>
 <pinref part="SUPPLY7" gate="G$1" pin="3.3V"/>
-<pinref part="U$97" gate="G$1" pin="C"/>
+<pinref part="U10O" gate="G$1" pin="C"/>
 <junction x="-88.9" y="650.24"/>
 </segment>
 <segment>
@@ -30766,15 +30911,13 @@ Thomas Hudson</text>
 <wire x1="-106.68" y1="617.22" x2="-99.06" y2="617.22" width="0.1524" layer="91"/>
 <wire x1="-99.06" y1="617.22" x2="-99.06" y2="614.68" width="0.1524" layer="91"/>
 <junction x="-106.68" y="617.22"/>
-<pinref part="U$98" gate="G$1" pin="A"/>
-<junction x="-99.06" y="614.68"/>
-<pinref part="U$98" gate="G$1" pin="C"/>
-<junction x="-106.68" y="614.68"/>
+<pinref part="U09I" gate="G$1" pin="A"/>
+<pinref part="U09I" gate="G$1" pin="C"/>
 </segment>
 <segment>
 <wire x1="-88.9" y1="614.68" x2="-88.9" y2="619.76" width="0.1524" layer="91"/>
 <pinref part="SUPPLY9" gate="G$1" pin="3.3V"/>
-<pinref part="U$99" gate="G$1" pin="C"/>
+<pinref part="U09O" gate="G$1" pin="C"/>
 <junction x="-88.9" y="614.68"/>
 </segment>
 <segment>
@@ -30784,15 +30927,15 @@ Thomas Hudson</text>
 <wire x1="-96.52" y1="566.42" x2="-96.52" y2="568.96" width="0.1524" layer="91"/>
 <wire x1="-96.52" y1="568.96" x2="-104.14" y2="568.96" width="0.1524" layer="91"/>
 <junction x="-104.14" y="568.96"/>
-<pinref part="U$100" gate="G$1" pin="A"/>
+<pinref part="U08I" gate="G$1" pin="A"/>
 <junction x="-96.52" y="566.42"/>
-<pinref part="U$100" gate="G$1" pin="C"/>
+<pinref part="U08I" gate="G$1" pin="C"/>
 <junction x="-104.14" y="566.42"/>
 </segment>
 <segment>
 <wire x1="-86.36" y1="566.42" x2="-86.36" y2="571.5" width="0.1524" layer="91"/>
 <pinref part="SUPPLY10" gate="G$1" pin="3.3V"/>
-<pinref part="U$101" gate="G$1" pin="C"/>
+<pinref part="U08O" gate="G$1" pin="C"/>
 <junction x="-86.36" y="566.42"/>
 </segment>
 <segment>
@@ -30802,15 +30945,15 @@ Thomas Hudson</text>
 <wire x1="-104.14" y1="497.84" x2="-96.52" y2="497.84" width="0.1524" layer="91"/>
 <junction x="-104.14" y="497.84"/>
 <wire x1="-96.52" y1="497.84" x2="-96.52" y2="495.3" width="0.1524" layer="91"/>
-<pinref part="U$104" gate="G$1" pin="A"/>
+<pinref part="U06I" gate="G$1" pin="A"/>
 <junction x="-96.52" y="495.3"/>
-<pinref part="U$104" gate="G$1" pin="C"/>
+<pinref part="U06I" gate="G$1" pin="C"/>
 <junction x="-104.14" y="495.3"/>
 </segment>
 <segment>
 <wire x1="-86.36" y1="495.3" x2="-86.36" y2="500.38" width="0.1524" layer="91"/>
 <pinref part="SUPPLY12" gate="G$1" pin="3.3V"/>
-<pinref part="U$105" gate="G$1" pin="C"/>
+<pinref part="U06O" gate="G$1" pin="C"/>
 <junction x="-86.36" y="495.3"/>
 </segment>
 <segment>
@@ -30820,21 +30963,21 @@ Thomas Hudson</text>
 <wire x1="-104.14" y1="464.82" x2="-96.52" y2="464.82" width="0.1524" layer="91"/>
 <junction x="-104.14" y="464.82"/>
 <wire x1="-96.52" y1="464.82" x2="-96.52" y2="462.28" width="0.1524" layer="91"/>
-<pinref part="U$106" gate="G$1" pin="A"/>
+<pinref part="U05I" gate="G$1" pin="A"/>
 <junction x="-96.52" y="462.28"/>
-<pinref part="U$106" gate="G$1" pin="C"/>
+<pinref part="U05I" gate="G$1" pin="C"/>
 <junction x="-104.14" y="462.28"/>
 </segment>
 <segment>
 <wire x1="-86.36" y1="462.28" x2="-86.36" y2="467.36" width="0.1524" layer="91"/>
 <pinref part="SUPPLY14" gate="G$1" pin="3.3V"/>
-<pinref part="U$107" gate="G$1" pin="C"/>
+<pinref part="U05O" gate="G$1" pin="C"/>
 <junction x="-86.36" y="462.28"/>
 </segment>
 <segment>
 <wire x1="-86.36" y1="530.86" x2="-86.36" y2="535.94" width="0.1524" layer="91"/>
 <pinref part="SUPPLY16" gate="G$1" pin="3.3V"/>
-<pinref part="U$103" gate="G$1" pin="C"/>
+<pinref part="U07O" gate="G$1" pin="C"/>
 <junction x="-86.36" y="530.86"/>
 </segment>
 <segment>
@@ -30844,9 +30987,9 @@ Thomas Hudson</text>
 <wire x1="-104.14" y1="533.4" x2="-96.52" y2="533.4" width="0.1524" layer="91"/>
 <junction x="-104.14" y="533.4"/>
 <wire x1="-96.52" y1="533.4" x2="-96.52" y2="530.86" width="0.1524" layer="91"/>
-<pinref part="U$102" gate="G$1" pin="A"/>
+<pinref part="U07I" gate="G$1" pin="A"/>
 <junction x="-96.52" y="530.86"/>
-<pinref part="U$102" gate="G$1" pin="C"/>
+<pinref part="U07I" gate="G$1" pin="C"/>
 <junction x="-104.14" y="530.86"/>
 </segment>
 <segment>
@@ -30856,21 +30999,21 @@ Thomas Hudson</text>
 <wire x1="-106.68" y1="401.32" x2="-99.06" y2="401.32" width="0.1524" layer="91"/>
 <junction x="-106.68" y="401.32"/>
 <wire x1="-99.06" y1="401.32" x2="-99.06" y2="398.78" width="0.1524" layer="91"/>
-<pinref part="U$108" gate="G$1" pin="A"/>
+<pinref part="U04I" gate="G$1" pin="A"/>
 <junction x="-99.06" y="398.78"/>
-<pinref part="U$108" gate="G$1" pin="C"/>
+<pinref part="U04I" gate="G$1" pin="C"/>
 <junction x="-106.68" y="398.78"/>
 </segment>
 <segment>
 <pinref part="SUPPLY18" gate="G$1" pin="3.3V"/>
 <wire x1="-88.9" y1="403.86" x2="-88.9" y2="398.78" width="0.1524" layer="91"/>
-<pinref part="U$109" gate="G$1" pin="C"/>
+<pinref part="U04O" gate="G$1" pin="C"/>
 <junction x="-88.9" y="398.78"/>
 </segment>
 <segment>
 <wire x1="-88.9" y1="363.22" x2="-88.9" y2="368.3" width="0.1524" layer="91"/>
 <pinref part="SUPPLY20" gate="G$1" pin="3.3V"/>
-<pinref part="U$111" gate="G$1" pin="C"/>
+<pinref part="U03O" gate="G$1" pin="C"/>
 <junction x="-88.9" y="363.22"/>
 </segment>
 <segment>
@@ -30880,9 +31023,9 @@ Thomas Hudson</text>
 <wire x1="-106.68" y1="365.76" x2="-99.06" y2="365.76" width="0.1524" layer="91"/>
 <junction x="-106.68" y="365.76"/>
 <wire x1="-99.06" y1="365.76" x2="-99.06" y2="363.22" width="0.1524" layer="91"/>
-<pinref part="U$110" gate="G$1" pin="A"/>
+<pinref part="U03I" gate="G$1" pin="A"/>
 <junction x="-99.06" y="363.22"/>
-<pinref part="U$110" gate="G$1" pin="C"/>
+<pinref part="U03I" gate="G$1" pin="C"/>
 <junction x="-106.68" y="363.22"/>
 </segment>
 <segment>
@@ -30892,15 +31035,15 @@ Thomas Hudson</text>
 <wire x1="-106.68" y1="330.2" x2="-99.06" y2="330.2" width="0.1524" layer="91"/>
 <junction x="-106.68" y="330.2"/>
 <wire x1="-99.06" y1="330.2" x2="-99.06" y2="327.66" width="0.1524" layer="91"/>
-<pinref part="U$112" gate="G$1" pin="A"/>
+<pinref part="U02I" gate="G$1" pin="A"/>
 <junction x="-99.06" y="327.66"/>
-<pinref part="U$112" gate="G$1" pin="C"/>
+<pinref part="U02I" gate="G$1" pin="C"/>
 <junction x="-106.68" y="327.66"/>
 </segment>
 <segment>
 <wire x1="-88.9" y1="327.66" x2="-88.9" y2="332.74" width="0.1524" layer="91"/>
 <pinref part="SUPPLY22" gate="G$1" pin="3.3V"/>
-<pinref part="U$113" gate="G$1" pin="C"/>
+<pinref part="U02O" gate="G$1" pin="C"/>
 <junction x="-88.9" y="327.66"/>
 </segment>
 <segment>
@@ -30910,15 +31053,15 @@ Thomas Hudson</text>
 <wire x1="-106.68" y1="297.18" x2="-99.06" y2="297.18" width="0.1524" layer="91"/>
 <junction x="-106.68" y="297.18"/>
 <wire x1="-99.06" y1="297.18" x2="-99.06" y2="294.64" width="0.1524" layer="91"/>
-<pinref part="U$114" gate="G$1" pin="A"/>
+<pinref part="U01I" gate="G$1" pin="A"/>
 <junction x="-99.06" y="294.64"/>
-<pinref part="U$114" gate="G$1" pin="C"/>
+<pinref part="U01I" gate="G$1" pin="C"/>
 <junction x="-106.68" y="294.64"/>
 </segment>
 <segment>
 <wire x1="-88.9" y1="294.64" x2="-88.9" y2="299.72" width="0.1524" layer="91"/>
 <pinref part="SUPPLY24" gate="G$1" pin="3.3V"/>
-<pinref part="U$115" gate="G$1" pin="C"/>
+<pinref part="U01O" gate="G$1" pin="C"/>
 <junction x="-88.9" y="294.64"/>
 </segment>
 <segment>
@@ -30928,15 +31071,15 @@ Thomas Hudson</text>
 <wire x1="-101.6" y1="1209.04" x2="-101.6" y2="1211.58" width="0.1524" layer="91"/>
 <wire x1="-101.6" y1="1211.58" x2="-109.22" y2="1211.58" width="0.1524" layer="91"/>
 <junction x="-109.22" y="1211.58"/>
-<pinref part="U$68" gate="G$1" pin="A"/>
+<pinref part="U24I" gate="G$1" pin="A"/>
 <junction x="-101.6" y="1209.04"/>
-<pinref part="U$68" gate="G$1" pin="C"/>
+<pinref part="U24I" gate="G$1" pin="C"/>
 <junction x="-109.22" y="1209.04"/>
 </segment>
 <segment>
 <wire x1="-91.44" y1="1209.04" x2="-91.44" y2="1216.66" width="0.1524" layer="91"/>
 <pinref part="SUPPLY26" gate="G$1" pin="3.3V"/>
-<pinref part="U$69" gate="G$1" pin="C"/>
+<pinref part="U24O" gate="G$1" pin="C"/>
 <junction x="-91.44" y="1209.04"/>
 </segment>
 <segment>
@@ -30946,15 +31089,15 @@ Thomas Hudson</text>
 <wire x1="-109.22" y1="1178.56" x2="-101.6" y2="1178.56" width="0.1524" layer="91"/>
 <junction x="-109.22" y="1178.56"/>
 <wire x1="-101.6" y1="1178.56" x2="-101.6" y2="1176.02" width="0.1524" layer="91"/>
-<pinref part="U$70" gate="G$1" pin="A"/>
+<pinref part="U23I" gate="G$1" pin="A"/>
 <junction x="-101.6" y="1176.02"/>
-<pinref part="U$70" gate="G$1" pin="C"/>
+<pinref part="U23I" gate="G$1" pin="C"/>
 <junction x="-109.22" y="1176.02"/>
 </segment>
 <segment>
 <wire x1="-91.44" y1="1176.02" x2="-91.44" y2="1181.1" width="0.1524" layer="91"/>
 <pinref part="SUPPLY28" gate="G$1" pin="3.3V"/>
-<pinref part="U$71" gate="G$1" pin="C"/>
+<pinref part="U23O" gate="G$1" pin="C"/>
 <junction x="-91.44" y="1176.02"/>
 </segment>
 <segment>
@@ -30964,15 +31107,15 @@ Thomas Hudson</text>
 <wire x1="-109.22" y1="1145.54" x2="-101.6" y2="1145.54" width="0.1524" layer="91"/>
 <junction x="-109.22" y="1145.54"/>
 <wire x1="-101.6" y1="1145.54" x2="-101.6" y2="1143" width="0.1524" layer="91"/>
-<pinref part="U$72" gate="G$1" pin="A"/>
+<pinref part="U22I" gate="G$1" pin="A"/>
 <junction x="-101.6" y="1143"/>
-<pinref part="U$72" gate="G$1" pin="C"/>
+<pinref part="U22I" gate="G$1" pin="C"/>
 <junction x="-109.22" y="1143"/>
 </segment>
 <segment>
 <wire x1="-91.44" y1="1143" x2="-91.44" y2="1148.08" width="0.1524" layer="91"/>
 <pinref part="SUPPLY30" gate="G$1" pin="3.3V"/>
-<pinref part="U$73" gate="G$1" pin="C"/>
+<pinref part="U22O" gate="G$1" pin="C"/>
 <junction x="-91.44" y="1143"/>
 </segment>
 <segment>
@@ -30982,15 +31125,15 @@ Thomas Hudson</text>
 <wire x1="-109.22" y1="1109.98" x2="-101.6" y2="1109.98" width="0.1524" layer="91"/>
 <wire x1="-101.6" y1="1109.98" x2="-101.6" y2="1107.44" width="0.1524" layer="91"/>
 <junction x="-109.22" y="1109.98"/>
-<pinref part="U$74" gate="G$1" pin="A"/>
+<pinref part="U21I" gate="G$1" pin="A"/>
 <junction x="-101.6" y="1107.44"/>
-<pinref part="U$74" gate="G$1" pin="C"/>
+<pinref part="U21I" gate="G$1" pin="C"/>
 <junction x="-109.22" y="1107.44"/>
 </segment>
 <segment>
 <wire x1="-91.44" y1="1107.44" x2="-91.44" y2="1112.52" width="0.1524" layer="91"/>
 <pinref part="SUPPLY32" gate="G$1" pin="3.3V"/>
-<pinref part="U$75" gate="G$1" pin="C"/>
+<pinref part="U21O" gate="G$1" pin="C"/>
 <junction x="-91.44" y="1107.44"/>
 </segment>
 <segment>
@@ -31000,13 +31143,13 @@ Thomas Hudson</text>
 <wire x1="-101.6" y1="1059.18" x2="-101.6" y2="1061.72" width="0.1524" layer="91"/>
 <wire x1="-101.6" y1="1061.72" x2="-109.22" y2="1061.72" width="0.1524" layer="91"/>
 <junction x="-109.22" y="1061.72"/>
-<pinref part="U$76" gate="G$1" pin="A"/>
-<pinref part="U$76" gate="G$1" pin="C"/>
+<pinref part="U20I" gate="G$1" pin="A"/>
+<pinref part="U20I" gate="G$1" pin="C"/>
 </segment>
 <segment>
 <wire x1="-91.44" y1="1059.18" x2="-91.44" y2="1064.26" width="0.1524" layer="91"/>
 <pinref part="SUPPLY34" gate="G$1" pin="3.3V"/>
-<pinref part="U$77" gate="G$1" pin="C"/>
+<pinref part="U20O" gate="G$1" pin="C"/>
 </segment>
 <segment>
 <wire x1="-109.22" y1="988.06" x2="-109.22" y2="990.6" width="0.1524" layer="91"/>
@@ -31015,13 +31158,13 @@ Thomas Hudson</text>
 <wire x1="-109.22" y1="990.6" x2="-101.6" y2="990.6" width="0.1524" layer="91"/>
 <junction x="-109.22" y="990.6"/>
 <wire x1="-101.6" y1="990.6" x2="-101.6" y2="988.06" width="0.1524" layer="91"/>
-<pinref part="U$80" gate="G$1" pin="A"/>
-<pinref part="U$80" gate="G$1" pin="C"/>
+<pinref part="U18I" gate="G$1" pin="A"/>
+<pinref part="U18I" gate="G$1" pin="C"/>
 </segment>
 <segment>
 <wire x1="-91.44" y1="988.06" x2="-91.44" y2="993.14" width="0.1524" layer="91"/>
 <pinref part="SUPPLY36" gate="G$1" pin="3.3V"/>
-<pinref part="U$81" gate="G$1" pin="C"/>
+<pinref part="U18O" gate="G$1" pin="C"/>
 </segment>
 <segment>
 <wire x1="-109.22" y1="955.04" x2="-109.22" y2="957.58" width="0.1524" layer="91"/>
@@ -31030,18 +31173,18 @@ Thomas Hudson</text>
 <wire x1="-109.22" y1="957.58" x2="-101.6" y2="957.58" width="0.1524" layer="91"/>
 <junction x="-109.22" y="957.58"/>
 <wire x1="-101.6" y1="957.58" x2="-101.6" y2="955.04" width="0.1524" layer="91"/>
-<pinref part="U$82" gate="G$1" pin="A"/>
-<pinref part="U$82" gate="G$1" pin="C"/>
+<pinref part="U17I" gate="G$1" pin="A"/>
+<pinref part="U17I" gate="G$1" pin="C"/>
 </segment>
 <segment>
 <wire x1="-91.44" y1="955.04" x2="-91.44" y2="960.12" width="0.1524" layer="91"/>
 <pinref part="SUPPLY38" gate="G$1" pin="3.3V"/>
-<pinref part="U$83" gate="G$1" pin="C"/>
+<pinref part="U17O" gate="G$1" pin="C"/>
 </segment>
 <segment>
 <wire x1="-91.44" y1="1023.62" x2="-91.44" y2="1028.7" width="0.1524" layer="91"/>
 <pinref part="SUPPLY40" gate="G$1" pin="3.3V"/>
-<pinref part="U$79" gate="G$1" pin="C"/>
+<pinref part="U19O" gate="G$1" pin="C"/>
 </segment>
 <segment>
 <wire x1="-109.22" y1="1023.62" x2="-109.22" y2="1026.16" width="0.1524" layer="91"/>
@@ -31050,8 +31193,8 @@ Thomas Hudson</text>
 <wire x1="-109.22" y1="1026.16" x2="-101.6" y2="1026.16" width="0.1524" layer="91"/>
 <junction x="-109.22" y="1026.16"/>
 <wire x1="-101.6" y1="1026.16" x2="-101.6" y2="1023.62" width="0.1524" layer="91"/>
-<pinref part="U$78" gate="G$1" pin="A"/>
-<pinref part="U$78" gate="G$1" pin="C"/>
+<pinref part="U19I" gate="G$1" pin="A"/>
+<pinref part="U19I" gate="G$1" pin="C"/>
 </segment>
 <segment>
 <pinref part="SUPPLY41" gate="G$1" pin="3.3V"/>
@@ -31060,21 +31203,21 @@ Thomas Hudson</text>
 <wire x1="-109.22" y1="894.08" x2="-101.6" y2="894.08" width="0.1524" layer="91"/>
 <junction x="-109.22" y="894.08"/>
 <wire x1="-101.6" y1="894.08" x2="-101.6" y2="891.54" width="0.1524" layer="91"/>
-<pinref part="U$84" gate="G$1" pin="A"/>
+<pinref part="U16I" gate="G$1" pin="A"/>
 <junction x="-101.6" y="891.54"/>
-<pinref part="U$84" gate="G$1" pin="C"/>
+<pinref part="U16I" gate="G$1" pin="C"/>
 <junction x="-109.22" y="891.54"/>
 </segment>
 <segment>
 <pinref part="SUPPLY42" gate="G$1" pin="3.3V"/>
 <wire x1="-91.44" y1="896.62" x2="-91.44" y2="891.54" width="0.1524" layer="91"/>
-<pinref part="U$85" gate="G$1" pin="C"/>
+<pinref part="U16O" gate="G$1" pin="C"/>
 <junction x="-91.44" y="891.54"/>
 </segment>
 <segment>
 <wire x1="-91.44" y1="855.98" x2="-91.44" y2="861.06" width="0.1524" layer="91"/>
 <pinref part="SUPPLY44" gate="G$1" pin="3.3V"/>
-<pinref part="U$87" gate="G$1" pin="C"/>
+<pinref part="U15O" gate="G$1" pin="C"/>
 <junction x="-91.44" y="855.98"/>
 </segment>
 <segment>
@@ -31084,9 +31227,9 @@ Thomas Hudson</text>
 <wire x1="-109.22" y1="858.52" x2="-101.6" y2="858.52" width="0.1524" layer="91"/>
 <junction x="-109.22" y="858.52"/>
 <wire x1="-101.6" y1="858.52" x2="-101.6" y2="855.98" width="0.1524" layer="91"/>
-<pinref part="U$86" gate="G$1" pin="A"/>
+<pinref part="U15I" gate="G$1" pin="A"/>
 <junction x="-101.6" y="855.98"/>
-<pinref part="U$86" gate="G$1" pin="C"/>
+<pinref part="U15I" gate="G$1" pin="C"/>
 <junction x="-109.22" y="855.98"/>
 </segment>
 <segment>
@@ -31096,15 +31239,15 @@ Thomas Hudson</text>
 <wire x1="-109.22" y1="822.96" x2="-101.6" y2="822.96" width="0.1524" layer="91"/>
 <junction x="-109.22" y="822.96"/>
 <wire x1="-101.6" y1="822.96" x2="-101.6" y2="820.42" width="0.1524" layer="91"/>
-<pinref part="U$88" gate="G$1" pin="A"/>
+<pinref part="U14I" gate="G$1" pin="A"/>
 <junction x="-101.6" y="820.42"/>
-<pinref part="U$88" gate="G$1" pin="C"/>
+<pinref part="U14I" gate="G$1" pin="C"/>
 <junction x="-109.22" y="820.42"/>
 </segment>
 <segment>
 <wire x1="-91.44" y1="820.42" x2="-91.44" y2="825.5" width="0.1524" layer="91"/>
 <pinref part="SUPPLY46" gate="G$1" pin="3.3V"/>
-<pinref part="U$89" gate="G$1" pin="C"/>
+<pinref part="U14O" gate="G$1" pin="C"/>
 <junction x="-91.44" y="820.42"/>
 </segment>
 <segment>
@@ -31114,15 +31257,15 @@ Thomas Hudson</text>
 <wire x1="-109.22" y1="789.94" x2="-101.6" y2="789.94" width="0.1524" layer="91"/>
 <junction x="-109.22" y="789.94"/>
 <wire x1="-101.6" y1="789.94" x2="-101.6" y2="787.4" width="0.1524" layer="91"/>
-<pinref part="U$90" gate="G$1" pin="A"/>
+<pinref part="U13I" gate="G$1" pin="A"/>
 <junction x="-101.6" y="787.4"/>
-<pinref part="U$90" gate="G$1" pin="C"/>
+<pinref part="U13I" gate="G$1" pin="C"/>
 <junction x="-109.22" y="787.4"/>
 </segment>
 <segment>
 <wire x1="-91.44" y1="787.4" x2="-91.44" y2="792.48" width="0.1524" layer="91"/>
 <pinref part="SUPPLY48" gate="G$1" pin="3.3V"/>
-<pinref part="U$91" gate="G$1" pin="C"/>
+<pinref part="U13O" gate="G$1" pin="C"/>
 <junction x="-91.44" y="787.4"/>
 </segment>
 <segment>
@@ -31136,57 +31279,57 @@ Thomas Hudson</text>
 </segment>
 <segment>
 <pinref part="U1" gate="U1" pin="VCC"/>
-<wire x1="-10.16" y1="1079.5" x2="-7.62" y2="1079.5" width="0.1524" layer="91"/>
-<wire x1="-7.62" y1="1079.5" x2="-7.62" y2="1066.8" width="0.1524" layer="91"/>
-<wire x1="-7.62" y1="1066.8" x2="-10.16" y2="1066.8" width="0.1524" layer="91"/>
+<wire x1="-10.16" y1="1069.34" x2="-7.62" y2="1069.34" width="0.1524" layer="91"/>
+<wire x1="-7.62" y1="1069.34" x2="-7.62" y2="1056.64" width="0.1524" layer="91"/>
+<wire x1="-7.62" y1="1056.64" x2="-10.16" y2="1056.64" width="0.1524" layer="91"/>
 <pinref part="SUPPLY52" gate="G$1" pin="3.3V"/>
-<wire x1="-10.16" y1="1066.8" x2="-15.24" y2="1066.8" width="0.1524" layer="91"/>
-<wire x1="-10.16" y1="1061.72" x2="-10.16" y2="1066.8" width="0.1524" layer="91"/>
-<junction x="-10.16" y="1066.8"/>
+<wire x1="-10.16" y1="1056.64" x2="-15.24" y2="1056.64" width="0.1524" layer="91"/>
+<wire x1="-10.16" y1="1051.56" x2="-10.16" y2="1056.64" width="0.1524" layer="91"/>
+<junction x="-10.16" y="1056.64"/>
 <pinref part="C1" gate="G$1" pin="1"/>
 </segment>
 <segment>
 <pinref part="U2" gate="U1" pin="VCC"/>
-<wire x1="-10.16" y1="924.56" x2="-7.62" y2="924.56" width="0.1524" layer="91"/>
-<wire x1="-7.62" y1="924.56" x2="-7.62" y2="911.86" width="0.1524" layer="91"/>
-<wire x1="-7.62" y1="911.86" x2="-10.16" y2="911.86" width="0.1524" layer="91"/>
+<wire x1="-10.16" y1="914.4" x2="-7.62" y2="914.4" width="0.1524" layer="91"/>
+<wire x1="-7.62" y1="914.4" x2="-7.62" y2="901.7" width="0.1524" layer="91"/>
+<wire x1="-7.62" y1="901.7" x2="-10.16" y2="901.7" width="0.1524" layer="91"/>
 <pinref part="SUPPLY53" gate="G$1" pin="3.3V"/>
-<wire x1="-10.16" y1="911.86" x2="-15.24" y2="911.86" width="0.1524" layer="91"/>
-<wire x1="-10.16" y1="906.78" x2="-10.16" y2="911.86" width="0.1524" layer="91"/>
-<junction x="-10.16" y="911.86"/>
+<wire x1="-10.16" y1="901.7" x2="-15.24" y2="901.7" width="0.1524" layer="91"/>
+<wire x1="-10.16" y1="896.62" x2="-10.16" y2="901.7" width="0.1524" layer="91"/>
+<junction x="-10.16" y="901.7"/>
 <pinref part="C2" gate="G$1" pin="1"/>
 </segment>
 <segment>
 <pinref part="U3" gate="U1" pin="VCC"/>
-<wire x1="-7.62" y1="749.3" x2="-5.08" y2="749.3" width="0.1524" layer="91"/>
-<wire x1="-5.08" y1="749.3" x2="-5.08" y2="736.6" width="0.1524" layer="91"/>
-<wire x1="-5.08" y1="736.6" x2="-7.62" y2="736.6" width="0.1524" layer="91"/>
+<wire x1="-7.62" y1="751.84" x2="-5.08" y2="751.84" width="0.1524" layer="91"/>
+<wire x1="-5.08" y1="751.84" x2="-5.08" y2="739.14" width="0.1524" layer="91"/>
+<wire x1="-5.08" y1="739.14" x2="-7.62" y2="739.14" width="0.1524" layer="91"/>
 <pinref part="SUPPLY54" gate="G$1" pin="3.3V"/>
-<wire x1="-7.62" y1="736.6" x2="-12.7" y2="736.6" width="0.1524" layer="91"/>
-<wire x1="-7.62" y1="731.52" x2="-7.62" y2="736.6" width="0.1524" layer="91"/>
-<junction x="-7.62" y="736.6"/>
+<wire x1="-7.62" y1="739.14" x2="-12.7" y2="739.14" width="0.1524" layer="91"/>
+<wire x1="-7.62" y1="734.06" x2="-7.62" y2="739.14" width="0.1524" layer="91"/>
+<junction x="-7.62" y="739.14"/>
 <pinref part="C3" gate="G$1" pin="1"/>
 </segment>
 <segment>
 <pinref part="U4" gate="U1" pin="VCC"/>
-<wire x1="-7.62" y1="586.74" x2="-5.08" y2="586.74" width="0.1524" layer="91"/>
-<wire x1="-5.08" y1="586.74" x2="-5.08" y2="574.04" width="0.1524" layer="91"/>
-<wire x1="-5.08" y1="574.04" x2="-7.62" y2="574.04" width="0.1524" layer="91"/>
+<wire x1="-7.62" y1="576.58" x2="-5.08" y2="576.58" width="0.1524" layer="91"/>
+<wire x1="-5.08" y1="576.58" x2="-5.08" y2="553.72" width="0.1524" layer="91"/>
+<wire x1="-5.08" y1="553.72" x2="-7.62" y2="553.72" width="0.1524" layer="91"/>
 <pinref part="SUPPLY55" gate="G$1" pin="3.3V"/>
-<wire x1="-7.62" y1="574.04" x2="-12.7" y2="574.04" width="0.1524" layer="91"/>
-<wire x1="-7.62" y1="568.96" x2="-7.62" y2="574.04" width="0.1524" layer="91"/>
-<junction x="-7.62" y="574.04"/>
+<wire x1="-7.62" y1="553.72" x2="-12.7" y2="553.72" width="0.1524" layer="91"/>
+<wire x1="-7.62" y1="551.18" x2="-7.62" y2="553.72" width="0.1524" layer="91"/>
+<junction x="-7.62" y="553.72"/>
 <pinref part="C4" gate="G$1" pin="1"/>
 </segment>
 <segment>
 <pinref part="U5" gate="U1" pin="VCC"/>
-<wire x1="-5.08" y1="431.8" x2="-2.54" y2="431.8" width="0.1524" layer="91"/>
-<wire x1="-2.54" y1="431.8" x2="-2.54" y2="419.1" width="0.1524" layer="91"/>
-<wire x1="-2.54" y1="419.1" x2="-5.08" y2="419.1" width="0.1524" layer="91"/>
+<wire x1="-5.08" y1="421.64" x2="-2.54" y2="421.64" width="0.1524" layer="91"/>
+<wire x1="-2.54" y1="421.64" x2="-2.54" y2="403.86" width="0.1524" layer="91"/>
+<wire x1="-2.54" y1="403.86" x2="-5.08" y2="403.86" width="0.1524" layer="91"/>
 <pinref part="SUPPLY56" gate="G$1" pin="3.3V"/>
-<wire x1="-5.08" y1="419.1" x2="-10.16" y2="419.1" width="0.1524" layer="91"/>
-<wire x1="-5.08" y1="414.02" x2="-5.08" y2="419.1" width="0.1524" layer="91"/>
-<junction x="-5.08" y="419.1"/>
+<wire x1="-5.08" y1="403.86" x2="-7.62" y2="403.86" width="0.1524" layer="91"/>
+<wire x1="-5.08" y1="401.32" x2="-5.08" y2="403.86" width="0.1524" layer="91"/>
+<junction x="-5.08" y="403.86"/>
 <pinref part="C5" gate="G$1" pin="1"/>
 </segment>
 <segment>
@@ -31228,9 +31371,9 @@ Thomas Hudson</text>
 <wire x1="-93.98" y1="701.04" x2="-93.98" y2="718.82" width="0.1524" layer="91"/>
 <wire x1="-93.98" y1="718.82" x2="-81.28" y2="718.82" width="0.1524" layer="91"/>
 <wire x1="-81.28" y1="718.82" x2="-81.28" y2="716.28" width="0.1524" layer="91"/>
-<pinref part="U$92" gate="G$1" pin="K"/>
+<pinref part="U12I" gate="G$1" pin="K"/>
 <junction x="-99.06" y="703.58"/>
-<pinref part="U$93" gate="G$1" pin="A"/>
+<pinref part="U12O" gate="G$1" pin="A"/>
 <junction x="-81.28" y="716.28"/>
 </segment>
 </net>
@@ -31239,7 +31382,7 @@ Thomas Hudson</text>
 <wire x1="-81.28" y1="703.58" x2="-81.28" y2="701.04" width="0.1524" layer="91"/>
 <wire x1="-81.28" y1="701.04" x2="-73.66" y2="701.04" width="0.1524" layer="91"/>
 <label x="-73.66" y="701.04" size="1.778" layer="95"/>
-<pinref part="U$93" gate="G$1" pin="K"/>
+<pinref part="U12O" gate="G$1" pin="K"/>
 <junction x="-81.28" y="703.58"/>
 </segment>
 <segment>
@@ -31255,9 +31398,9 @@ Thomas Hudson</text>
 <wire x1="-93.98" y1="668.02" x2="-93.98" y2="685.8" width="0.1524" layer="91"/>
 <wire x1="-93.98" y1="685.8" x2="-81.28" y2="685.8" width="0.1524" layer="91"/>
 <wire x1="-81.28" y1="685.8" x2="-81.28" y2="683.26" width="0.1524" layer="91"/>
-<pinref part="U$94" gate="G$1" pin="K"/>
+<pinref part="U11I" gate="G$1" pin="K"/>
 <junction x="-99.06" y="670.56"/>
-<pinref part="U$95" gate="G$1" pin="A"/>
+<pinref part="U11O" gate="G$1" pin="A"/>
 <junction x="-81.28" y="683.26"/>
 </segment>
 </net>
@@ -31266,7 +31409,7 @@ Thomas Hudson</text>
 <wire x1="-81.28" y1="670.56" x2="-81.28" y2="668.02" width="0.1524" layer="91"/>
 <wire x1="-81.28" y1="668.02" x2="-73.66" y2="668.02" width="0.1524" layer="91"/>
 <label x="-73.66" y="668.02" size="1.778" layer="95"/>
-<pinref part="U$95" gate="G$1" pin="K"/>
+<pinref part="U11O" gate="G$1" pin="K"/>
 <junction x="-81.28" y="670.56"/>
 </segment>
 <segment>
@@ -31282,9 +31425,9 @@ Thomas Hudson</text>
 <wire x1="-93.98" y1="635" x2="-93.98" y2="652.78" width="0.1524" layer="91"/>
 <wire x1="-93.98" y1="652.78" x2="-81.28" y2="652.78" width="0.1524" layer="91"/>
 <wire x1="-81.28" y1="652.78" x2="-81.28" y2="650.24" width="0.1524" layer="91"/>
-<pinref part="U$96" gate="G$1" pin="K"/>
+<pinref part="U10I" gate="G$1" pin="K"/>
 <junction x="-99.06" y="637.54"/>
-<pinref part="U$97" gate="G$1" pin="A"/>
+<pinref part="U10O" gate="G$1" pin="A"/>
 <junction x="-81.28" y="650.24"/>
 </segment>
 </net>
@@ -31293,7 +31436,7 @@ Thomas Hudson</text>
 <wire x1="-81.28" y1="637.54" x2="-81.28" y2="635" width="0.1524" layer="91"/>
 <wire x1="-81.28" y1="635" x2="-73.66" y2="635" width="0.1524" layer="91"/>
 <label x="-73.66" y="635" size="1.778" layer="95"/>
-<pinref part="U$97" gate="G$1" pin="K"/>
+<pinref part="U10O" gate="G$1" pin="K"/>
 <junction x="-81.28" y="637.54"/>
 </segment>
 <segment>
@@ -31309,10 +31452,9 @@ Thomas Hudson</text>
 <wire x1="-93.98" y1="599.44" x2="-93.98" y2="617.22" width="0.1524" layer="91"/>
 <wire x1="-93.98" y1="617.22" x2="-81.28" y2="617.22" width="0.1524" layer="91"/>
 <wire x1="-81.28" y1="617.22" x2="-81.28" y2="614.68" width="0.1524" layer="91"/>
-<pinref part="U$98" gate="G$1" pin="K"/>
-<junction x="-99.06" y="601.98"/>
-<pinref part="U$99" gate="G$1" pin="A"/>
+<pinref part="U09O" gate="G$1" pin="A"/>
 <junction x="-81.28" y="614.68"/>
+<pinref part="U09I" gate="G$1" pin="K"/>
 </segment>
 </net>
 <net name="9_CATHODE" class="0">
@@ -31320,7 +31462,7 @@ Thomas Hudson</text>
 <wire x1="-81.28" y1="601.98" x2="-81.28" y2="599.44" width="0.1524" layer="91"/>
 <wire x1="-81.28" y1="599.44" x2="-73.66" y2="599.44" width="0.1524" layer="91"/>
 <label x="-73.66" y="599.44" size="1.778" layer="95"/>
-<pinref part="U$99" gate="G$1" pin="K"/>
+<pinref part="U09O" gate="G$1" pin="K"/>
 <junction x="-81.28" y="601.98"/>
 </segment>
 <segment>
@@ -31336,9 +31478,9 @@ Thomas Hudson</text>
 <wire x1="-91.44" y1="447.04" x2="-91.44" y2="464.82" width="0.1524" layer="91"/>
 <wire x1="-91.44" y1="464.82" x2="-78.74" y2="464.82" width="0.1524" layer="91"/>
 <wire x1="-78.74" y1="464.82" x2="-78.74" y2="462.28" width="0.1524" layer="91"/>
-<pinref part="U$106" gate="G$1" pin="K"/>
+<pinref part="U05I" gate="G$1" pin="K"/>
 <junction x="-96.52" y="449.58"/>
-<pinref part="U$107" gate="G$1" pin="A"/>
+<pinref part="U05O" gate="G$1" pin="A"/>
 <junction x="-78.74" y="462.28"/>
 </segment>
 </net>
@@ -31349,9 +31491,9 @@ Thomas Hudson</text>
 <wire x1="-91.44" y1="480.06" x2="-91.44" y2="497.84" width="0.1524" layer="91"/>
 <wire x1="-91.44" y1="497.84" x2="-78.74" y2="497.84" width="0.1524" layer="91"/>
 <wire x1="-78.74" y1="497.84" x2="-78.74" y2="495.3" width="0.1524" layer="91"/>
-<pinref part="U$104" gate="G$1" pin="K"/>
+<pinref part="U06I" gate="G$1" pin="K"/>
 <junction x="-96.52" y="482.6"/>
-<pinref part="U$105" gate="G$1" pin="A"/>
+<pinref part="U06O" gate="G$1" pin="A"/>
 <junction x="-78.74" y="495.3"/>
 </segment>
 </net>
@@ -31362,9 +31504,9 @@ Thomas Hudson</text>
 <wire x1="-91.44" y1="551.18" x2="-91.44" y2="568.96" width="0.1524" layer="91"/>
 <wire x1="-91.44" y1="568.96" x2="-78.74" y2="568.96" width="0.1524" layer="91"/>
 <wire x1="-78.74" y1="568.96" x2="-78.74" y2="566.42" width="0.1524" layer="91"/>
-<pinref part="U$100" gate="G$1" pin="K"/>
+<pinref part="U08I" gate="G$1" pin="K"/>
 <junction x="-96.52" y="553.72"/>
-<pinref part="U$101" gate="G$1" pin="A"/>
+<pinref part="U08O" gate="G$1" pin="A"/>
 <junction x="-78.74" y="566.42"/>
 </segment>
 </net>
@@ -31373,7 +31515,7 @@ Thomas Hudson</text>
 <wire x1="-78.74" y1="553.72" x2="-78.74" y2="551.18" width="0.1524" layer="91"/>
 <wire x1="-78.74" y1="551.18" x2="-71.12" y2="551.18" width="0.1524" layer="91"/>
 <label x="-71.12" y="551.18" size="1.778" layer="95"/>
-<pinref part="U$101" gate="G$1" pin="K"/>
+<pinref part="U08O" gate="G$1" pin="K"/>
 <junction x="-78.74" y="553.72"/>
 </segment>
 <segment>
@@ -31389,9 +31531,9 @@ Thomas Hudson</text>
 <wire x1="-91.44" y1="515.62" x2="-91.44" y2="533.4" width="0.1524" layer="91"/>
 <wire x1="-91.44" y1="533.4" x2="-78.74" y2="533.4" width="0.1524" layer="91"/>
 <wire x1="-78.74" y1="533.4" x2="-78.74" y2="530.86" width="0.1524" layer="91"/>
-<pinref part="U$102" gate="G$1" pin="K"/>
+<pinref part="U07I" gate="G$1" pin="K"/>
 <junction x="-96.52" y="518.16"/>
-<pinref part="U$103" gate="G$1" pin="A"/>
+<pinref part="U07O" gate="G$1" pin="A"/>
 <junction x="-78.74" y="530.86"/>
 </segment>
 </net>
@@ -31400,7 +31542,7 @@ Thomas Hudson</text>
 <wire x1="-78.74" y1="518.16" x2="-78.74" y2="515.62" width="0.1524" layer="91"/>
 <wire x1="-78.74" y1="515.62" x2="-71.12" y2="515.62" width="0.1524" layer="91"/>
 <label x="-71.12" y="515.62" size="1.778" layer="95"/>
-<pinref part="U$103" gate="G$1" pin="K"/>
+<pinref part="U07O" gate="G$1" pin="K"/>
 <junction x="-78.74" y="518.16"/>
 </segment>
 <segment>
@@ -31414,7 +31556,7 @@ Thomas Hudson</text>
 <wire x1="-78.74" y1="482.6" x2="-78.74" y2="480.06" width="0.1524" layer="91"/>
 <wire x1="-78.74" y1="480.06" x2="-71.12" y2="480.06" width="0.1524" layer="91"/>
 <label x="-71.12" y="480.06" size="1.778" layer="95"/>
-<pinref part="U$105" gate="G$1" pin="K"/>
+<pinref part="U06O" gate="G$1" pin="K"/>
 <junction x="-78.74" y="482.6"/>
 </segment>
 <segment>
@@ -31430,9 +31572,9 @@ Thomas Hudson</text>
 <wire x1="-93.98" y1="383.54" x2="-93.98" y2="401.32" width="0.1524" layer="91"/>
 <wire x1="-93.98" y1="401.32" x2="-81.28" y2="401.32" width="0.1524" layer="91"/>
 <wire x1="-81.28" y1="401.32" x2="-81.28" y2="398.78" width="0.1524" layer="91"/>
-<pinref part="U$108" gate="G$1" pin="K"/>
+<pinref part="U04I" gate="G$1" pin="K"/>
 <junction x="-99.06" y="386.08"/>
-<pinref part="U$109" gate="G$1" pin="A"/>
+<pinref part="U04O" gate="G$1" pin="A"/>
 <junction x="-81.28" y="398.78"/>
 </segment>
 </net>
@@ -31441,7 +31583,7 @@ Thomas Hudson</text>
 <wire x1="-81.28" y1="386.08" x2="-81.28" y2="383.54" width="0.1524" layer="91"/>
 <wire x1="-81.28" y1="383.54" x2="-71.12" y2="383.54" width="0.1524" layer="91"/>
 <label x="-71.12" y="383.54" size="1.778" layer="95"/>
-<pinref part="U$109" gate="G$1" pin="K"/>
+<pinref part="U04O" gate="G$1" pin="K"/>
 <junction x="-81.28" y="386.08"/>
 </segment>
 <segment>
@@ -31457,9 +31599,9 @@ Thomas Hudson</text>
 <wire x1="-93.98" y1="347.98" x2="-93.98" y2="365.76" width="0.1524" layer="91"/>
 <wire x1="-93.98" y1="365.76" x2="-81.28" y2="365.76" width="0.1524" layer="91"/>
 <wire x1="-81.28" y1="365.76" x2="-81.28" y2="363.22" width="0.1524" layer="91"/>
-<pinref part="U$110" gate="G$1" pin="K"/>
+<pinref part="U03I" gate="G$1" pin="K"/>
 <junction x="-99.06" y="350.52"/>
-<pinref part="U$111" gate="G$1" pin="A"/>
+<pinref part="U03O" gate="G$1" pin="A"/>
 <junction x="-81.28" y="363.22"/>
 </segment>
 </net>
@@ -31468,7 +31610,7 @@ Thomas Hudson</text>
 <wire x1="-81.28" y1="350.52" x2="-81.28" y2="347.98" width="0.1524" layer="91"/>
 <wire x1="-81.28" y1="347.98" x2="-76.2" y2="347.98" width="0.1524" layer="91"/>
 <label x="-76.2" y="347.98" size="1.778" layer="95"/>
-<pinref part="U$111" gate="G$1" pin="K"/>
+<pinref part="U03O" gate="G$1" pin="K"/>
 <junction x="-81.28" y="350.52"/>
 </segment>
 <segment>
@@ -31484,9 +31626,9 @@ Thomas Hudson</text>
 <wire x1="-93.98" y1="312.42" x2="-93.98" y2="330.2" width="0.1524" layer="91"/>
 <wire x1="-93.98" y1="330.2" x2="-81.28" y2="330.2" width="0.1524" layer="91"/>
 <wire x1="-81.28" y1="330.2" x2="-81.28" y2="327.66" width="0.1524" layer="91"/>
-<pinref part="U$112" gate="G$1" pin="K"/>
+<pinref part="U02I" gate="G$1" pin="K"/>
 <junction x="-99.06" y="314.96"/>
-<pinref part="U$113" gate="G$1" pin="A"/>
+<pinref part="U02O" gate="G$1" pin="A"/>
 <junction x="-81.28" y="327.66"/>
 </segment>
 </net>
@@ -31495,7 +31637,7 @@ Thomas Hudson</text>
 <wire x1="-81.28" y1="314.96" x2="-81.28" y2="312.42" width="0.1524" layer="91"/>
 <wire x1="-81.28" y1="312.42" x2="-73.66" y2="312.42" width="0.1524" layer="91"/>
 <label x="-73.66" y="312.42" size="1.778" layer="95"/>
-<pinref part="U$113" gate="G$1" pin="K"/>
+<pinref part="U02O" gate="G$1" pin="K"/>
 <junction x="-81.28" y="314.96"/>
 </segment>
 <segment>
@@ -31511,9 +31653,9 @@ Thomas Hudson</text>
 <wire x1="-93.98" y1="279.4" x2="-93.98" y2="297.18" width="0.1524" layer="91"/>
 <wire x1="-93.98" y1="297.18" x2="-81.28" y2="297.18" width="0.1524" layer="91"/>
 <wire x1="-81.28" y1="297.18" x2="-81.28" y2="294.64" width="0.1524" layer="91"/>
-<pinref part="U$114" gate="G$1" pin="K"/>
+<pinref part="U01I" gate="G$1" pin="K"/>
 <junction x="-99.06" y="281.94"/>
-<pinref part="U$115" gate="G$1" pin="A"/>
+<pinref part="U01O" gate="G$1" pin="A"/>
 <junction x="-81.28" y="294.64"/>
 </segment>
 </net>
@@ -31522,7 +31664,7 @@ Thomas Hudson</text>
 <wire x1="-81.28" y1="281.94" x2="-81.28" y2="279.4" width="0.1524" layer="91"/>
 <wire x1="-81.28" y1="279.4" x2="-76.2" y2="279.4" width="0.1524" layer="91"/>
 <label x="-76.2" y="279.4" size="1.778" layer="95"/>
-<pinref part="U$115" gate="G$1" pin="K"/>
+<pinref part="U01O" gate="G$1" pin="K"/>
 <junction x="-81.28" y="281.94"/>
 </segment>
 <segment>
@@ -31536,7 +31678,7 @@ Thomas Hudson</text>
 <wire x1="-78.74" y1="449.58" x2="-78.74" y2="447.04" width="0.1524" layer="91"/>
 <wire x1="-78.74" y1="447.04" x2="-73.66" y2="447.04" width="0.1524" layer="91"/>
 <label x="-73.66" y="447.04" size="1.778" layer="95"/>
-<pinref part="U$107" gate="G$1" pin="K"/>
+<pinref part="U05O" gate="G$1" pin="K"/>
 <junction x="-78.74" y="449.58"/>
 </segment>
 <segment>
@@ -31545,331 +31687,316 @@ Thomas Hudson</text>
 <label x="-398.78" y="922.02" size="1.778" layer="95"/>
 </segment>
 </net>
-<net name="N$15" class="0">
+<net name="SNS13I" class="0">
 <segment>
-<wire x1="-109.22" y1="774.7" x2="-109.22" y2="751.84" width="0.1524" layer="91"/>
-<wire x1="-109.22" y1="774.7" x2="-165.1" y2="774.7" width="0.1524" layer="91"/>
-<wire x1="-165.1" y1="774.7" x2="-165.1" y2="858.52" width="0.1524" layer="91"/>
+<wire x1="-165.1" y1="767.08" x2="-165.1" y2="858.52" width="0.1524" layer="91"/>
 <wire x1="-165.1" y1="858.52" x2="-175.26" y2="858.52" width="0.1524" layer="91"/>
-<junction x="-109.22" y="774.7"/>
-<wire x1="-109.22" y1="751.84" x2="-27.94" y2="751.84" width="0.1524" layer="91"/>
-<pinref part="U$90" gate="G$1" pin="E"/>
 <pinref part="R6" gate="G$1" pin="3"/>
-<pinref part="U3" gate="U1" pin="A"/>
-</segment>
-</net>
-<net name="N$16" class="0">
-<segment>
-<wire x1="-91.44" y1="774.7" x2="-91.44" y2="769.62" width="0.1524" layer="91"/>
-<wire x1="-91.44" y1="769.62" x2="-91.44" y2="754.38" width="0.1524" layer="91"/>
-<wire x1="-91.44" y1="769.62" x2="-167.64" y2="769.62" width="0.1524" layer="91"/>
-<wire x1="-167.64" y1="769.62" x2="-167.64" y2="855.98" width="0.1524" layer="91"/>
-<wire x1="-167.64" y1="855.98" x2="-175.26" y2="855.98" width="0.1524" layer="91"/>
-<junction x="-91.44" y="769.62"/>
-<wire x1="-27.94" y1="754.38" x2="-91.44" y2="754.38" width="0.1524" layer="91"/>
-<pinref part="U$91" gate="G$1" pin="E"/>
-<junction x="-91.44" y="774.7"/>
-<pinref part="R6" gate="G$1" pin="2"/>
-<pinref part="U3" gate="U1" pin="B"/>
-</segment>
-</net>
-<net name="N$17" class="0">
-<segment>
-<wire x1="-109.22" y1="807.72" x2="-109.22" y2="800.1" width="0.1524" layer="91"/>
-<wire x1="-109.22" y1="800.1" x2="-60.96" y2="800.1" width="0.1524" layer="91"/>
-<wire x1="-60.96" y1="800.1" x2="-60.96" y2="756.92" width="0.1524" layer="91"/>
-<wire x1="-109.22" y1="800.1" x2="-162.56" y2="800.1" width="0.1524" layer="91"/>
-<wire x1="-162.56" y1="800.1" x2="-162.56" y2="861.06" width="0.1524" layer="91"/>
-<wire x1="-162.56" y1="861.06" x2="-175.26" y2="861.06" width="0.1524" layer="91"/>
-<junction x="-109.22" y="800.1"/>
-<wire x1="-60.96" y1="756.92" x2="-27.94" y2="756.92" width="0.1524" layer="91"/>
-<pinref part="U$88" gate="G$1" pin="E"/>
-<junction x="-109.22" y="807.72"/>
-<pinref part="R6" gate="G$1" pin="4"/>
-<pinref part="U3" gate="U1" pin="C"/>
-</segment>
-</net>
-<net name="N$19" class="0">
-<segment>
-<wire x1="-91.44" y1="807.72" x2="-91.44" y2="802.64" width="0.1524" layer="91"/>
-<wire x1="-91.44" y1="802.64" x2="-58.42" y2="802.64" width="0.1524" layer="91"/>
-<wire x1="-58.42" y1="802.64" x2="-58.42" y2="759.46" width="0.1524" layer="91"/>
-<wire x1="-91.44" y1="802.64" x2="-160.02" y2="802.64" width="0.1524" layer="91"/>
-<wire x1="-160.02" y1="802.64" x2="-160.02" y2="863.6" width="0.1524" layer="91"/>
-<wire x1="-160.02" y1="863.6" x2="-175.26" y2="863.6" width="0.1524" layer="91"/>
-<junction x="-91.44" y="802.64"/>
-<wire x1="-27.94" y1="759.46" x2="-58.42" y2="759.46" width="0.1524" layer="91"/>
-<pinref part="U$89" gate="G$1" pin="E"/>
-<junction x="-91.44" y="807.72"/>
-<pinref part="R6" gate="G$1" pin="5"/>
-<pinref part="U3" gate="U1" pin="D"/>
-</segment>
-</net>
-<net name="N$20" class="0">
-<segment>
-<wire x1="-109.22" y1="878.84" x2="-109.22" y2="871.22" width="0.1524" layer="91"/>
-<wire x1="-109.22" y1="871.22" x2="-50.8" y2="871.22" width="0.1524" layer="91"/>
-<wire x1="-50.8" y1="767.08" x2="-50.8" y2="871.22" width="0.1524" layer="91"/>
-<wire x1="-109.22" y1="871.22" x2="-175.26" y2="871.22" width="0.1524" layer="91"/>
-<junction x="-109.22" y="871.22"/>
-<wire x1="-50.8" y1="767.08" x2="-27.94" y2="767.08" width="0.1524" layer="91"/>
-<pinref part="U$84" gate="G$1" pin="E"/>
-<junction x="-109.22" y="878.84"/>
-<pinref part="R6" gate="G$1" pin="8"/>
-<pinref part="U3" gate="U1" pin="G"/>
-</segment>
-</net>
-<net name="N$22" class="0">
-<segment>
-<wire x1="-91.44" y1="878.84" x2="-91.44" y2="873.76" width="0.1524" layer="91"/>
-<wire x1="-91.44" y1="873.76" x2="-48.26" y2="873.76" width="0.1524" layer="91"/>
-<wire x1="-48.26" y1="873.76" x2="-48.26" y2="769.62" width="0.1524" layer="91"/>
-<wire x1="-175.26" y1="873.76" x2="-91.44" y2="873.76" width="0.1524" layer="91"/>
-<junction x="-91.44" y="873.76"/>
-<wire x1="-27.94" y1="769.62" x2="-48.26" y2="769.62" width="0.1524" layer="91"/>
-<pinref part="U$85" gate="G$1" pin="E"/>
-<junction x="-91.44" y="878.84"/>
-<pinref part="R6" gate="G$1" pin="9"/>
-<pinref part="U3" gate="U1" pin="H"/>
-</segment>
-</net>
-<net name="N$23" class="0">
-<segment>
-<wire x1="-109.22" y1="843.28" x2="-109.22" y2="835.66" width="0.1524" layer="91"/>
-<wire x1="-109.22" y1="835.66" x2="-55.88" y2="835.66" width="0.1524" layer="91"/>
-<wire x1="-109.22" y1="835.66" x2="-157.48" y2="835.66" width="0.1524" layer="91"/>
-<junction x="-109.22" y="835.66"/>
-<wire x1="-55.88" y1="762" x2="-55.88" y2="835.66" width="0.1524" layer="91"/>
-<wire x1="-157.48" y1="835.66" x2="-157.48" y2="866.14" width="0.1524" layer="91"/>
-<wire x1="-157.48" y1="866.14" x2="-175.26" y2="866.14" width="0.1524" layer="91"/>
-<wire x1="-55.88" y1="762" x2="-27.94" y2="762" width="0.1524" layer="91"/>
-<pinref part="U$86" gate="G$1" pin="E"/>
-<junction x="-109.22" y="843.28"/>
-<pinref part="R6" gate="G$1" pin="6"/>
-<pinref part="U3" gate="U1" pin="E"/>
-</segment>
-</net>
-<net name="N$24" class="0">
-<segment>
-<wire x1="-91.44" y1="843.28" x2="-91.44" y2="838.2" width="0.1524" layer="91"/>
-<wire x1="-91.44" y1="838.2" x2="-53.34" y2="838.2" width="0.1524" layer="91"/>
-<wire x1="-53.34" y1="838.2" x2="-53.34" y2="764.54" width="0.1524" layer="91"/>
-<wire x1="-91.44" y1="838.2" x2="-154.94" y2="838.2" width="0.1524" layer="91"/>
-<junction x="-91.44" y="838.2"/>
-<wire x1="-154.94" y1="838.2" x2="-154.94" y2="868.68" width="0.1524" layer="91"/>
-<wire x1="-154.94" y1="868.68" x2="-175.26" y2="868.68" width="0.1524" layer="91"/>
-<wire x1="-27.94" y1="764.54" x2="-53.34" y2="764.54" width="0.1524" layer="91"/>
-<pinref part="U$87" gate="G$1" pin="E"/>
-<junction x="-91.44" y="843.28"/>
-<pinref part="R6" gate="G$1" pin="7"/>
+<wire x1="-165.1" y1="767.08" x2="-109.22" y2="767.08" width="0.1524" layer="91"/>
+<wire x1="-109.22" y1="767.08" x2="-27.94" y2="767.08" width="0.1524" layer="91"/>
+<label x="-144.78" y="767.08" size="1.778" layer="95"/>
+<pinref part="U13I" gate="G$1" pin="E"/>
+<wire x1="-109.22" y1="774.7" x2="-109.22" y2="767.08" width="0.1524" layer="91"/>
+<junction x="-109.22" y="767.08"/>
 <pinref part="U3" gate="U1" pin="F"/>
 </segment>
 </net>
-<net name="N$25" class="0">
+<net name="SNS13O" class="0">
 <segment>
-<wire x1="-109.22" y1="975.36" x2="-109.22" y2="967.74" width="0.1524" layer="91"/>
-<wire x1="-109.22" y1="967.74" x2="-58.42" y2="967.74" width="0.1524" layer="91"/>
-<wire x1="-58.42" y1="967.74" x2="-58.42" y2="932.18" width="0.1524" layer="91"/>
-<wire x1="-160.02" y1="932.18" x2="-58.42" y2="932.18" width="0.1524" layer="91"/>
-<junction x="-58.42" y="932.18"/>
+<wire x1="-167.64" y1="764.54" x2="-167.64" y2="855.98" width="0.1524" layer="91"/>
+<wire x1="-167.64" y1="855.98" x2="-175.26" y2="855.98" width="0.1524" layer="91"/>
+<pinref part="R6" gate="G$1" pin="2"/>
+<wire x1="-167.64" y1="764.54" x2="-91.44" y2="764.54" width="0.1524" layer="91"/>
+<label x="-144.78" y="764.54" size="1.778" layer="95"/>
+<pinref part="U13O" gate="G$1" pin="E"/>
+<wire x1="-91.44" y1="774.7" x2="-91.44" y2="764.54" width="0.1524" layer="91"/>
+<junction x="-91.44" y="764.54"/>
+<wire x1="-91.44" y1="764.54" x2="-27.94" y2="764.54" width="0.1524" layer="91"/>
+<pinref part="U3" gate="U1" pin="E"/>
+</segment>
+</net>
+<net name="SNS14O" class="0">
+<segment>
+<wire x1="-60.96" y1="800.1" x2="-60.96" y2="769.62" width="0.1524" layer="91"/>
+<wire x1="-60.96" y1="800.1" x2="-91.44" y2="800.1" width="0.1524" layer="91"/>
+<wire x1="-91.44" y1="800.1" x2="-162.56" y2="800.1" width="0.1524" layer="91"/>
+<wire x1="-162.56" y1="800.1" x2="-162.56" y2="861.06" width="0.1524" layer="91"/>
+<wire x1="-162.56" y1="861.06" x2="-175.26" y2="861.06" width="0.1524" layer="91"/>
+<pinref part="R6" gate="G$1" pin="4"/>
+<label x="-144.78" y="800.1" size="1.778" layer="95"/>
+<pinref part="U14O" gate="G$1" pin="E"/>
+<wire x1="-91.44" y1="807.72" x2="-91.44" y2="800.1" width="0.1524" layer="91"/>
+<junction x="-91.44" y="800.1"/>
+<pinref part="U3" gate="U1" pin="G"/>
+<wire x1="-27.94" y1="769.62" x2="-60.96" y2="769.62" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="SNS14I" class="0">
+<segment>
+<wire x1="-58.42" y1="802.64" x2="-58.42" y2="772.16" width="0.1524" layer="91"/>
+<wire x1="-58.42" y1="802.64" x2="-109.22" y2="802.64" width="0.1524" layer="91"/>
+<wire x1="-109.22" y1="802.64" x2="-160.02" y2="802.64" width="0.1524" layer="91"/>
+<wire x1="-160.02" y1="802.64" x2="-160.02" y2="863.6" width="0.1524" layer="91"/>
+<wire x1="-160.02" y1="863.6" x2="-175.26" y2="863.6" width="0.1524" layer="91"/>
+<pinref part="R6" gate="G$1" pin="5"/>
+<label x="-144.78" y="802.64" size="1.778" layer="95"/>
+<pinref part="U14I" gate="G$1" pin="E"/>
+<wire x1="-109.22" y1="807.72" x2="-109.22" y2="802.64" width="0.1524" layer="91"/>
+<junction x="-109.22" y="802.64"/>
+<pinref part="U3" gate="U1" pin="H"/>
+<wire x1="-27.94" y1="772.16" x2="-58.42" y2="772.16" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="SNS16O" class="0">
+<segment>
+<wire x1="-50.8" y1="756.92" x2="-50.8" y2="871.22" width="0.1524" layer="91"/>
+<wire x1="-50.8" y1="871.22" x2="-175.26" y2="871.22" width="0.1524" layer="91"/>
+<pinref part="R6" gate="G$1" pin="8"/>
+<label x="-142.24" y="871.22" size="1.778" layer="95"/>
+<pinref part="U3" gate="U1" pin="B"/>
+<wire x1="-50.8" y1="756.92" x2="-27.94" y2="756.92" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="SNS16I" class="0">
+<segment>
+<wire x1="-48.26" y1="873.76" x2="-48.26" y2="754.38" width="0.1524" layer="91"/>
+<wire x1="-175.26" y1="873.76" x2="-48.26" y2="873.76" width="0.1524" layer="91"/>
+<pinref part="R6" gate="G$1" pin="9"/>
+<label x="-142.24" y="873.76" size="1.778" layer="95"/>
+<pinref part="U3" gate="U1" pin="A"/>
+<wire x1="-48.26" y1="754.38" x2="-27.94" y2="754.38" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="SNS15O" class="0">
+<segment>
+<wire x1="-157.48" y1="835.66" x2="-91.44" y2="835.66" width="0.1524" layer="91"/>
+<wire x1="-91.44" y1="835.66" x2="-55.88" y2="835.66" width="0.1524" layer="91"/>
+<wire x1="-55.88" y1="762" x2="-55.88" y2="835.66" width="0.1524" layer="91"/>
+<wire x1="-157.48" y1="835.66" x2="-157.48" y2="866.14" width="0.1524" layer="91"/>
+<wire x1="-157.48" y1="866.14" x2="-175.26" y2="866.14" width="0.1524" layer="91"/>
+<pinref part="R6" gate="G$1" pin="6"/>
+<label x="-142.24" y="835.66" size="1.778" layer="95"/>
+<pinref part="U15O" gate="G$1" pin="E"/>
+<wire x1="-91.44" y1="843.28" x2="-91.44" y2="835.66" width="0.1524" layer="91"/>
+<junction x="-91.44" y="835.66"/>
+<pinref part="U3" gate="U1" pin="D"/>
+<wire x1="-27.94" y1="762" x2="-55.88" y2="762" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="SNS15I" class="0">
+<segment>
+<wire x1="-53.34" y1="838.2" x2="-53.34" y2="759.46" width="0.1524" layer="91"/>
+<wire x1="-53.34" y1="838.2" x2="-109.22" y2="838.2" width="0.1524" layer="91"/>
+<wire x1="-109.22" y1="838.2" x2="-154.94" y2="838.2" width="0.1524" layer="91"/>
+<wire x1="-154.94" y1="838.2" x2="-154.94" y2="868.68" width="0.1524" layer="91"/>
+<wire x1="-154.94" y1="868.68" x2="-175.26" y2="868.68" width="0.1524" layer="91"/>
+<pinref part="R6" gate="G$1" pin="7"/>
+<label x="-142.24" y="838.2" size="1.778" layer="95"/>
+<pinref part="U15I" gate="G$1" pin="E"/>
+<wire x1="-109.22" y1="843.28" x2="-109.22" y2="838.2" width="0.1524" layer="91"/>
+<junction x="-109.22" y="838.2"/>
+<pinref part="U3" gate="U1" pin="C"/>
+<wire x1="-27.94" y1="759.46" x2="-53.34" y2="759.46" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="SNS18O" class="0">
+<segment>
 <wire x1="-160.02" y1="932.18" x2="-160.02" y2="1028.7" width="0.1524" layer="91"/>
 <wire x1="-160.02" y1="1028.7" x2="-172.72" y2="1028.7" width="0.1524" layer="91"/>
-<wire x1="-58.42" y1="932.18" x2="-30.48" y2="932.18" width="0.1524" layer="91"/>
-<pinref part="U$80" gate="G$1" pin="E"/>
 <pinref part="R5" gate="G$1" pin="4"/>
-<pinref part="U2" gate="U1" pin="C"/>
-</segment>
-</net>
-<net name="N$26" class="0">
-<segment>
+<label x="-142.24" y="932.18" size="1.778" layer="95"/>
+<pinref part="U2" gate="U1" pin="G"/>
+<wire x1="-160.02" y1="932.18" x2="-55.88" y2="932.18" width="0.1524" layer="91"/>
+<pinref part="U18O" gate="G$1" pin="E"/>
+<wire x1="-55.88" y1="932.18" x2="-30.48" y2="932.18" width="0.1524" layer="91"/>
 <wire x1="-91.44" y1="975.36" x2="-91.44" y2="970.28" width="0.1524" layer="91"/>
 <wire x1="-91.44" y1="970.28" x2="-55.88" y2="970.28" width="0.1524" layer="91"/>
-<wire x1="-55.88" y1="970.28" x2="-55.88" y2="934.72" width="0.1524" layer="91"/>
-<wire x1="-55.88" y1="934.72" x2="-157.48" y2="934.72" width="0.1524" layer="91"/>
-<junction x="-55.88" y="934.72"/>
+<wire x1="-55.88" y1="970.28" x2="-55.88" y2="932.18" width="0.1524" layer="91"/>
+<junction x="-55.88" y="932.18"/>
+</segment>
+</net>
+<net name="SNS18I" class="0">
+<segment>
 <wire x1="-157.48" y1="934.72" x2="-157.48" y2="1031.24" width="0.1524" layer="91"/>
 <wire x1="-157.48" y1="1031.24" x2="-172.72" y2="1031.24" width="0.1524" layer="91"/>
-<wire x1="-55.88" y1="934.72" x2="-30.48" y2="934.72" width="0.1524" layer="91"/>
-<pinref part="U$81" gate="G$1" pin="E"/>
 <pinref part="R5" gate="G$1" pin="5"/>
-<pinref part="U2" gate="U1" pin="D"/>
+<label x="-142.24" y="934.72" size="1.778" layer="95"/>
+<pinref part="U2" gate="U1" pin="H"/>
+<wire x1="-157.48" y1="934.72" x2="-58.42" y2="934.72" width="0.1524" layer="91"/>
+<pinref part="U18I" gate="G$1" pin="E"/>
+<wire x1="-58.42" y1="934.72" x2="-30.48" y2="934.72" width="0.1524" layer="91"/>
+<wire x1="-109.22" y1="975.36" x2="-109.22" y2="967.74" width="0.1524" layer="91"/>
+<wire x1="-109.22" y1="967.74" x2="-58.42" y2="967.74" width="0.1524" layer="91"/>
+<wire x1="-58.42" y1="967.74" x2="-58.42" y2="934.72" width="0.1524" layer="91"/>
+<junction x="-58.42" y="934.72"/>
 </segment>
 </net>
-<net name="N$27" class="0">
+<net name="SNS20O" class="0">
 <segment>
-<wire x1="-109.22" y1="1046.48" x2="-109.22" y2="1038.86" width="0.1524" layer="91"/>
-<wire x1="-109.22" y1="1038.86" x2="-48.26" y2="1038.86" width="0.1524" layer="91"/>
-<wire x1="-48.26" y1="942.34" x2="-48.26" y2="1038.86" width="0.1524" layer="91"/>
-<wire x1="-109.22" y1="1038.86" x2="-172.72" y2="1038.86" width="0.1524" layer="91"/>
-<junction x="-109.22" y="1038.86"/>
-<wire x1="-48.26" y1="942.34" x2="-30.48" y2="942.34" width="0.1524" layer="91"/>
-<pinref part="U$76" gate="G$1" pin="E"/>
+<wire x1="-48.26" y1="919.48" x2="-48.26" y2="1038.86" width="0.1524" layer="91"/>
+<wire x1="-48.26" y1="1038.86" x2="-172.72" y2="1038.86" width="0.1524" layer="91"/>
 <pinref part="R5" gate="G$1" pin="8"/>
-<pinref part="U2" gate="U1" pin="G"/>
+<label x="-142.24" y="1038.86" size="1.778" layer="95"/>
+<pinref part="U2" gate="U1" pin="B"/>
+<wire x1="-48.26" y1="919.48" x2="-30.48" y2="919.48" width="0.1524" layer="91"/>
 </segment>
 </net>
-<net name="N$29" class="0">
+<net name="SNS19O" class="0">
 <segment>
-<wire x1="-109.22" y1="1010.92" x2="-109.22" y2="1003.3" width="0.1524" layer="91"/>
-<wire x1="-109.22" y1="1003.3" x2="-53.34" y2="1003.3" width="0.1524" layer="91"/>
-<wire x1="-154.94" y1="1003.3" x2="-109.22" y2="1003.3" width="0.1524" layer="91"/>
-<junction x="-109.22" y="1003.3"/>
-<wire x1="-53.34" y1="937.26" x2="-53.34" y2="1003.3" width="0.1524" layer="91"/>
+<wire x1="-154.94" y1="1003.3" x2="-91.44" y2="1003.3" width="0.1524" layer="91"/>
+<wire x1="-91.44" y1="1003.3" x2="-53.34" y2="1003.3" width="0.1524" layer="91"/>
+<wire x1="-53.34" y1="924.56" x2="-53.34" y2="1003.3" width="0.1524" layer="91"/>
 <wire x1="-154.94" y1="1003.3" x2="-154.94" y2="1033.78" width="0.1524" layer="91"/>
 <wire x1="-154.94" y1="1033.78" x2="-172.72" y2="1033.78" width="0.1524" layer="91"/>
-<wire x1="-53.34" y1="937.26" x2="-30.48" y2="937.26" width="0.1524" layer="91"/>
-<pinref part="U$78" gate="G$1" pin="E"/>
 <pinref part="R5" gate="G$1" pin="6"/>
-<pinref part="U2" gate="U1" pin="E"/>
+<label x="-142.24" y="1003.3" size="1.778" layer="95"/>
+<pinref part="U19O" gate="G$1" pin="E"/>
+<wire x1="-91.44" y1="1010.92" x2="-91.44" y2="1003.3" width="0.1524" layer="91"/>
+<junction x="-91.44" y="1003.3"/>
+<pinref part="U2" gate="U1" pin="D"/>
+<wire x1="-53.34" y1="924.56" x2="-30.48" y2="924.56" width="0.1524" layer="91"/>
 </segment>
 </net>
-<net name="N$32" class="0">
+<net name="SNS19I" class="0">
 <segment>
-<wire x1="-91.44" y1="1010.92" x2="-91.44" y2="1005.84" width="0.1524" layer="91"/>
-<wire x1="-91.44" y1="1005.84" x2="-50.8" y2="1005.84" width="0.1524" layer="91"/>
-<wire x1="-50.8" y1="1005.84" x2="-50.8" y2="939.8" width="0.1524" layer="91"/>
-<wire x1="-91.44" y1="1005.84" x2="-152.4" y2="1005.84" width="0.1524" layer="91"/>
-<junction x="-91.44" y="1005.84"/>
+<wire x1="-50.8" y1="1005.84" x2="-50.8" y2="922.02" width="0.1524" layer="91"/>
+<wire x1="-50.8" y1="1005.84" x2="-109.22" y2="1005.84" width="0.1524" layer="91"/>
+<wire x1="-109.22" y1="1005.84" x2="-152.4" y2="1005.84" width="0.1524" layer="91"/>
 <wire x1="-172.72" y1="1036.32" x2="-152.4" y2="1036.32" width="0.1524" layer="91"/>
 <wire x1="-152.4" y1="1036.32" x2="-152.4" y2="1005.84" width="0.1524" layer="91"/>
-<wire x1="-50.8" y1="939.8" x2="-30.48" y2="939.8" width="0.1524" layer="91"/>
-<pinref part="U$79" gate="G$1" pin="E"/>
 <pinref part="R5" gate="G$1" pin="7"/>
-<pinref part="U2" gate="U1" pin="F"/>
+<label x="-142.24" y="1005.84" size="1.778" layer="95"/>
+<pinref part="U19I" gate="G$1" pin="E"/>
+<wire x1="-109.22" y1="1010.92" x2="-109.22" y2="1005.84" width="0.1524" layer="91"/>
+<junction x="-109.22" y="1005.84"/>
+<pinref part="U2" gate="U1" pin="C"/>
+<wire x1="-50.8" y1="922.02" x2="-30.48" y2="922.02" width="0.1524" layer="91"/>
 </segment>
 </net>
-<net name="N$33" class="0">
+<net name="SNS17I" class="0">
 <segment>
-<wire x1="-30.48" y1="929.64" x2="-91.44" y2="929.64" width="0.1524" layer="91"/>
-<wire x1="-91.44" y1="929.64" x2="-91.44" y2="942.34" width="0.1524" layer="91"/>
-<wire x1="-162.56" y1="929.64" x2="-91.44" y2="929.64" width="0.1524" layer="91"/>
-<junction x="-91.44" y="929.64"/>
 <wire x1="-162.56" y1="929.64" x2="-162.56" y2="1026.16" width="0.1524" layer="91"/>
 <wire x1="-162.56" y1="1026.16" x2="-172.72" y2="1026.16" width="0.1524" layer="91"/>
-<pinref part="U$83" gate="G$1" pin="E"/>
 <pinref part="R5" gate="G$1" pin="3"/>
-<pinref part="U2" gate="U1" pin="B"/>
+<label x="-142.24" y="929.64" size="1.778" layer="95"/>
+<pinref part="U2" gate="U1" pin="F"/>
+<wire x1="-162.56" y1="929.64" x2="-109.22" y2="929.64" width="0.1524" layer="91"/>
+<pinref part="U17I" gate="G$1" pin="E"/>
+<wire x1="-109.22" y1="929.64" x2="-30.48" y2="929.64" width="0.1524" layer="91"/>
+<wire x1="-109.22" y1="942.34" x2="-109.22" y2="929.64" width="0.1524" layer="91"/>
+<junction x="-109.22" y="929.64"/>
 </segment>
 </net>
-<net name="N$35" class="0">
+<net name="SNS17O" class="0">
 <segment>
-<wire x1="-30.48" y1="927.1" x2="-109.22" y2="927.1" width="0.1524" layer="91"/>
-<wire x1="-109.22" y1="927.1" x2="-109.22" y2="942.34" width="0.1524" layer="91"/>
-<wire x1="-109.22" y1="927.1" x2="-165.1" y2="927.1" width="0.1524" layer="91"/>
-<junction x="-109.22" y="927.1"/>
 <wire x1="-165.1" y1="927.1" x2="-165.1" y2="1023.62" width="0.1524" layer="91"/>
 <wire x1="-165.1" y1="1023.62" x2="-172.72" y2="1023.62" width="0.1524" layer="91"/>
-<pinref part="U$82" gate="G$1" pin="E"/>
 <pinref part="R5" gate="G$1" pin="2"/>
-<pinref part="U2" gate="U1" pin="A"/>
+<label x="-142.24" y="927.1" size="1.778" layer="95"/>
+<wire x1="-165.1" y1="927.1" x2="-91.44" y2="927.1" width="0.1524" layer="91"/>
+<pinref part="U2" gate="U1" pin="E"/>
+<pinref part="U17O" gate="G$1" pin="E"/>
+<wire x1="-91.44" y1="927.1" x2="-30.48" y2="927.1" width="0.1524" layer="91"/>
+<wire x1="-91.44" y1="942.34" x2="-91.44" y2="927.1" width="0.1524" layer="91"/>
+<junction x="-91.44" y="927.1"/>
 </segment>
 </net>
-<net name="N$36" class="0">
+<net name="SNS22O" class="0">
 <segment>
-<wire x1="-109.22" y1="1130.3" x2="-109.22" y2="1122.68" width="0.1524" layer="91"/>
-<wire x1="-109.22" y1="1122.68" x2="-60.96" y2="1122.68" width="0.1524" layer="91"/>
-<wire x1="-60.96" y1="1122.68" x2="-60.96" y2="1087.12" width="0.1524" layer="91"/>
-<wire x1="-157.48" y1="1087.12" x2="-60.96" y2="1087.12" width="0.1524" layer="91"/>
-<junction x="-60.96" y="1087.12"/>
-<wire x1="-157.48" y1="1087.12" x2="-157.48" y2="1178.56" width="0.1524" layer="91"/>
-<wire x1="-30.48" y1="1087.12" x2="-60.96" y2="1087.12" width="0.1524" layer="91"/>
-<wire x1="-157.48" y1="1178.56" x2="-170.18" y2="1178.56" width="0.1524" layer="91"/>
-<pinref part="U$72" gate="G$1" pin="E"/>
-<junction x="-109.22" y="1130.3"/>
-<pinref part="R2" gate="G$1" pin="7"/>
-<pinref part="U1" gate="U1" pin="C"/>
-</segment>
-</net>
-<net name="N$37" class="0">
-<segment>
+<wire x1="-157.48" y1="1087.12" x2="-157.48" y2="1170.94" width="0.1524" layer="91"/>
+<label x="-137.16" y="1087.12" size="1.778" layer="95"/>
+<pinref part="R2" gate="G$1" pin="4"/>
+<wire x1="-170.18" y1="1170.94" x2="-157.48" y2="1170.94" width="0.1524" layer="91"/>
+<pinref part="U1" gate="U1" pin="G"/>
+<wire x1="-157.48" y1="1087.12" x2="-58.42" y2="1087.12" width="0.1524" layer="91"/>
+<pinref part="U22O" gate="G$1" pin="E"/>
+<junction x="-91.44" y="1130.3"/>
+<wire x1="-58.42" y1="1087.12" x2="-30.48" y2="1087.12" width="0.1524" layer="91"/>
 <wire x1="-91.44" y1="1130.3" x2="-91.44" y2="1125.22" width="0.1524" layer="91"/>
 <wire x1="-91.44" y1="1125.22" x2="-58.42" y2="1125.22" width="0.1524" layer="91"/>
-<wire x1="-58.42" y1="1125.22" x2="-58.42" y2="1089.66" width="0.1524" layer="91"/>
-<wire x1="-58.42" y1="1089.66" x2="-154.94" y2="1089.66" width="0.1524" layer="91"/>
-<junction x="-58.42" y="1089.66"/>
-<wire x1="-154.94" y1="1089.66" x2="-154.94" y2="1176.02" width="0.1524" layer="91"/>
-<wire x1="-58.42" y1="1089.66" x2="-30.48" y2="1089.66" width="0.1524" layer="91"/>
-<wire x1="-154.94" y1="1176.02" x2="-170.18" y2="1176.02" width="0.1524" layer="91"/>
-<pinref part="U$73" gate="G$1" pin="E"/>
-<junction x="-91.44" y="1130.3"/>
-<pinref part="R2" gate="G$1" pin="6"/>
-<pinref part="U1" gate="U1" pin="D"/>
+<wire x1="-58.42" y1="1125.22" x2="-58.42" y2="1087.12" width="0.1524" layer="91"/>
+<junction x="-58.42" y="1087.12"/>
 </segment>
 </net>
-<net name="N$38" class="0">
+<net name="SNS22I" class="0">
 <segment>
-<wire x1="-109.22" y1="1196.34" x2="-109.22" y2="1188.72" width="0.1524" layer="91"/>
-<wire x1="-109.22" y1="1188.72" x2="-50.8" y2="1188.72" width="0.1524" layer="91"/>
-<wire x1="-50.8" y1="1097.28" x2="-50.8" y2="1188.72" width="0.1524" layer="91"/>
-<wire x1="-109.22" y1="1188.72" x2="-144.78" y2="1188.72" width="0.1524" layer="91"/>
-<junction x="-109.22" y="1188.72"/>
-<wire x1="-30.48" y1="1097.28" x2="-50.8" y2="1097.28" width="0.1524" layer="91"/>
-<wire x1="-144.78" y1="1173.48" x2="-144.78" y2="1188.72" width="0.1524" layer="91"/>
-<wire x1="-170.18" y1="1173.48" x2="-144.78" y2="1173.48" width="0.1524" layer="91"/>
-<pinref part="U$68" gate="G$1" pin="E"/>
-<junction x="-109.22" y="1196.34"/>
+<wire x1="-154.94" y1="1089.66" x2="-154.94" y2="1173.48" width="0.1524" layer="91"/>
+<label x="-137.16" y="1089.66" size="1.778" layer="95"/>
 <pinref part="R2" gate="G$1" pin="5"/>
-<pinref part="U1" gate="U1" pin="G"/>
+<wire x1="-170.18" y1="1173.48" x2="-154.94" y2="1173.48" width="0.1524" layer="91"/>
+<wire x1="-154.94" y1="1089.66" x2="-60.96" y2="1089.66" width="0.1524" layer="91"/>
+<pinref part="U1" gate="U1" pin="H"/>
+<wire x1="-60.96" y1="1089.66" x2="-30.48" y2="1089.66" width="0.1524" layer="91"/>
+<wire x1="-109.22" y1="1122.68" x2="-60.96" y2="1122.68" width="0.1524" layer="91"/>
+<wire x1="-109.22" y1="1130.3" x2="-109.22" y2="1122.68" width="0.1524" layer="91"/>
+<pinref part="U22I" gate="G$1" pin="E"/>
+<junction x="-109.22" y="1130.3"/>
+<wire x1="-60.96" y1="1122.68" x2="-60.96" y2="1089.66" width="0.1524" layer="91"/>
+<junction x="-60.96" y="1089.66"/>
 </segment>
 </net>
-<net name="N$40" class="0">
+<net name="SNS24O" class="0">
 <segment>
-<wire x1="-109.22" y1="1163.32" x2="-109.22" y2="1155.7" width="0.1524" layer="91"/>
-<wire x1="-109.22" y1="1155.7" x2="-55.88" y2="1155.7" width="0.1524" layer="91"/>
-<wire x1="-165.1" y1="1155.7" x2="-109.22" y2="1155.7" width="0.1524" layer="91"/>
-<junction x="-109.22" y="1155.7"/>
-<wire x1="-55.88" y1="1092.2" x2="-55.88" y2="1155.7" width="0.1524" layer="91"/>
-<wire x1="-30.48" y1="1092.2" x2="-55.88" y2="1092.2" width="0.1524" layer="91"/>
-<wire x1="-165.1" y1="1155.7" x2="-165.1" y2="1165.86" width="0.1524" layer="91"/>
-<wire x1="-165.1" y1="1165.86" x2="-170.18" y2="1165.86" width="0.1524" layer="91"/>
-<pinref part="U$70" gate="G$1" pin="E"/>
-<junction x="-109.22" y="1163.32"/>
-<pinref part="R2" gate="G$1" pin="2"/>
-<pinref part="U1" gate="U1" pin="E"/>
-</segment>
-</net>
-<net name="N$41" class="0">
-<segment>
-<wire x1="-91.44" y1="1163.32" x2="-91.44" y2="1158.24" width="0.1524" layer="91"/>
-<wire x1="-91.44" y1="1158.24" x2="-53.34" y2="1158.24" width="0.1524" layer="91"/>
-<wire x1="-53.34" y1="1158.24" x2="-53.34" y2="1094.74" width="0.1524" layer="91"/>
-<wire x1="-91.44" y1="1158.24" x2="-152.4" y2="1158.24" width="0.1524" layer="91"/>
-<junction x="-91.44" y="1158.24"/>
-<wire x1="-53.34" y1="1094.74" x2="-30.48" y2="1094.74" width="0.1524" layer="91"/>
-<wire x1="-152.4" y1="1158.24" x2="-152.4" y2="1168.4" width="0.1524" layer="91"/>
-<wire x1="-152.4" y1="1168.4" x2="-170.18" y2="1168.4" width="0.1524" layer="91"/>
-<pinref part="U$71" gate="G$1" pin="E"/>
-<junction x="-91.44" y="1163.32"/>
-<pinref part="R2" gate="G$1" pin="3"/>
-<pinref part="U1" gate="U1" pin="F"/>
-</segment>
-</net>
-<net name="N$42" class="0">
-<segment>
-<wire x1="-91.44" y1="1084.58" x2="-91.44" y2="1094.74" width="0.1524" layer="91"/>
-<wire x1="-160.02" y1="1084.58" x2="-91.44" y2="1084.58" width="0.1524" layer="91"/>
-<junction x="-91.44" y="1084.58"/>
-<wire x1="-160.02" y1="1084.58" x2="-160.02" y2="1181.1" width="0.1524" layer="91"/>
-<wire x1="-91.44" y1="1084.58" x2="-30.48" y2="1084.58" width="0.1524" layer="91"/>
-<wire x1="-160.02" y1="1181.1" x2="-170.18" y2="1181.1" width="0.1524" layer="91"/>
-<pinref part="U$75" gate="G$1" pin="E"/>
-<junction x="-91.44" y="1094.74"/>
+<wire x1="-144.78" y1="1188.72" x2="-50.8" y2="1188.72" width="0.1524" layer="91"/>
+<wire x1="-50.8" y1="1074.42" x2="-50.8" y2="1188.72" width="0.1524" layer="91"/>
 <pinref part="R2" gate="G$1" pin="8"/>
+<wire x1="-144.78" y1="1181.1" x2="-144.78" y2="1188.72" width="0.1524" layer="91"/>
+<wire x1="-170.18" y1="1181.1" x2="-144.78" y2="1181.1" width="0.1524" layer="91"/>
+<label x="-137.16" y="1188.72" size="1.778" layer="95"/>
 <pinref part="U1" gate="U1" pin="B"/>
+<wire x1="-50.8" y1="1074.42" x2="-30.48" y2="1074.42" width="0.1524" layer="91"/>
 </segment>
 </net>
-<net name="N$43" class="0">
+<net name="SNS23O" class="0">
 <segment>
-<wire x1="-109.22" y1="1082.04" x2="-109.22" y2="1094.74" width="0.1524" layer="91"/>
-<wire x1="-109.22" y1="1082.04" x2="-162.56" y2="1082.04" width="0.1524" layer="91"/>
-<junction x="-109.22" y="1082.04"/>
-<wire x1="-162.56" y1="1082.04" x2="-162.56" y2="1183.64" width="0.1524" layer="91"/>
-<wire x1="-30.48" y1="1082.04" x2="-109.22" y2="1082.04" width="0.1524" layer="91"/>
-<wire x1="-162.56" y1="1183.64" x2="-170.18" y2="1183.64" width="0.1524" layer="91"/>
-<pinref part="U$74" gate="G$1" pin="E"/>
-<junction x="-109.22" y="1094.74"/>
-<pinref part="R2" gate="G$1" pin="9"/>
-<pinref part="U1" gate="U1" pin="A"/>
+<wire x1="-152.4" y1="1155.7" x2="-55.88" y2="1155.7" width="0.1524" layer="91"/>
+<wire x1="-55.88" y1="1079.5" x2="-55.88" y2="1155.7" width="0.1524" layer="91"/>
+<pinref part="R2" gate="G$1" pin="6"/>
+<wire x1="-152.4" y1="1155.7" x2="-152.4" y2="1176.02" width="0.1524" layer="91"/>
+<wire x1="-152.4" y1="1176.02" x2="-170.18" y2="1176.02" width="0.1524" layer="91"/>
+<label x="-137.16" y="1155.7" size="1.778" layer="95"/>
+<pinref part="U1" gate="U1" pin="D"/>
+<wire x1="-55.88" y1="1079.5" x2="-30.48" y2="1079.5" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="SNS23I" class="0">
+<segment>
+<wire x1="-53.34" y1="1158.24" x2="-53.34" y2="1076.96" width="0.1524" layer="91"/>
+<wire x1="-53.34" y1="1158.24" x2="-149.86" y2="1158.24" width="0.1524" layer="91"/>
+<pinref part="R2" gate="G$1" pin="7"/>
+<wire x1="-170.18" y1="1178.56" x2="-149.86" y2="1178.56" width="0.1524" layer="91"/>
+<wire x1="-149.86" y1="1178.56" x2="-149.86" y2="1158.24" width="0.1524" layer="91"/>
+<label x="-137.16" y="1158.24" size="1.778" layer="95"/>
+<pinref part="U1" gate="U1" pin="C"/>
+<wire x1="-53.34" y1="1076.96" x2="-30.48" y2="1076.96" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="SNS21I" class="0">
+<segment>
+<wire x1="-160.02" y1="1084.58" x2="-160.02" y2="1168.4" width="0.1524" layer="91"/>
+<label x="-137.16" y="1084.58" size="1.778" layer="95"/>
+<pinref part="R2" gate="G$1" pin="3"/>
+<wire x1="-170.18" y1="1168.4" x2="-160.02" y2="1168.4" width="0.1524" layer="91"/>
+<pinref part="U1" gate="U1" pin="F"/>
+<wire x1="-160.02" y1="1084.58" x2="-109.22" y2="1084.58" width="0.1524" layer="91"/>
+<pinref part="U21I" gate="G$1" pin="E"/>
+<wire x1="-109.22" y1="1084.58" x2="-30.48" y2="1084.58" width="0.1524" layer="91"/>
+<wire x1="-109.22" y1="1094.74" x2="-109.22" y2="1084.58" width="0.1524" layer="91"/>
+<junction x="-109.22" y="1084.58"/>
+</segment>
+</net>
+<net name="SNS21O" class="0">
+<segment>
+<wire x1="-162.56" y1="1082.04" x2="-162.56" y2="1165.86" width="0.1524" layer="91"/>
+<label x="-137.16" y="1082.04" size="1.778" layer="95"/>
+<pinref part="R2" gate="G$1" pin="2"/>
+<wire x1="-170.18" y1="1165.86" x2="-162.56" y2="1165.86" width="0.1524" layer="91"/>
+<pinref part="U1" gate="U1" pin="E"/>
+<wire x1="-162.56" y1="1082.04" x2="-91.44" y2="1082.04" width="0.1524" layer="91"/>
+<pinref part="U21O" gate="G$1" pin="E"/>
+<wire x1="-91.44" y1="1082.04" x2="-30.48" y2="1082.04" width="0.1524" layer="91"/>
+<wire x1="-91.44" y1="1094.74" x2="-91.44" y2="1082.04" width="0.1524" layer="91"/>
+<junction x="-91.44" y="1082.04"/>
 </segment>
 </net>
 <net name="N$45" class="0">
@@ -31879,9 +32006,9 @@ Thomas Hudson</text>
 <wire x1="-96.52" y1="1193.8" x2="-96.52" y2="1211.58" width="0.1524" layer="91"/>
 <wire x1="-96.52" y1="1211.58" x2="-83.82" y2="1211.58" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="1211.58" x2="-83.82" y2="1209.04" width="0.1524" layer="91"/>
-<pinref part="U$68" gate="G$1" pin="K"/>
+<pinref part="U24I" gate="G$1" pin="K"/>
 <junction x="-101.6" y="1196.34"/>
-<pinref part="U$69" gate="G$1" pin="A"/>
+<pinref part="U24O" gate="G$1" pin="A"/>
 <junction x="-83.82" y="1209.04"/>
 </segment>
 </net>
@@ -31892,9 +32019,9 @@ Thomas Hudson</text>
 <wire x1="-96.52" y1="1160.78" x2="-96.52" y2="1178.56" width="0.1524" layer="91"/>
 <wire x1="-96.52" y1="1178.56" x2="-83.82" y2="1178.56" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="1178.56" x2="-83.82" y2="1176.02" width="0.1524" layer="91"/>
-<pinref part="U$70" gate="G$1" pin="K"/>
+<pinref part="U23I" gate="G$1" pin="K"/>
 <junction x="-101.6" y="1163.32"/>
-<pinref part="U$71" gate="G$1" pin="A"/>
+<pinref part="U23O" gate="G$1" pin="A"/>
 <junction x="-83.82" y="1176.02"/>
 </segment>
 </net>
@@ -31905,9 +32032,9 @@ Thomas Hudson</text>
 <wire x1="-96.52" y1="1127.76" x2="-96.52" y2="1145.54" width="0.1524" layer="91"/>
 <wire x1="-96.52" y1="1145.54" x2="-83.82" y2="1145.54" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="1145.54" x2="-83.82" y2="1143" width="0.1524" layer="91"/>
-<pinref part="U$72" gate="G$1" pin="K"/>
+<pinref part="U22I" gate="G$1" pin="K"/>
 <junction x="-101.6" y="1130.3"/>
-<pinref part="U$73" gate="G$1" pin="A"/>
+<pinref part="U22O" gate="G$1" pin="A"/>
 <junction x="-83.82" y="1143"/>
 </segment>
 </net>
@@ -31918,9 +32045,9 @@ Thomas Hudson</text>
 <wire x1="-96.52" y1="1092.2" x2="-96.52" y2="1109.98" width="0.1524" layer="91"/>
 <wire x1="-96.52" y1="1109.98" x2="-83.82" y2="1109.98" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="1109.98" x2="-83.82" y2="1107.44" width="0.1524" layer="91"/>
-<pinref part="U$74" gate="G$1" pin="K"/>
+<pinref part="U21I" gate="G$1" pin="K"/>
 <junction x="-101.6" y="1094.74"/>
-<pinref part="U$75" gate="G$1" pin="A"/>
+<pinref part="U21O" gate="G$1" pin="A"/>
 <junction x="-83.82" y="1107.44"/>
 </segment>
 </net>
@@ -31931,8 +32058,8 @@ Thomas Hudson</text>
 <wire x1="-93.98" y1="939.8" x2="-93.98" y2="957.58" width="0.1524" layer="91"/>
 <wire x1="-93.98" y1="957.58" x2="-83.82" y2="957.58" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="957.58" x2="-83.82" y2="955.04" width="0.1524" layer="91"/>
-<pinref part="U$82" gate="G$1" pin="K"/>
-<pinref part="U$83" gate="G$1" pin="A"/>
+<pinref part="U17I" gate="G$1" pin="K"/>
+<pinref part="U17O" gate="G$1" pin="A"/>
 </segment>
 </net>
 <net name="N$50" class="0">
@@ -31942,8 +32069,8 @@ Thomas Hudson</text>
 <wire x1="-93.98" y1="972.82" x2="-93.98" y2="990.6" width="0.1524" layer="91"/>
 <wire x1="-93.98" y1="990.6" x2="-83.82" y2="990.6" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="990.6" x2="-83.82" y2="988.06" width="0.1524" layer="91"/>
-<pinref part="U$80" gate="G$1" pin="K"/>
-<pinref part="U$81" gate="G$1" pin="A"/>
+<pinref part="U18I" gate="G$1" pin="K"/>
+<pinref part="U18O" gate="G$1" pin="A"/>
 </segment>
 </net>
 <net name="N$51" class="0">
@@ -31953,8 +32080,8 @@ Thomas Hudson</text>
 <wire x1="-93.98" y1="1043.94" x2="-93.98" y2="1061.72" width="0.1524" layer="91"/>
 <wire x1="-93.98" y1="1061.72" x2="-83.82" y2="1061.72" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="1061.72" x2="-83.82" y2="1059.18" width="0.1524" layer="91"/>
-<pinref part="U$76" gate="G$1" pin="K"/>
-<pinref part="U$77" gate="G$1" pin="A"/>
+<pinref part="U20I" gate="G$1" pin="K"/>
+<pinref part="U20O" gate="G$1" pin="A"/>
 </segment>
 </net>
 <net name="N$52" class="0">
@@ -31964,8 +32091,8 @@ Thomas Hudson</text>
 <wire x1="-93.98" y1="1008.38" x2="-93.98" y2="1026.16" width="0.1524" layer="91"/>
 <wire x1="-93.98" y1="1026.16" x2="-83.82" y2="1026.16" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="1026.16" x2="-83.82" y2="1023.62" width="0.1524" layer="91"/>
-<pinref part="U$78" gate="G$1" pin="K"/>
-<pinref part="U$79" gate="G$1" pin="A"/>
+<pinref part="U19I" gate="G$1" pin="K"/>
+<pinref part="U19O" gate="G$1" pin="A"/>
 </segment>
 </net>
 <net name="N$53" class="0">
@@ -31975,9 +32102,9 @@ Thomas Hudson</text>
 <wire x1="-96.52" y1="876.3" x2="-96.52" y2="894.08" width="0.1524" layer="91"/>
 <wire x1="-96.52" y1="894.08" x2="-83.82" y2="894.08" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="894.08" x2="-83.82" y2="891.54" width="0.1524" layer="91"/>
-<pinref part="U$84" gate="G$1" pin="K"/>
+<pinref part="U16I" gate="G$1" pin="K"/>
 <junction x="-101.6" y="878.84"/>
-<pinref part="U$85" gate="G$1" pin="A"/>
+<pinref part="U16O" gate="G$1" pin="A"/>
 <junction x="-83.82" y="891.54"/>
 </segment>
 </net>
@@ -31988,9 +32115,9 @@ Thomas Hudson</text>
 <wire x1="-96.52" y1="840.74" x2="-96.52" y2="858.52" width="0.1524" layer="91"/>
 <wire x1="-96.52" y1="858.52" x2="-83.82" y2="858.52" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="858.52" x2="-83.82" y2="855.98" width="0.1524" layer="91"/>
-<pinref part="U$86" gate="G$1" pin="K"/>
+<pinref part="U15I" gate="G$1" pin="K"/>
 <junction x="-101.6" y="843.28"/>
-<pinref part="U$87" gate="G$1" pin="A"/>
+<pinref part="U15O" gate="G$1" pin="A"/>
 <junction x="-83.82" y="855.98"/>
 </segment>
 </net>
@@ -32001,9 +32128,9 @@ Thomas Hudson</text>
 <wire x1="-96.52" y1="805.18" x2="-96.52" y2="822.96" width="0.1524" layer="91"/>
 <wire x1="-96.52" y1="822.96" x2="-83.82" y2="822.96" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="822.96" x2="-83.82" y2="820.42" width="0.1524" layer="91"/>
-<pinref part="U$88" gate="G$1" pin="K"/>
+<pinref part="U14I" gate="G$1" pin="K"/>
 <junction x="-101.6" y="807.72"/>
-<pinref part="U$89" gate="G$1" pin="A"/>
+<pinref part="U14O" gate="G$1" pin="A"/>
 <junction x="-83.82" y="820.42"/>
 </segment>
 </net>
@@ -32014,9 +32141,9 @@ Thomas Hudson</text>
 <wire x1="-96.52" y1="772.16" x2="-96.52" y2="789.94" width="0.1524" layer="91"/>
 <wire x1="-96.52" y1="789.94" x2="-83.82" y2="789.94" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="789.94" x2="-83.82" y2="787.4" width="0.1524" layer="91"/>
-<pinref part="U$90" gate="G$1" pin="K"/>
+<pinref part="U13I" gate="G$1" pin="K"/>
 <junction x="-101.6" y="774.7"/>
-<pinref part="U$91" gate="G$1" pin="A"/>
+<pinref part="U13O" gate="G$1" pin="A"/>
 <junction x="-83.82" y="787.4"/>
 </segment>
 </net>
@@ -32044,141 +32171,122 @@ Thomas Hudson</text>
 <pinref part="U$45" gate="G$1" pin="SCL"/>
 </segment>
 </net>
-<net name="N$62" class="0">
+<net name="SNS12O" class="0">
 <segment>
-<wire x1="-106.68" y1="703.58" x2="-106.68" y2="695.96" width="0.1524" layer="91"/>
-<wire x1="-106.68" y1="695.96" x2="-48.26" y2="695.96" width="0.1524" layer="91"/>
-<wire x1="-48.26" y1="604.52" x2="-48.26" y2="695.96" width="0.1524" layer="91"/>
-<wire x1="-106.68" y1="695.96" x2="-162.56" y2="695.96" width="0.1524" layer="91"/>
+<wire x1="-162.56" y1="695.96" x2="-88.9" y2="695.96" width="0.1524" layer="91"/>
+<wire x1="-88.9" y1="695.96" x2="-45.72" y2="695.96" width="0.1524" layer="91"/>
+<wire x1="-45.72" y1="581.66" x2="-45.72" y2="695.96" width="0.1524" layer="91"/>
 <wire x1="-162.56" y1="695.96" x2="-162.56" y2="688.34" width="0.1524" layer="91"/>
 <wire x1="-162.56" y1="688.34" x2="-167.64" y2="688.34" width="0.1524" layer="91"/>
-<junction x="-106.68" y="695.96"/>
-<wire x1="-48.26" y1="604.52" x2="-27.94" y2="604.52" width="0.1524" layer="91"/>
-<pinref part="U$92" gate="G$1" pin="E"/>
-<junction x="-106.68" y="703.58"/>
 <pinref part="R7" gate="G$1" pin="8"/>
-<pinref part="U4" gate="U1" pin="G"/>
+<label x="-139.7" y="695.96" size="1.778" layer="95"/>
+<pinref part="U12O" gate="G$1" pin="E"/>
+<wire x1="-88.9" y1="703.58" x2="-88.9" y2="695.96" width="0.1524" layer="91"/>
+<junction x="-88.9" y="695.96"/>
+<pinref part="U4" gate="U1" pin="B"/>
+<wire x1="-45.72" y1="581.66" x2="-27.94" y2="581.66" width="0.1524" layer="91"/>
+<label x="-38.1" y="581.66" size="1.778" layer="95"/>
 </segment>
 </net>
-<net name="N$65" class="0">
+<net name="SNS11O" class="0">
 <segment>
-<wire x1="-106.68" y1="670.56" x2="-106.68" y2="662.94" width="0.1524" layer="91"/>
-<wire x1="-106.68" y1="662.94" x2="-53.34" y2="662.94" width="0.1524" layer="91"/>
-<wire x1="-149.86" y1="662.94" x2="-106.68" y2="662.94" width="0.1524" layer="91"/>
-<junction x="-106.68" y="662.94"/>
-<wire x1="-53.34" y1="599.44" x2="-53.34" y2="662.94" width="0.1524" layer="91"/>
+<wire x1="-149.86" y1="662.94" x2="-88.9" y2="662.94" width="0.1524" layer="91"/>
+<wire x1="-88.9" y1="662.94" x2="-50.8" y2="662.94" width="0.1524" layer="91"/>
+<wire x1="-50.8" y1="586.74" x2="-50.8" y2="662.94" width="0.1524" layer="91"/>
 <wire x1="-149.86" y1="662.94" x2="-149.86" y2="683.26" width="0.1524" layer="91"/>
 <wire x1="-149.86" y1="683.26" x2="-167.64" y2="683.26" width="0.1524" layer="91"/>
-<wire x1="-53.34" y1="599.44" x2="-27.94" y2="599.44" width="0.1524" layer="91"/>
-<pinref part="U$94" gate="G$1" pin="E"/>
-<junction x="-106.68" y="670.56"/>
 <pinref part="R7" gate="G$1" pin="6"/>
-<pinref part="U4" gate="U1" pin="E"/>
+<label x="-142.24" y="662.94" size="1.778" layer="95"/>
+<pinref part="U11O" gate="G$1" pin="E"/>
+<wire x1="-88.9" y1="670.56" x2="-88.9" y2="662.94" width="0.1524" layer="91"/>
+<junction x="-88.9" y="662.94"/>
+<pinref part="U4" gate="U1" pin="D"/>
+<wire x1="-50.8" y1="586.74" x2="-27.94" y2="586.74" width="0.1524" layer="91"/>
+<label x="-38.1" y="586.74" size="1.778" layer="95"/>
 </segment>
 </net>
-<net name="N$68" class="0">
+<net name="SNS09I" class="0">
 <segment>
-<wire x1="-106.68" y1="589.28" x2="-106.68" y2="601.98" width="0.1524" layer="91"/>
-<wire x1="-106.68" y1="589.28" x2="-160.02" y2="589.28" width="0.1524" layer="91"/>
-<junction x="-106.68" y="589.28"/>
-<wire x1="-160.02" y1="589.28" x2="-160.02" y2="673.1" width="0.1524" layer="91"/>
-<wire x1="-160.02" y1="673.1" x2="-167.64" y2="673.1" width="0.1524" layer="91"/>
-<wire x1="-106.68" y1="589.28" x2="-27.94" y2="589.28" width="0.1524" layer="91"/>
-<pinref part="U$98" gate="G$1" pin="E"/>
-<junction x="-106.68" y="601.98"/>
-<pinref part="R7" gate="G$1" pin="2"/>
-<pinref part="U4" gate="U1" pin="A"/>
+<wire x1="-157.48" y1="591.82" x2="-157.48" y2="675.64" width="0.1524" layer="91"/>
+<label x="-147.32" y="591.82" size="1.778" layer="95"/>
+<wire x1="-157.48" y1="591.82" x2="-106.68" y2="591.82" width="0.1524" layer="91"/>
+<pinref part="U4" gate="U1" pin="F"/>
+<pinref part="R7" gate="G$1" pin="3"/>
+<wire x1="-106.68" y1="591.82" x2="-27.94" y2="591.82" width="0.1524" layer="91"/>
+<wire x1="-157.48" y1="675.64" x2="-167.64" y2="675.64" width="0.1524" layer="91"/>
+<label x="-38.1" y="591.82" size="1.778" layer="95"/>
+<pinref part="U09I" gate="G$1" pin="E"/>
+<wire x1="-106.68" y1="601.98" x2="-106.68" y2="591.82" width="0.1524" layer="91"/>
+<junction x="-106.68" y="591.82"/>
 </segment>
 </net>
-<net name="N$34" class="0">
+<net name="SNS10O" class="0">
 <segment>
-<wire x1="-106.68" y1="637.54" x2="-106.68" y2="629.92" width="0.1524" layer="91"/>
-<wire x1="-106.68" y1="629.92" x2="-58.42" y2="629.92" width="0.1524" layer="91"/>
-<wire x1="-58.42" y1="629.92" x2="-58.42" y2="594.36" width="0.1524" layer="91"/>
-<wire x1="-154.94" y1="594.36" x2="-58.42" y2="594.36" width="0.1524" layer="91"/>
-<junction x="-58.42" y="594.36"/>
+<wire x1="-154.94" y1="594.36" x2="-55.88" y2="594.36" width="0.1524" layer="91"/>
 <wire x1="-154.94" y1="594.36" x2="-154.94" y2="678.18" width="0.1524" layer="91"/>
 <wire x1="-154.94" y1="678.18" x2="-167.64" y2="678.18" width="0.1524" layer="91"/>
-<wire x1="-58.42" y1="594.36" x2="-27.94" y2="594.36" width="0.1524" layer="91"/>
-<pinref part="U$96" gate="G$1" pin="E"/>
-<junction x="-106.68" y="637.54"/>
 <pinref part="R7" gate="G$1" pin="4"/>
-<pinref part="U4" gate="U1" pin="C"/>
+<label x="-147.32" y="594.36" size="1.778" layer="95"/>
+<pinref part="U10O" gate="G$1" pin="E"/>
+<junction x="-88.9" y="637.54"/>
+<wire x1="-88.9" y1="637.54" x2="-88.9" y2="632.46" width="0.1524" layer="91"/>
+<wire x1="-88.9" y1="632.46" x2="-55.88" y2="632.46" width="0.1524" layer="91"/>
+<wire x1="-55.88" y1="632.46" x2="-55.88" y2="594.36" width="0.1524" layer="91"/>
+<junction x="-55.88" y="594.36"/>
+<pinref part="U4" gate="U1" pin="G"/>
+<wire x1="-55.88" y1="594.36" x2="-27.94" y2="594.36" width="0.1524" layer="91"/>
+<label x="-38.1" y="594.36" size="1.778" layer="95"/>
 </segment>
 </net>
-<net name="N$87" class="0">
+<net name="SNS01O" class="0">
 <segment>
 <wire x1="-88.9" y1="281.94" x2="-88.9" y2="276.86" width="0.1524" layer="91"/>
-<wire x1="-88.9" y1="276.86" x2="-88.9" y2="261.62" width="0.1524" layer="91"/>
+<wire x1="-88.9" y1="276.86" x2="-88.9" y2="269.24" width="0.1524" layer="91"/>
 <wire x1="-88.9" y1="276.86" x2="-165.1" y2="276.86" width="0.1524" layer="91"/>
 <wire x1="-165.1" y1="276.86" x2="-165.1" y2="363.22" width="0.1524" layer="91"/>
 <wire x1="-165.1" y1="363.22" x2="-172.72" y2="363.22" width="0.1524" layer="91"/>
 <junction x="-88.9" y="276.86"/>
-<wire x1="-25.4" y1="261.62" x2="-88.9" y2="261.62" width="0.1524" layer="91"/>
-<pinref part="U$115" gate="G$1" pin="E"/>
+<pinref part="U01O" gate="G$1" pin="E"/>
 <junction x="-88.9" y="281.94"/>
 <pinref part="R12" gate="G$1" pin="2"/>
-<pinref part="U6" gate="U1" pin="B"/>
+<pinref part="U6" gate="U1" pin="E"/>
+<wire x1="-25.4" y1="269.24" x2="-88.9" y2="269.24" width="0.1524" layer="91"/>
+<label x="-124.46" y="276.86" size="1.778" layer="95"/>
+<label x="-38.1" y="269.24" size="1.778" layer="95"/>
 </segment>
 </net>
-<net name="N$89" class="0">
+<net name="SNS06I" class="0">
 <segment>
-<wire x1="-104.14" y1="482.6" x2="-104.14" y2="474.98" width="0.1524" layer="91"/>
-<wire x1="-104.14" y1="474.98" x2="-55.88" y2="474.98" width="0.1524" layer="91"/>
-<wire x1="-55.88" y1="474.98" x2="-55.88" y2="439.42" width="0.1524" layer="91"/>
-<wire x1="-157.48" y1="439.42" x2="-55.88" y2="439.42" width="0.1524" layer="91"/>
-<junction x="-55.88" y="439.42"/>
-<wire x1="-157.48" y1="439.42" x2="-157.48" y2="535.94" width="0.1524" layer="91"/>
-<wire x1="-157.48" y1="535.94" x2="-170.18" y2="535.94" width="0.1524" layer="91"/>
-<wire x1="-55.88" y1="439.42" x2="-25.4" y2="439.42" width="0.1524" layer="91"/>
-<pinref part="U$104" gate="G$1" pin="E"/>
+<pinref part="U06I" gate="G$1" pin="E"/>
 <junction x="-104.14" y="482.6"/>
-<pinref part="R11" gate="G$1" pin="4"/>
-<pinref part="U5" gate="U1" pin="C"/>
+<wire x1="-104.14" y1="482.6" x2="-104.14" y2="477.52" width="0.1524" layer="91"/>
+<wire x1="-104.14" y1="477.52" x2="-53.34" y2="477.52" width="0.1524" layer="91"/>
+<wire x1="-53.34" y1="477.52" x2="-53.34" y2="441.96" width="0.1524" layer="91"/>
+<wire x1="-154.94" y1="477.52" x2="-154.94" y2="538.48" width="0.1524" layer="91"/>
+<wire x1="-154.94" y1="538.48" x2="-170.18" y2="538.48" width="0.1524" layer="91"/>
+<pinref part="R11" gate="G$1" pin="5"/>
+<wire x1="-104.14" y1="477.52" x2="-154.94" y2="477.52" width="0.1524" layer="91"/>
+<junction x="-104.14" y="477.52"/>
+<label x="-124.46" y="477.52" size="1.778" layer="95"/>
+<pinref part="U5" gate="U1" pin="H"/>
+<wire x1="-25.4" y1="441.96" x2="-53.34" y2="441.96" width="0.1524" layer="91"/>
+<label x="-38.1" y="441.96" size="1.778" layer="95"/>
 </segment>
 </net>
-<net name="N$91" class="0">
+<net name="SNS08O" class="0">
 <segment>
-<wire x1="-104.14" y1="553.72" x2="-104.14" y2="546.1" width="0.1524" layer="91"/>
-<wire x1="-104.14" y1="546.1" x2="-45.72" y2="546.1" width="0.1524" layer="91"/>
-<wire x1="-45.72" y1="449.58" x2="-45.72" y2="546.1" width="0.1524" layer="91"/>
-<wire x1="-104.14" y1="546.1" x2="-170.18" y2="546.1" width="0.1524" layer="91"/>
-<junction x="-104.14" y="546.1"/>
-<wire x1="-45.72" y1="449.58" x2="-25.4" y2="449.58" width="0.1524" layer="91"/>
-<pinref part="U$100" gate="G$1" pin="E"/>
-<junction x="-104.14" y="553.72"/>
+<wire x1="-45.72" y1="546.1" x2="-45.72" y2="426.72" width="0.1524" layer="91"/>
+<pinref part="U08O" gate="G$1" pin="E"/>
+<junction x="-86.36" y="553.72"/>
+<wire x1="-86.36" y1="553.72" x2="-86.36" y2="546.1" width="0.1524" layer="91"/>
 <pinref part="R11" gate="G$1" pin="8"/>
-<pinref part="U5" gate="U1" pin="G"/>
-</segment>
-</net>
-<net name="N$93" class="0">
-<segment>
-<wire x1="-104.14" y1="518.16" x2="-104.14" y2="510.54" width="0.1524" layer="91"/>
-<wire x1="-104.14" y1="510.54" x2="-50.8" y2="510.54" width="0.1524" layer="91"/>
-<wire x1="-152.4" y1="510.54" x2="-104.14" y2="510.54" width="0.1524" layer="91"/>
-<junction x="-104.14" y="510.54"/>
-<wire x1="-50.8" y1="444.5" x2="-50.8" y2="510.54" width="0.1524" layer="91"/>
-<wire x1="-152.4" y1="510.54" x2="-152.4" y2="541.02" width="0.1524" layer="91"/>
-<wire x1="-152.4" y1="541.02" x2="-170.18" y2="541.02" width="0.1524" layer="91"/>
-<wire x1="-50.8" y1="444.5" x2="-25.4" y2="444.5" width="0.1524" layer="91"/>
-<pinref part="U$102" gate="G$1" pin="E"/>
-<junction x="-104.14" y="518.16"/>
-<pinref part="R11" gate="G$1" pin="6"/>
-<pinref part="U5" gate="U1" pin="E"/>
-</segment>
-</net>
-<net name="N$97" class="0">
-<segment>
-<wire x1="-104.14" y1="434.34" x2="-104.14" y2="449.58" width="0.1524" layer="91"/>
-<wire x1="-104.14" y1="434.34" x2="-162.56" y2="434.34" width="0.1524" layer="91"/>
-<junction x="-104.14" y="434.34"/>
-<wire x1="-162.56" y1="434.34" x2="-162.56" y2="530.86" width="0.1524" layer="91"/>
-<wire x1="-162.56" y1="530.86" x2="-170.18" y2="530.86" width="0.1524" layer="91"/>
-<wire x1="-104.14" y1="434.34" x2="-25.4" y2="434.34" width="0.1524" layer="91"/>
-<pinref part="U$106" gate="G$1" pin="E"/>
-<junction x="-104.14" y="449.58"/>
-<pinref part="R11" gate="G$1" pin="2"/>
-<pinref part="U5" gate="U1" pin="A"/>
+<wire x1="-170.18" y1="546.1" x2="-86.36" y2="546.1" width="0.1524" layer="91"/>
+<label x="-124.46" y="546.1" size="1.778" layer="95"/>
+<wire x1="-86.36" y1="546.1" x2="-45.72" y2="546.1" width="0.1524" layer="91"/>
+<junction x="-86.36" y="546.1"/>
+<pinref part="U5" gate="U1" pin="B"/>
+<wire x1="-25.4" y1="426.72" x2="-45.72" y2="426.72" width="0.1524" layer="91"/>
+<label x="-38.1" y="426.72" size="1.778" layer="95"/>
 </segment>
 </net>
 <net name="13_CATHODE" class="0">
@@ -32186,7 +32294,7 @@ Thomas Hudson</text>
 <wire x1="-83.82" y1="774.7" x2="-83.82" y2="772.16" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="772.16" x2="-78.74" y2="772.16" width="0.1524" layer="91"/>
 <label x="-78.74" y="772.16" size="1.778" layer="95"/>
-<pinref part="U$91" gate="G$1" pin="K"/>
+<pinref part="U13O" gate="G$1" pin="K"/>
 <junction x="-83.82" y="774.7"/>
 </segment>
 <segment>
@@ -32200,7 +32308,7 @@ Thomas Hudson</text>
 <wire x1="-83.82" y1="807.72" x2="-83.82" y2="805.18" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="805.18" x2="-76.2" y2="805.18" width="0.1524" layer="91"/>
 <label x="-76.2" y="805.18" size="1.778" layer="95"/>
-<pinref part="U$89" gate="G$1" pin="K"/>
+<pinref part="U14O" gate="G$1" pin="K"/>
 <junction x="-83.82" y="807.72"/>
 </segment>
 <segment>
@@ -32214,7 +32322,7 @@ Thomas Hudson</text>
 <wire x1="-83.82" y1="843.28" x2="-83.82" y2="840.74" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="840.74" x2="-78.74" y2="840.74" width="0.1524" layer="91"/>
 <label x="-78.74" y="840.74" size="1.778" layer="95"/>
-<pinref part="U$87" gate="G$1" pin="K"/>
+<pinref part="U15O" gate="G$1" pin="K"/>
 <junction x="-83.82" y="843.28"/>
 </segment>
 <segment>
@@ -32228,7 +32336,7 @@ Thomas Hudson</text>
 <wire x1="-83.82" y1="878.84" x2="-83.82" y2="876.3" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="876.3" x2="-73.66" y2="876.3" width="0.1524" layer="91"/>
 <label x="-73.66" y="876.3" size="1.778" layer="95"/>
-<pinref part="U$85" gate="G$1" pin="K"/>
+<pinref part="U16O" gate="G$1" pin="K"/>
 <junction x="-83.82" y="878.84"/>
 </segment>
 <segment>
@@ -32242,7 +32350,7 @@ Thomas Hudson</text>
 <wire x1="-83.82" y1="942.34" x2="-83.82" y2="939.8" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="939.8" x2="-76.2" y2="939.8" width="0.1524" layer="91"/>
 <label x="-76.2" y="939.8" size="1.778" layer="95"/>
-<pinref part="U$83" gate="G$1" pin="K"/>
+<pinref part="U17O" gate="G$1" pin="K"/>
 </segment>
 <segment>
 <pinref part="U$34" gate="G$1" pin="9"/>
@@ -32255,7 +32363,7 @@ Thomas Hudson</text>
 <wire x1="-83.82" y1="975.36" x2="-83.82" y2="972.82" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="972.82" x2="-73.66" y2="972.82" width="0.1524" layer="91"/>
 <label x="-73.66" y="972.82" size="1.778" layer="95"/>
-<pinref part="U$81" gate="G$1" pin="K"/>
+<pinref part="U18O" gate="G$1" pin="K"/>
 </segment>
 <segment>
 <pinref part="U$34" gate="G$1" pin="8"/>
@@ -32268,7 +32376,7 @@ Thomas Hudson</text>
 <wire x1="-83.82" y1="1010.92" x2="-83.82" y2="1008.38" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="1008.38" x2="-73.66" y2="1008.38" width="0.1524" layer="91"/>
 <label x="-73.66" y="1008.38" size="1.778" layer="95"/>
-<pinref part="U$79" gate="G$1" pin="K"/>
+<pinref part="U19O" gate="G$1" pin="K"/>
 </segment>
 <segment>
 <pinref part="U$34" gate="G$1" pin="7"/>
@@ -32281,7 +32389,7 @@ Thomas Hudson</text>
 <wire x1="-83.82" y1="1046.48" x2="-83.82" y2="1043.94" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="1043.94" x2="-73.66" y2="1043.94" width="0.1524" layer="91"/>
 <label x="-73.66" y="1043.94" size="1.778" layer="95"/>
-<pinref part="U$77" gate="G$1" pin="K"/>
+<pinref part="U20O" gate="G$1" pin="K"/>
 </segment>
 <segment>
 <pinref part="U$34" gate="G$1" pin="6"/>
@@ -32294,7 +32402,7 @@ Thomas Hudson</text>
 <wire x1="-83.82" y1="1094.74" x2="-83.82" y2="1092.2" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="1092.2" x2="-76.2" y2="1092.2" width="0.1524" layer="91"/>
 <label x="-76.2" y="1092.2" size="1.778" layer="95"/>
-<pinref part="U$75" gate="G$1" pin="K"/>
+<pinref part="U21O" gate="G$1" pin="K"/>
 <junction x="-83.82" y="1094.74"/>
 </segment>
 <segment>
@@ -32308,7 +32416,7 @@ Thomas Hudson</text>
 <wire x1="-83.82" y1="1130.3" x2="-83.82" y2="1127.76" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="1127.76" x2="-76.2" y2="1127.76" width="0.1524" layer="91"/>
 <label x="-76.2" y="1127.76" size="1.778" layer="95"/>
-<pinref part="U$73" gate="G$1" pin="K"/>
+<pinref part="U22O" gate="G$1" pin="K"/>
 <junction x="-83.82" y="1130.3"/>
 </segment>
 <segment>
@@ -32322,7 +32430,7 @@ Thomas Hudson</text>
 <wire x1="-83.82" y1="1163.32" x2="-83.82" y2="1160.78" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="1160.78" x2="-76.2" y2="1160.78" width="0.1524" layer="91"/>
 <label x="-76.2" y="1160.78" size="1.778" layer="95"/>
-<pinref part="U$71" gate="G$1" pin="K"/>
+<pinref part="U23O" gate="G$1" pin="K"/>
 <junction x="-83.82" y="1163.32"/>
 </segment>
 <segment>
@@ -32336,7 +32444,7 @@ Thomas Hudson</text>
 <wire x1="-83.82" y1="1196.34" x2="-83.82" y2="1193.8" width="0.1524" layer="91"/>
 <wire x1="-83.82" y1="1193.8" x2="-76.2" y2="1193.8" width="0.1524" layer="91"/>
 <label x="-76.2" y="1193.8" size="1.778" layer="95"/>
-<pinref part="U$69" gate="G$1" pin="K"/>
+<pinref part="U24O" gate="G$1" pin="K"/>
 <junction x="-83.82" y="1196.34"/>
 </segment>
 <segment>
@@ -32345,50 +32453,29 @@ Thomas Hudson</text>
 <label x="-398.78" y="1038.86" size="1.778" layer="95"/>
 </segment>
 </net>
-<net name="N$12" class="0">
+<net name="SNS20I" class="0">
 <segment>
-<wire x1="-91.44" y1="1046.48" x2="-91.44" y2="1041.4" width="0.1524" layer="91"/>
-<wire x1="-91.44" y1="1041.4" x2="-45.72" y2="1041.4" width="0.1524" layer="91"/>
-<wire x1="-45.72" y1="1041.4" x2="-45.72" y2="944.88" width="0.1524" layer="91"/>
-<wire x1="-91.44" y1="1041.4" x2="-172.72" y2="1041.4" width="0.1524" layer="91"/>
-<junction x="-91.44" y="1041.4"/>
-<wire x1="-45.72" y1="944.88" x2="-30.48" y2="944.88" width="0.1524" layer="91"/>
-<pinref part="U$77" gate="G$1" pin="E"/>
+<wire x1="-45.72" y1="1041.4" x2="-45.72" y2="916.94" width="0.1524" layer="91"/>
+<wire x1="-45.72" y1="1041.4" x2="-172.72" y2="1041.4" width="0.1524" layer="91"/>
 <pinref part="R5" gate="G$1" pin="9"/>
-<pinref part="U2" gate="U1" pin="H"/>
+<label x="-142.24" y="1041.4" size="1.778" layer="95"/>
+<pinref part="U2" gate="U1" pin="A"/>
+<wire x1="-45.72" y1="916.94" x2="-30.48" y2="916.94" width="0.1524" layer="91"/>
 </segment>
 </net>
-<net name="N$74" class="0">
+<net name="SNS24I" class="0">
 <segment>
-<wire x1="-86.36" y1="436.88" x2="-86.36" y2="449.58" width="0.1524" layer="91"/>
-<wire x1="-160.02" y1="436.88" x2="-86.36" y2="436.88" width="0.1524" layer="91"/>
-<junction x="-86.36" y="436.88"/>
-<wire x1="-160.02" y1="436.88" x2="-160.02" y2="533.4" width="0.1524" layer="91"/>
-<wire x1="-160.02" y1="533.4" x2="-170.18" y2="533.4" width="0.1524" layer="91"/>
-<wire x1="-25.4" y1="436.88" x2="-86.36" y2="436.88" width="0.1524" layer="91"/>
-<pinref part="U$107" gate="G$1" pin="E"/>
-<junction x="-86.36" y="449.58"/>
-<pinref part="R11" gate="G$1" pin="3"/>
-<pinref part="U5" gate="U1" pin="B"/>
+<wire x1="-48.26" y1="1191.26" x2="-48.26" y2="1071.88" width="0.1524" layer="91"/>
+<wire x1="-48.26" y1="1191.26" x2="-147.32" y2="1191.26" width="0.1524" layer="91"/>
+<pinref part="R2" gate="G$1" pin="9"/>
+<wire x1="-170.18" y1="1183.64" x2="-147.32" y2="1183.64" width="0.1524" layer="91"/>
+<wire x1="-147.32" y1="1183.64" x2="-147.32" y2="1191.26" width="0.1524" layer="91"/>
+<label x="-137.16" y="1191.26" size="1.778" layer="95"/>
+<pinref part="U1" gate="U1" pin="A"/>
+<wire x1="-48.26" y1="1071.88" x2="-30.48" y2="1071.88" width="0.1524" layer="91"/>
 </segment>
 </net>
-<net name="N$39" class="0">
-<segment>
-<wire x1="-91.44" y1="1196.34" x2="-91.44" y2="1191.26" width="0.1524" layer="91"/>
-<wire x1="-91.44" y1="1191.26" x2="-48.26" y2="1191.26" width="0.1524" layer="91"/>
-<wire x1="-48.26" y1="1191.26" x2="-48.26" y2="1099.82" width="0.1524" layer="91"/>
-<wire x1="-91.44" y1="1191.26" x2="-142.24" y2="1191.26" width="0.1524" layer="91"/>
-<junction x="-91.44" y="1191.26"/>
-<wire x1="-48.26" y1="1099.82" x2="-30.48" y2="1099.82" width="0.1524" layer="91"/>
-<wire x1="-142.24" y1="1170.94" x2="-142.24" y2="1191.26" width="0.1524" layer="91"/>
-<wire x1="-170.18" y1="1170.94" x2="-142.24" y2="1170.94" width="0.1524" layer="91"/>
-<pinref part="U$69" gate="G$1" pin="E"/>
-<junction x="-91.44" y="1196.34"/>
-<pinref part="R2" gate="G$1" pin="4"/>
-<pinref part="U1" gate="U1" pin="H"/>
-</segment>
-</net>
-<net name="N$21" class="0">
+<net name="PWR_13-24" class="0">
 <segment>
 <pinref part="U$34" gate="G$1" pin="1"/>
 <wire x1="-340.36" y1="1038.86" x2="-325.12" y2="1038.86" width="0.1524" layer="91"/>
@@ -32422,68 +32509,68 @@ Thomas Hudson</text>
 <net name="SER1" class="0">
 <segment>
 <pinref part="U6" gate="U1" pin="SER"/>
-<wire x1="-5.08" y1="269.24" x2="2.54" y2="269.24" width="0.1524" layer="91"/>
-<wire x1="2.54" y1="269.24" x2="2.54" y2="447.04" width="0.1524" layer="91"/>
+<wire x1="-5.08" y1="269.24" x2="5.08" y2="269.24" width="0.1524" layer="91"/>
+<wire x1="5.08" y1="269.24" x2="5.08" y2="436.88" width="0.1524" layer="91"/>
 <pinref part="U5" gate="U1" pin="QH"/>
-<wire x1="2.54" y1="447.04" x2="-5.08" y2="447.04" width="0.1524" layer="91"/>
+<wire x1="5.08" y1="436.88" x2="-5.08" y2="436.88" width="0.1524" layer="91"/>
 <label x="5.08" y="274.32" size="1.778" layer="95"/>
 </segment>
 </net>
 <net name="SER2" class="0">
 <segment>
 <pinref part="U5" gate="U1" pin="SER"/>
-<wire x1="-5.08" y1="444.5" x2="0" y2="444.5" width="0.1524" layer="91"/>
-<wire x1="0" y1="444.5" x2="0" y2="601.98" width="0.1524" layer="91"/>
+<wire x1="-5.08" y1="434.34" x2="0" y2="434.34" width="0.1524" layer="91"/>
+<wire x1="0" y1="434.34" x2="0" y2="591.82" width="0.1524" layer="91"/>
 <pinref part="U4" gate="U1" pin="QH"/>
-<wire x1="-7.62" y1="601.98" x2="0" y2="601.98" width="0.1524" layer="91"/>
+<wire x1="-7.62" y1="591.82" x2="0" y2="591.82" width="0.1524" layer="91"/>
 <label x="2.54" y="449.58" size="1.778" layer="95"/>
 </segment>
 </net>
 <net name="SER3" class="0">
 <segment>
 <pinref part="U3" gate="U1" pin="SER"/>
-<wire x1="-7.62" y1="762" x2="2.54" y2="762" width="0.1524" layer="91"/>
-<wire x1="2.54" y1="762" x2="2.54" y2="939.8" width="0.1524" layer="91"/>
+<wire x1="-7.62" y1="764.54" x2="2.54" y2="764.54" width="0.1524" layer="91"/>
+<wire x1="2.54" y1="764.54" x2="2.54" y2="929.64" width="0.1524" layer="91"/>
 <pinref part="U2" gate="U1" pin="QH"/>
-<wire x1="2.54" y1="939.8" x2="-10.16" y2="939.8" width="0.1524" layer="91"/>
-<label x="5.08" y="767.08" size="1.778" layer="95"/>
+<wire x1="2.54" y1="929.64" x2="-10.16" y2="929.64" width="0.1524" layer="91"/>
+<label x="5.08" y="769.62" size="1.778" layer="95"/>
 </segment>
 </net>
 <net name="SER4" class="0">
 <segment>
 <pinref part="U2" gate="U1" pin="SER"/>
-<wire x1="-10.16" y1="937.26" x2="0" y2="937.26" width="0.1524" layer="91"/>
-<wire x1="0" y1="937.26" x2="0" y2="1094.74" width="0.1524" layer="91"/>
+<wire x1="-10.16" y1="927.1" x2="0" y2="927.1" width="0.1524" layer="91"/>
+<wire x1="0" y1="927.1" x2="0" y2="1084.58" width="0.1524" layer="91"/>
 <pinref part="U1" gate="U1" pin="QH"/>
-<wire x1="0" y1="1094.74" x2="-10.16" y2="1094.74" width="0.1524" layer="91"/>
-<label x="2.54" y="944.88" size="1.778" layer="95"/>
+<wire x1="0" y1="1084.58" x2="-10.16" y2="1084.58" width="0.1524" layer="91"/>
+<label x="2.54" y="934.72" size="1.778" layer="95"/>
 </segment>
 </net>
 <net name="SCK" class="0">
 <segment>
 <pinref part="U1" gate="U1" pin="CLK"/>
-<wire x1="-10.16" y1="1087.12" x2="5.08" y2="1087.12" width="0.1524" layer="91"/>
-<label x="5.08" y="1087.12" size="1.778" layer="95"/>
+<wire x1="-10.16" y1="1076.96" x2="5.08" y2="1076.96" width="0.1524" layer="91"/>
+<label x="5.08" y="1076.96" size="1.778" layer="95"/>
 </segment>
 <segment>
 <pinref part="U2" gate="U1" pin="CLK"/>
-<wire x1="-10.16" y1="932.18" x2="5.08" y2="932.18" width="0.1524" layer="91"/>
-<label x="5.08" y="932.18" size="1.778" layer="95"/>
+<wire x1="-10.16" y1="922.02" x2="5.08" y2="922.02" width="0.1524" layer="91"/>
+<label x="5.08" y="922.02" size="1.778" layer="95"/>
 </segment>
 <segment>
 <pinref part="U3" gate="U1" pin="CLK"/>
-<wire x1="-7.62" y1="756.92" x2="2.54" y2="756.92" width="0.1524" layer="91"/>
-<label x="2.54" y="756.92" size="1.778" layer="95"/>
+<wire x1="-7.62" y1="759.46" x2="2.54" y2="759.46" width="0.1524" layer="91"/>
+<label x="2.54" y="759.46" size="1.778" layer="95"/>
 </segment>
 <segment>
 <pinref part="U4" gate="U1" pin="CLK"/>
-<wire x1="-7.62" y1="594.36" x2="2.54" y2="594.36" width="0.1524" layer="91"/>
-<label x="2.54" y="594.36" size="1.778" layer="95"/>
+<wire x1="-7.62" y1="584.2" x2="2.54" y2="584.2" width="0.1524" layer="91"/>
+<label x="2.54" y="584.2" size="1.778" layer="95"/>
 </segment>
 <segment>
 <pinref part="U5" gate="U1" pin="CLK"/>
-<wire x1="-5.08" y1="439.42" x2="5.08" y2="439.42" width="0.1524" layer="91"/>
-<label x="5.08" y="439.42" size="1.778" layer="95"/>
+<wire x1="-5.08" y1="429.26" x2="7.62" y2="429.26" width="0.1524" layer="91"/>
+<label x="7.62" y="429.26" size="1.778" layer="95"/>
 </segment>
 <segment>
 <pinref part="U6" gate="U1" pin="CLK"/>
@@ -32504,28 +32591,28 @@ Thomas Hudson</text>
 <net name="LOAD" class="0">
 <segment>
 <pinref part="U1" gate="U1" pin="SH/!LD"/>
-<wire x1="-10.16" y1="1084.58" x2="5.08" y2="1084.58" width="0.1524" layer="91"/>
-<label x="5.08" y="1084.58" size="1.778" layer="95"/>
+<wire x1="-10.16" y1="1074.42" x2="5.08" y2="1074.42" width="0.1524" layer="91"/>
+<label x="5.08" y="1074.42" size="1.778" layer="95"/>
 </segment>
 <segment>
 <pinref part="U2" gate="U1" pin="SH/!LD"/>
-<wire x1="-10.16" y1="929.64" x2="5.08" y2="929.64" width="0.1524" layer="91"/>
-<label x="5.08" y="929.64" size="1.778" layer="95"/>
+<wire x1="-10.16" y1="919.48" x2="5.08" y2="919.48" width="0.1524" layer="91"/>
+<label x="5.08" y="919.48" size="1.778" layer="95"/>
 </segment>
 <segment>
 <pinref part="U3" gate="U1" pin="SH/!LD"/>
-<wire x1="-7.62" y1="754.38" x2="2.54" y2="754.38" width="0.1524" layer="91"/>
-<label x="2.54" y="754.38" size="1.778" layer="95"/>
+<wire x1="-7.62" y1="756.92" x2="2.54" y2="756.92" width="0.1524" layer="91"/>
+<label x="2.54" y="756.92" size="1.778" layer="95"/>
 </segment>
 <segment>
 <pinref part="U4" gate="U1" pin="SH/!LD"/>
-<wire x1="-7.62" y1="591.82" x2="2.54" y2="591.82" width="0.1524" layer="91"/>
-<label x="2.54" y="591.82" size="1.778" layer="95"/>
+<wire x1="-7.62" y1="581.66" x2="2.54" y2="581.66" width="0.1524" layer="91"/>
+<label x="2.54" y="581.66" size="1.778" layer="95"/>
 </segment>
 <segment>
 <pinref part="U5" gate="U1" pin="SH/!LD"/>
-<wire x1="-5.08" y1="436.88" x2="5.08" y2="436.88" width="0.1524" layer="91"/>
-<label x="5.08" y="436.88" size="1.778" layer="95"/>
+<wire x1="-5.08" y1="426.72" x2="7.62" y2="426.72" width="0.1524" layer="91"/>
+<label x="7.62" y="426.72" size="1.778" layer="95"/>
 </segment>
 <segment>
 <pinref part="U6" gate="U1" pin="SH/!LD"/>
@@ -32543,7 +32630,7 @@ Thomas Hudson</text>
 <pinref part="U$45" gate="G$1" pin="A5"/>
 </segment>
 </net>
-<net name="N$63" class="0">
+<net name="PWR_1-12" class="0">
 <segment>
 <pinref part="U$36" gate="G$1" pin="1"/>
 <wire x1="-340.36" y1="929.64" x2="-325.12" y2="929.64" width="0.1524" layer="91"/>
@@ -32580,12 +32667,29 @@ Thomas Hudson</text>
 <pinref part="U$40" gate="G$1" pin="1"/>
 <pinref part="SUPPLY59" gate="G$1" pin="5V"/>
 </segment>
+<segment>
+<pinref part="SUPPLY58" gate="G$1" pin="5V"/>
+<pinref part="SERVO5" gate="A" pin="2"/>
+<wire x1="-386.08" y1="833.12" x2="-373.38" y2="833.12" width="0.1524" layer="91"/>
+<pinref part="SERVO4" gate="A" pin="2"/>
+<wire x1="-373.38" y1="833.12" x2="-360.68" y2="833.12" width="0.1524" layer="91"/>
+<junction x="-373.38" y="833.12"/>
+<pinref part="SERVO3" gate="A" pin="2"/>
+<wire x1="-360.68" y1="833.12" x2="-347.98" y2="833.12" width="0.1524" layer="91"/>
+<junction x="-360.68" y="833.12"/>
+<pinref part="SERVO2" gate="A" pin="2"/>
+<wire x1="-347.98" y1="833.12" x2="-335.28" y2="833.12" width="0.1524" layer="91"/>
+<junction x="-347.98" y="833.12"/>
+<pinref part="SERVO1" gate="A" pin="2"/>
+<wire x1="-335.28" y1="833.12" x2="-322.58" y2="833.12" width="0.1524" layer="91"/>
+<junction x="-335.28" y="833.12"/>
+</segment>
 </net>
 <net name="P1" class="0">
 <segment>
-<label x="-271.78" y="993.14" size="1.778" layer="95"/>
-<wire x1="-269.24" y1="993.14" x2="-261.62" y2="993.14" width="0.1524" layer="91"/>
-<wire x1="-261.62" y1="993.14" x2="-261.62" y2="998.22" width="0.1524" layer="91"/>
+<label x="-271.78" y="995.68" size="1.778" layer="95"/>
+<wire x1="-269.24" y1="995.68" x2="-261.62" y2="995.68" width="0.1524" layer="91"/>
+<wire x1="-261.62" y1="995.68" x2="-261.62" y2="998.22" width="0.1524" layer="91"/>
 <pinref part="MS2" gate="G$1" pin="GPIO9"/>
 <wire x1="-261.62" y1="998.22" x2="-254" y2="998.22" width="0.1524" layer="91"/>
 </segment>
@@ -32664,21 +32768,21 @@ Thomas Hudson</text>
 <net name="N$28" class="0">
 <segment>
 <pinref part="U4" gate="U1" pin="SER"/>
-<wire x1="-7.62" y1="599.44" x2="2.54" y2="599.44" width="0.1524" layer="91"/>
-<wire x1="2.54" y1="599.44" x2="2.54" y2="739.14" width="0.1524" layer="91"/>
-<wire x1="2.54" y1="739.14" x2="20.32" y2="739.14" width="0.1524" layer="91"/>
-<wire x1="20.32" y1="739.14" x2="20.32" y2="764.54" width="0.1524" layer="91"/>
+<wire x1="-7.62" y1="589.28" x2="2.54" y2="589.28" width="0.1524" layer="91"/>
+<wire x1="2.54" y1="589.28" x2="2.54" y2="741.68" width="0.1524" layer="91"/>
+<wire x1="2.54" y1="741.68" x2="20.32" y2="741.68" width="0.1524" layer="91"/>
+<wire x1="20.32" y1="741.68" x2="20.32" y2="767.08" width="0.1524" layer="91"/>
 <pinref part="U3" gate="U1" pin="QH"/>
-<wire x1="20.32" y1="764.54" x2="-7.62" y2="764.54" width="0.1524" layer="91"/>
+<wire x1="20.32" y1="767.08" x2="-7.62" y2="767.08" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="P2" class="0">
 <segment>
-<label x="-271.78" y="990.6" size="1.778" layer="95"/>
+<label x="-271.78" y="993.14" size="1.778" layer="95"/>
 <pinref part="MS2" gate="G$1" pin="GPIO10"/>
 <wire x1="-254" y1="995.68" x2="-259.08" y2="995.68" width="0.1524" layer="91"/>
-<wire x1="-259.08" y1="995.68" x2="-259.08" y2="990.6" width="0.1524" layer="91"/>
-<wire x1="-259.08" y1="990.6" x2="-269.24" y2="990.6" width="0.1524" layer="91"/>
+<wire x1="-259.08" y1="995.68" x2="-259.08" y2="993.14" width="0.1524" layer="91"/>
+<wire x1="-259.08" y1="993.14" x2="-269.24" y2="993.14" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <wire x1="-213.36" y1="1054.1" x2="-208.28" y2="1054.1" width="0.1524" layer="91"/>
@@ -32694,6 +32798,195 @@ Thomas Hudson</text>
 <pinref part="R13" gate="G$1" pin="2"/>
 <wire x1="-299.72" y1="1023.62" x2="-299.72" y2="1026.16" width="0.1524" layer="91"/>
 <label x="-307.34" y="1013.46" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="SRVO3" class="0">
+<segment>
+<pinref part="U$45" gate="G$1" pin="A3"/>
+<wire x1="-246.38" y1="1049.02" x2="-254" y2="1049.02" width="0.1524" layer="91"/>
+<label x="-254" y="1049.02" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="SERVO3" gate="A" pin="3"/>
+<wire x1="-347.98" y1="830.58" x2="-347.98" y2="807.72" width="0.1524" layer="91"/>
+<label x="-347.98" y="812.8" size="1.778" layer="95" rot="R90"/>
+</segment>
+<segment>
+<pinref part="MS2" gate="G$1" pin="GPIOA2"/>
+<wire x1="-210.82" y1="985.52" x2="-185.42" y2="985.52" width="0.1524" layer="91"/>
+<label x="-200.66" y="985.52" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="SRVO2" class="0">
+<segment>
+<pinref part="U$45" gate="G$1" pin="A2"/>
+<wire x1="-246.38" y1="1051.56" x2="-254" y2="1051.56" width="0.1524" layer="91"/>
+<label x="-254" y="1051.56" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="MS2" gate="G$1" pin="GPIOA1"/>
+<wire x1="-210.82" y1="982.98" x2="-185.42" y2="982.98" width="0.1524" layer="91"/>
+<label x="-200.66" y="982.98" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="SERVO2" gate="A" pin="3"/>
+<wire x1="-335.28" y1="830.58" x2="-335.28" y2="807.72" width="0.1524" layer="91"/>
+<label x="-335.28" y="812.8" size="1.778" layer="95" rot="R90"/>
+</segment>
+</net>
+<net name="SRVO4" class="0">
+<segment>
+<pinref part="U$45" gate="G$1" pin="D13"/>
+<wire x1="-213.36" y1="1059.18" x2="-203.2" y2="1059.18" width="0.1524" layer="91"/>
+<label x="-213.36" y="1059.18" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="MS2" gate="G$1" pin="GPIO13"/>
+<wire x1="-254" y1="988.06" x2="-269.24" y2="988.06" width="0.1524" layer="91"/>
+<label x="-271.78" y="988.06" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="SERVO4" gate="A" pin="3"/>
+<wire x1="-360.68" y1="830.58" x2="-360.68" y2="807.72" width="0.1524" layer="91"/>
+<label x="-360.68" y="812.8" size="1.778" layer="95" rot="R90"/>
+</segment>
+</net>
+<net name="SRVO5" class="0">
+<segment>
+<pinref part="U$45" gate="G$1" pin="D9"/>
+<wire x1="-203.2" y1="1049.02" x2="-213.36" y2="1049.02" width="0.1524" layer="91"/>
+<label x="-213.36" y="1049.02" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="MS2" gate="G$1" pin="GPIO12"/>
+<wire x1="-254" y1="990.6" x2="-269.24" y2="990.6" width="0.1524" layer="91"/>
+<label x="-271.78" y="990.6" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="SERVO5" gate="A" pin="3"/>
+<wire x1="-373.38" y1="830.58" x2="-373.38" y2="807.72" width="0.1524" layer="91"/>
+<label x="-373.38" y="812.8" size="1.778" layer="95" rot="R90"/>
+</segment>
+</net>
+<net name="SRVO1" class="0">
+<segment>
+<pinref part="U$45" gate="G$1" pin="A1"/>
+<wire x1="-246.38" y1="1054.1" x2="-254" y2="1054.1" width="0.1524" layer="91"/>
+<label x="-254" y="1054.1" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="MS2" gate="G$1" pin="GPIOA0"/>
+<wire x1="-210.82" y1="980.44" x2="-185.42" y2="980.44" width="0.1524" layer="91"/>
+<label x="-200.66" y="980.44" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="SERVO1" gate="A" pin="3"/>
+<wire x1="-322.58" y1="830.58" x2="-322.58" y2="807.72" width="0.1524" layer="91"/>
+<label x="-322.58" y="812.8" size="1.778" layer="95" rot="R90"/>
+</segment>
+</net>
+<net name="SNS02O" class="0">
+<segment>
+<wire x1="-160.02" y1="368.3" x2="-172.72" y2="368.3" width="0.1524" layer="91"/>
+<pinref part="R12" gate="G$1" pin="4"/>
+<wire x1="-88.9" y1="314.96" x2="-88.9" y2="307.34" width="0.1524" layer="91"/>
+<wire x1="-88.9" y1="307.34" x2="-58.42" y2="307.34" width="0.1524" layer="91"/>
+<wire x1="-58.42" y1="307.34" x2="-58.42" y2="274.32" width="0.1524" layer="91"/>
+<wire x1="-88.9" y1="307.34" x2="-160.02" y2="307.34" width="0.1524" layer="91"/>
+<junction x="-88.9" y="307.34"/>
+<pinref part="U02O" gate="G$1" pin="E"/>
+<junction x="-88.9" y="314.96"/>
+<wire x1="-160.02" y1="368.3" x2="-160.02" y2="307.34" width="0.1524" layer="91"/>
+<pinref part="U6" gate="U1" pin="G"/>
+<wire x1="-25.4" y1="274.32" x2="-58.42" y2="274.32" width="0.1524" layer="91"/>
+<label x="-124.46" y="307.34" size="1.778" layer="95"/>
+<label x="-38.1" y="274.32" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="SNS07O" class="0">
+<segment>
+<pinref part="R11" gate="G$1" pin="6"/>
+<wire x1="-152.4" y1="541.02" x2="-170.18" y2="541.02" width="0.1524" layer="91"/>
+<wire x1="-152.4" y1="510.54" x2="-152.4" y2="541.02" width="0.1524" layer="91"/>
+<wire x1="-86.36" y1="518.16" x2="-86.36" y2="510.54" width="0.1524" layer="91"/>
+<pinref part="U07O" gate="G$1" pin="E"/>
+<junction x="-86.36" y="518.16"/>
+<wire x1="-152.4" y1="510.54" x2="-86.36" y2="510.54" width="0.1524" layer="91"/>
+<label x="-124.46" y="510.54" size="1.778" layer="95"/>
+<wire x1="-50.8" y1="510.54" x2="-50.8" y2="431.8" width="0.1524" layer="91"/>
+<wire x1="-86.36" y1="510.54" x2="-50.8" y2="510.54" width="0.1524" layer="91"/>
+<junction x="-86.36" y="510.54"/>
+<pinref part="U5" gate="U1" pin="D"/>
+<wire x1="-25.4" y1="431.8" x2="-50.8" y2="431.8" width="0.1524" layer="91"/>
+<label x="-38.1" y="431.8" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="SNS06O" class="0">
+<segment>
+<pinref part="U06O" gate="G$1" pin="E"/>
+<junction x="-86.36" y="482.6"/>
+<wire x1="-86.36" y1="482.6" x2="-86.36" y2="474.98" width="0.1524" layer="91"/>
+<wire x1="-86.36" y1="474.98" x2="-55.88" y2="474.98" width="0.1524" layer="91"/>
+<wire x1="-55.88" y1="474.98" x2="-55.88" y2="439.42" width="0.1524" layer="91"/>
+<label x="-124.46" y="474.98" size="1.778" layer="95"/>
+<pinref part="R11" gate="G$1" pin="4"/>
+<wire x1="-157.48" y1="535.94" x2="-170.18" y2="535.94" width="0.1524" layer="91"/>
+<wire x1="-157.48" y1="474.98" x2="-157.48" y2="535.94" width="0.1524" layer="91"/>
+<wire x1="-86.36" y1="474.98" x2="-157.48" y2="474.98" width="0.1524" layer="91"/>
+<junction x="-86.36" y="474.98"/>
+<pinref part="U5" gate="U1" pin="G"/>
+<wire x1="-25.4" y1="439.42" x2="-55.88" y2="439.42" width="0.1524" layer="91"/>
+<label x="-38.1" y="439.42" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="SNS05I" class="0">
+<segment>
+<pinref part="U05I" gate="G$1" pin="E"/>
+<junction x="-104.14" y="449.58"/>
+<wire x1="-104.14" y1="436.88" x2="-104.14" y2="449.58" width="0.1524" layer="91"/>
+<wire x1="-160.02" y1="436.88" x2="-160.02" y2="533.4" width="0.1524" layer="91"/>
+<wire x1="-160.02" y1="533.4" x2="-170.18" y2="533.4" width="0.1524" layer="91"/>
+<pinref part="R11" gate="G$1" pin="3"/>
+<wire x1="-104.14" y1="436.88" x2="-160.02" y2="436.88" width="0.1524" layer="91"/>
+<label x="-124.46" y="436.88" size="1.778" layer="95"/>
+<pinref part="U5" gate="U1" pin="F"/>
+<wire x1="-25.4" y1="436.88" x2="-104.14" y2="436.88" width="0.1524" layer="91"/>
+<junction x="-104.14" y="436.88"/>
+<label x="-38.1" y="436.88" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="SNS05O" class="0">
+<segment>
+<pinref part="U05O" gate="G$1" pin="E"/>
+<junction x="-86.36" y="449.58"/>
+<wire x1="-86.36" y1="434.34" x2="-86.36" y2="449.58" width="0.1524" layer="91"/>
+<wire x1="-162.56" y1="434.34" x2="-162.56" y2="530.86" width="0.1524" layer="91"/>
+<wire x1="-162.56" y1="530.86" x2="-170.18" y2="530.86" width="0.1524" layer="91"/>
+<pinref part="R11" gate="G$1" pin="2"/>
+<wire x1="-86.36" y1="434.34" x2="-162.56" y2="434.34" width="0.1524" layer="91"/>
+<label x="-124.46" y="434.34" size="1.778" layer="95"/>
+<pinref part="U5" gate="U1" pin="E"/>
+<wire x1="-86.36" y1="434.34" x2="-25.4" y2="434.34" width="0.1524" layer="91"/>
+<junction x="-86.36" y="434.34"/>
+<label x="-38.1" y="434.34" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="SNS07I" class="0">
+<segment>
+<pinref part="U07I" gate="G$1" pin="E"/>
+<junction x="-104.14" y="518.16"/>
+<wire x1="-104.14" y1="518.16" x2="-104.14" y2="513.08" width="0.1524" layer="91"/>
+<pinref part="R11" gate="G$1" pin="7"/>
+<wire x1="-170.18" y1="543.56" x2="-149.86" y2="543.56" width="0.1524" layer="91"/>
+<wire x1="-149.86" y1="543.56" x2="-149.86" y2="513.08" width="0.1524" layer="91"/>
+<wire x1="-149.86" y1="513.08" x2="-104.14" y2="513.08" width="0.1524" layer="91"/>
+<label x="-124.46" y="513.08" size="1.778" layer="95"/>
+<wire x1="-48.26" y1="513.08" x2="-48.26" y2="429.26" width="0.1524" layer="91"/>
+<wire x1="-104.14" y1="513.08" x2="-48.26" y2="513.08" width="0.1524" layer="91"/>
+<junction x="-104.14" y="513.08"/>
+<pinref part="U5" gate="U1" pin="C"/>
+<wire x1="-25.4" y1="429.26" x2="-48.26" y2="429.26" width="0.1524" layer="91"/>
+<label x="-38.1" y="429.26" size="1.778" layer="95"/>
 </segment>
 </net>
 </nets>
@@ -32773,13 +33066,18 @@ Thomas Hudson</text>
 <approved hash="104,1,-7.62,749.3,U3,VCC,3.3V,,,"/>
 <approved hash="202,1,-7.62,604.52,U4,!QH,,,,"/>
 <approved hash="104,1,-7.62,586.74,U4,VCC,3.3V,,,"/>
-<approved hash="202,1,-5.08,449.58,U5,!QH,,,,"/>
-<approved hash="104,1,-5.08,431.8,U5,VCC,3.3V,,,"/>
+<approved hash="202,1,-5.08,439.42,U5,!QH,,,,"/>
+<approved hash="104,1,-5.08,421.64,U5,VCC,3.3V,,,"/>
 <approved hash="202,1,-5.08,274.32,U6,!QH,,,,"/>
 <approved hash="104,1,-5.08,256.54,U6,VCC,3.3V,,,"/>
 <approved hash="202,1,-210.82,970.28,MS2,!RESET,,,,"/>
 <approved hash="117,1,-210.82,972.82,3V,,,,,"/>
 <approved hash="117,1,-254,980.44,VBAT,,,,,"/>
+<approved hash="113,1,-372.053,834.586,SERVO5,,,,,"/>
+<approved hash="113,1,-359.353,834.586,SERVO4,,,,,"/>
+<approved hash="113,1,-346.653,834.586,SERVO3,,,,,"/>
+<approved hash="113,1,-333.953,834.586,SERVO2,,,,,"/>
+<approved hash="113,1,-321.253,834.586,SERVO1,,,,,"/>
 </errors>
 </schematic>
 </drawing>

--- a/arduino/bee_counting/bee_counting.ino
+++ b/arduino/bee_counting/bee_counting.ino
@@ -1,9 +1,14 @@
 /*
  *  
+ * Gate Map (Sensor Numbers)
  *   gate     0   ||  1  ||  2  ||  3  ||  4   ||   5  ||  6   ||  7   ||  8   ||  9   ||  10  ||  11  ||  12  ||  13  ||  14  ||  15  ||  16  ||  17  ||  18  ||  19  ||  20  ||  21  ||  22  ||  23
  *   inside   1   ||  3  ||  5  ||  7  ||  9   ||  11  ||  13  ||  15  ||  17  ||  19  ||  21  ||  23  ||  25  ||  27  ||  29  ||  31  ||  33  ||  35  ||  37  ||  39  ||  41  ||  43  ||  45  ||  47
  *   outside  2   ||  4  ||  6  ||  8  ||  10  ||  12  ||  14  ||  16  ||  18  ||  20  ||  22  ||  24  ||  26  ||  28  ||  30  ||  32  ||  34  ||  36  ||  38  ||  40  ||  42  ||  44  ||  46  ||  48
  * 
+ * Gate Map (bit numbers)
+ *   gate    ||  00  ||  01  ||  02  ||  03  ||  04  ||  05  ||  06  ||  07  ||  08  ||  09  ||  10  ||  11  ||  12  ||  13  ||  14  ||  15  ||  16  ||  17  ||  18  ||  19  ||  20  ||  21  ||  22  ||  23  ||
+ *   inside  ||   5  ||   7  ||   2  ||   0  ||  13  ||  15  ||  10  ||   8  ||  21  ||  23  ||  18  ||  16  ||  29  ||  31  ||  26  ||  24  ||  37  ||  39  ||  34  ||  32  ||  45  ||  47  ||  42  ||  40  ||
+ *   outside ||   4  ||   6  ||   3  ||   1  ||  12  ||  14  ||  11  ||   9  ||  20  ||  22  ||  19  ||  17  ||  28  ||  30  ||  27  ||  25  ||  36  ||  38  ||  35  ||  33  ||  44  ||  46  ||  43  ||  41  ||
  *  
  *  HOW long can we drive the LEDs ON without current limiting resistors?
  *  LED timed pulse (tp) allowance vs period (T)
@@ -13,7 +18,6 @@
  *  So the minimum OFF time between ON times is 7.5ms
  *  This is very conservative as the forward voltage of 3.3v/2 = 1.65v, and max current from the cutsheet is estimated ~170ma 
  *  this is well below the absolute max of 1 amp with which the tp/T ratio was developed for
- *  
  *  
  *  Rough Power Draw with cheap USB current sensor
  *  feather ESP32 by itself with tp/T  15us/2ms => 50ma
@@ -25,39 +29,50 @@
  *  tp/T  15us/8ms  50-60ma had to add 3000uf cap to smooth out drawl
  *  tp/T  15us/10ms  50ma had to add 3000uf cap to smooth out drawl 
  *  
- *  
- *  
- *  
  *  This sketch:
  *  It takes a honey bee around 250ms to traverse the sensor This code only looks for honeybees moving faster than 650ms.
  *  
- *  
- *  
- *  
  */
+
+// Map of sensor number onto input pin on shift register (sensor number % 8 = pin number, int(sensor number / 8) = shift register number)
+uint8_t gatemap[] = {
+	0b00100000,	// Gate 0 (1I)
+	0b00010000,	// Gate 1 (1O)
+	0b10000000,	// Gate 2 (2I)
+	0b01000000,	// Gate 3 (2O)
+	0b00000100,	// Gate 4 (3I)
+	0b00001000,	// Gate 5 (3O)
+	0b00000001,	// Gate 6 (4I)
+	0b00000010,	// Gate 7 (4O)
+};
 
 #include <SPI.h>
 
-const int testLed = 13; //onboard LED
-const int LATCH = A5; 
+#define testLed  13 //onboard LED
+#define LATCH    A5 // Shift Register Latch Control Pin
 
+// Use compile-time macrod defined from build.board in boards.txt to determine which board type.
 //Pins Feather ESP32
-const byte powerGates1 = 15;
-const byte powerGates2 = 33;
-
+#if defined ARDUINO_FEATHER_ESP32
+#define powerGates1 15
+#define powerGates2 33
 //Pins ItsyBitsy
-//const byte powerGates1 = 10;
-//const byte powerGates2 = 11;
+#elif defined ARDUINO_ITSYBITSY_M0
+#define powerGates1 10
+#define powerGates2 11
+#else
+#warning Unknown board type, defaulting to ESP32 Feather Pinout
+#define powerGates1 15
+#define powerGates2 33
+#endif
 
-
-const int numberOfGates = 24; // 24 gates, 48 sensors
-const int startGate = 0;  //useful for testing
-const int endGate = 24;   //useful for testing
-const int debeebounce = 30;
-const int outputDelay = 15000;  //prints bee counts every 15 seconds
-unsigned long lastOutput = 0;
-unsigned long currentTime = 0;
-
+#define numberOfGates 24
+#define startGate 0
+#define endGate 24
+#define debeebounce 30
+#define outputDelay 15000
+uint32_t lastOutput = 0;
+uint32_t currentTime = 0;
 
 //boolean 0 or 1 sensor readings, 1 bee is present
 boolean inSensorReading[numberOfGates];
@@ -69,42 +84,76 @@ boolean lastOutSensorReading[numberOfGates];
 boolean checkStateIn[numberOfGates];
 boolean checkStateOut[numberOfGates];
 
-int inCount[numberOfGates];
-int outCount[numberOfGates];
+int16_t inCount[numberOfGates];
+int16_t outCount[numberOfGates];
   
-unsigned long startInReadingTime[numberOfGates];
-unsigned long startOutReadingTime[numberOfGates];
+uint32_t startInReadingTime[numberOfGates];
+uint32_t startOutReadingTime[numberOfGates];
 
-unsigned long inSensorTime[numberOfGates];
-unsigned long outSensorTime[numberOfGates];
+uint32_t inSensorTime[numberOfGates];
+uint32_t outSensorTime[numberOfGates];
  
-unsigned long lastInFinishedTime[numberOfGates];
-unsigned long lastOutFinishedTime[numberOfGates];
+uint32_t lastInFinishedTime[numberOfGates];
+uint32_t lastOutFinishedTime[numberOfGates];
   
-unsigned long inReadingTimeHigh[numberOfGates];
-unsigned long outReadingTimeHigh[numberOfGates];
+uint32_t inReadingTimeHigh[numberOfGates];
+uint32_t outReadingTimeHigh[numberOfGates];
 
-unsigned long lastInTime[numberOfGates];
-unsigned long lastOutTime[numberOfGates];
+uint32_t lastInTime[numberOfGates];
+uint32_t lastOutTime[numberOfGates];
 
-unsigned long lastInReadingTimeHigh[numberOfGates];
-unsigned long lastOutReadingTimeHigh[numberOfGates];
+uint32_t lastInReadingTimeHigh[numberOfGates];
+uint32_t lastOutReadingTimeHigh[numberOfGates];
 
-int totalTimeTravelGoingOut[numberOfGates];
-int totalTimeTravelGoingIn[numberOfGates];
+int16_t totalTimeTravelGoingOut[numberOfGates];
+int16_t totalTimeTravelGoingIn[numberOfGates];
 
-int firstTestInVariable[numberOfGates];
-
-
-int firstTestOutVariable[numberOfGates];
+int16_t firstTestInVariable[numberOfGates];
 
 
-int inTotal;
-int outTotal;
+int16_t firstTestOutVariable[numberOfGates];
+
+
+uint16_t inTotal;
+uint16_t outTotal;
 
 
 int n = 0;
 
+
+uint8_t switchBank[numberOfGates / 4]; // 4 gates per chip, 8 sensors
+uint8_t oldSwitchBank[numberOfGates / 4];
+
+void sensor_to_name (uint8_t sensor, char *buf)
+{
+  // Take a sensor number and convert it to a gate name
+  // Gate name is placed in buffer (must be at least 4 bytes)
+  snprintf(buf, 4, "%0d%c", (sensor >> 1), (sensor % 2) ? 'O' : 'I');
+}
+
+bool get_sensor_value(uint8_t sensor)
+{
+  uint8_t byte;
+  uint8_t result;
+  uint8_t bit_position;
+
+  byte = sensor / 8;
+  result = switchBank[byte] & gatemap[(sensor % 8)];
+  if (result) return(true);
+  return(false);
+}
+
+bool get_o_sensor_value(uint8_t sensor)
+{
+  uint8_t byte;
+  uint8_t result;
+  uint8_t bit_position;
+
+  byte = sensor / 8;
+  result = oldSwitchBank[byte] & gatemap[(sensor % 8)];
+  if (result) return(true);
+  return(false);
+}
 
 
 void setup ()
@@ -118,39 +167,21 @@ void setup ()
   pinMode (LATCH, OUTPUT);
   digitalWrite (LATCH, HIGH);
 
-  pinMode (chipSelect1, OUTPUT);
-  digitalWrite(chipSelect1, LOW);
-  pinMode (chipSelect2, OUTPUT);
-  digitalWrite(chipSelect2, LOW);
-
   pinMode (powerGates1, OUTPUT);
   digitalWrite(powerGates1, LOW);
   pinMode (powerGates2, OUTPUT);
   digitalWrite(powerGates2, LOW);
 
   pinMode(testLed, OUTPUT);
+
+  memset(switchBank, 0, (numberOfGates / 4));
+  memset(oldSwitchBank, 0, (numberOfGates / 4));
   
 }  // end of setup
 
-byte switchBank1;
-byte oldSwitchBank1; 
-byte switchBank2;
-byte oldSwitchBank2; 
-byte switchBank3;
-byte oldSwitchBank3; 
-byte switchBank4;
-byte oldSwitchBank4; 
-byte switchBank5;
-byte oldSwitchBank5; 
-byte switchBank6;
-byte oldSwitchBank6; 
-byte switchBank7;
-byte oldSwitchBank7; 
-byte switchBank8;
-byte oldSwitchBank8; 
-
 void loop ()
 {
+  uint8_t gate;
   currentTime = millis();  
   
   digitalWrite(powerGates1, HIGH);
@@ -169,91 +200,20 @@ void loop ()
   //Reading 24 bits at 1Mhz should take about 24 microseconds,
   //reading 24 bits at 3Mhz should take about 8us
   //reading 48 bits at 3Mhz should take abotu 16us
-  switchBank1 = SPI.transfer (0); //8
-  switchBank2 = SPI.transfer (0); //16
-  switchBank3 = SPI.transfer (0); //24
-  switchBank4 = SPI.transfer (0); //32
-  switchBank5 = SPI.transfer (0); //40
-  switchBank6 = SPI.transfer (0); //48  
-  
+  (void) SPI.transfer(switchBank, (numberOfGates / 4));
  
   
-  if(switchBank1 != oldSwitchBank1 || switchBank2 != oldSwitchBank2 || switchBank3 != oldSwitchBank3 || switchBank4 != oldSwitchBank4 || switchBank5 != oldSwitchBank5 || switchBank6 != oldSwitchBank6)
+  
+  // Store received values from gate scan if changed
+  if (memcmp(switchBank, oldSwitchBank, (numberOfGates / 4)))
   {
-    //convert bytes to gate values
-    int gate = 0;
-    for(int i = 0; i < 8; i++)
+    for(gate=0; gate < numberOfGates; gate++)
     {
-      if((switchBank1 >> i) & 1)
-          outSensorReading[gate] = HIGH;
-      else outSensorReading[gate] = LOW;
-      i++;
-      if((switchBank1 >> i) & 1)
-          inSensorReading[gate] = HIGH;
-      else inSensorReading[gate] = LOW;       
-      gate++;  
+      inSensorReading[gate] = get_sensor_value(gate * 2);			// Even number sensors are inside
+      outSensorReading[gate] = get_sensor_value(gate * 2 + 1);		// Odd number gates are outside
     }
-    for(int i = 0; i < 8; i++)
-    {
-      if((switchBank2 >> i) & 1)
-          outSensorReading[gate] = HIGH;
-      else outSensorReading[gate] = LOW;
-      i++;
-      if((switchBank2 >> i) & 1)
-          inSensorReading[gate] = HIGH;
-      else inSensorReading[gate] = LOW;      
-      gate++;  
-    }
-    for(int i = 0; i < 8; i++)
-    {
-      if((switchBank3 >> i) & 1)
-          outSensorReading[gate] = HIGH;
-      else outSensorReading[gate] = LOW;
-      i++;
-      if((switchBank3 >> i) & 1)
-          inSensorReading[gate] = HIGH;
-      else inSensorReading[gate] = LOW;       
-      gate++;  
-    }
-    for(int i = 0; i < 8; i++)
-    {
-      if((switchBank4 >> i) & 1)
-          outSensorReading[gate] = HIGH;
-      else outSensorReading[gate] = LOW;
-      i++;
-      if((switchBank4 >> i) & 1)
-          inSensorReading[gate] = HIGH;
-      else inSensorReading[gate] = LOW;       
-      gate++;  
-    }
-    for(int i = 0; i < 8; i++)
-    {
-      if((switchBank5 >> i) & 1)
-          outSensorReading[gate] = HIGH;
-      else outSensorReading[gate] = LOW;
-      i++;
-      if((switchBank5 >> i) & 1)
-          inSensorReading[gate] = HIGH;
-      else inSensorReading[gate] = LOW;       
-      gate++;  
-    }
-    for(int i = 0; i < 8; i++)
-    {
-      if((switchBank6 >> i) & 1)
-          outSensorReading[gate] = HIGH;
-      else outSensorReading[gate] = LOW;
-      i++;
-      if((switchBank6 >> i) & 1)
-          inSensorReading[gate] = HIGH;
-      else inSensorReading[gate] = LOW;      
-      gate++;  
-    }  
-    oldSwitchBank1 = switchBank1;
-    oldSwitchBank2 = switchBank2;
-    oldSwitchBank3 = switchBank3;
-    oldSwitchBank4 = switchBank4;
-    oldSwitchBank5 = switchBank5;
-    oldSwitchBank6 = switchBank6;
+    // Move current retrieved values to old values for comparison
+    memcpy(oldSwitchBank, switchBank, (numberOfGates / 4));
   }
 
   for (int i = startGate; i < endGate; i++) 

--- a/arduino/bee_counting/bee_counting.ino
+++ b/arduino/bee_counting/bee_counting.ino
@@ -33,8 +33,11 @@
  *  It takes a honey bee around 250ms to traverse the sensor This code only looks for honeybees moving faster than 650ms.
  *  
  */
+#define REV	1
+
 
 // Map of sensor number onto input pin on shift register (sensor number % 8 = pin number, int(sensor number / 8) = shift register number)
+#if REV >= 2
 uint8_t gatemap[] = {
 	0b00100000,	// Gate 0 (1I)
 	0b00010000,	// Gate 1 (1O)
@@ -45,6 +48,18 @@ uint8_t gatemap[] = {
 	0b00000001,	// Gate 6 (4I)
 	0b00000010,	// Gate 7 (4O)
 };
+#else
+uint8_t gatemap[] = {
+        0b00000001,     // Gate 0 (1I)
+        0b00000010,     // Gate 1 (1O)
+        0b00000100,     // Gate 2 (2I)
+        0b00001000,     // Gate 3 (2O)
+        0b00010000,     // Gate 4 (3I)
+        0b00100000,     // Gate 5 (3O)
+        0b01000000,     // Gate 6 (4I)
+        0b10000000,     // Gate 7 (4O)
+};
+#endif
 
 #include <SPI.h>
 
@@ -200,7 +215,7 @@ void loop ()
   //Reading 24 bits at 1Mhz should take about 24 microseconds,
   //reading 24 bits at 3Mhz should take about 8us
   //reading 48 bits at 3Mhz should take abotu 16us
-  (void) SPI.transfer(switchBank, (numberOfGates / 4));
+  (void) SPI.transfer((uint8_t *)switchBank, (uint32_t)(numberOfGates / 4));
  
   
   

--- a/arduino/test_shift_registers/test_shift_registers.ino
+++ b/arduino/test_shift_registers/test_shift_registers.ino
@@ -1,9 +1,16 @@
 /*
  * For more help on reading shift registers: http://www.gammon.com.au/forum/?id=11979
  *  
+ * Original design, preserved here for reference:
  *   gate     0   ||  1  ||  2  ||  3  ||  4   ||   5  ||  6   ||  7   ||  8   ||  9   ||  10  ||  11  ||  12  ||  13  ||  14  ||  15  ||  16  ||  17  ||  18  ||  19  ||  20  ||  21  ||  22  ||  23
  *   inside   1   ||  3  ||  5  ||  7  ||  9   ||  11  ||  13  ||  15  ||  17  ||  19  ||  21  ||  23  ||  25  ||  27  ||  29  ||  31  ||  33  ||  35  ||  37  ||  39  ||  41  ||  43  ||  45  ||  47
  *   outside  2   ||  4  ||  6  ||  8  ||  10  ||  12  ||  14  ||  16  ||  18  ||  20  ||  22  ||  24  ||  26  ||  28  ||  30  ||  32  ||  34  ||  36  ||  38  ||  40  ||  42  ||  44  ||  46  ||  48
+ *
+ * New design, simpler PCB layout:
+ *   gate    ||  00  ||  01  ||  02  ||  03  ||  04  ||  05  ||  06  ||  07  ||  08  ||  09  ||  10  ||  11  ||  12  ||  13  ||  14  ||  15  ||  16  ||  17  ||  18  ||  19  ||  20  ||  21  ||  22  ||  23  ||
+ *   inside  ||   5  ||   7  ||   2  ||   0  ||  13  ||  15  ||  10  ||   8  ||  21  ||  23  ||  18  ||  16  ||  29  ||  31  ||  26  ||  24  ||  37  ||  39  ||  34  ||  32  ||  45  ||  47  ||  42  ||  40  ||
+ *   outside ||   4  ||   6  ||   3  ||   1  ||  12  ||  14  ||  11  ||   9  ||  20  ||  22  ||  19  ||  17  ||  28  ||  30  ||  27  ||  25  ||  36  ||  38  ||  35  ||  33  ||  44  ||  46  ||  43  ||  41  ||
+ *
  * 
  *  HOW long can we drive the LEDs ON without current limiting resistors?
  *  LED timed pulse (tp) allowance vs period (T)
@@ -17,17 +24,71 @@
  */
 
 
+uint8_t gatemap[] = {
+	0b00100000,	// Gate 0 (1I)
+	0b00010000,	// Gate 1 (1O)
+	0b10000000,	// Gate 2 (2I)
+	0b01000000,	// Gate 3 (2O)
+	0b00000100,	// Gate 4 (3I)
+	0b00001000,	// Gate 5 (3O)
+	0b00000001,	// Gate 6 (4I)
+	0b00000010,	// Gate 7 (4O)
+};
+
+
+
 #include <SPI.h>
 
-const int LATCH = A5; 
+#define LATCH A5
 
+// Use compile-time macrod defined from build.board in boards.txt to determine which board type.
 //Pins Feather ESP32
-const byte powerGates1 = 15;
-const byte powerGates2 = 33;
-
+#if defined ARDUINO_FEATHER_ESP32
+#define powerGates1 15
+#define powerGates2 33
 //Pins ItsyBitsy
-//const byte powerGates1 = 10;
-//const byte powerGates2 = 11;
+#elif defined ARDUINO_ITSYBITSY_M0
+#define powerGates1 = 10
+#define powerGates2 = 11
+#else
+#warning Unknown board type, defaulting to ESP32 Feather Pinout
+#define powerGates1 15
+#define powerGates2 33
+#endif
+
+uint8_t sensors[6];
+uint8_t o_sensors[6];
+
+void sensor_to_name (uint8_t sensor, char *buf)
+{
+  // Take a sensor number and convert it to a gate name
+  // Gate name is placed in buffer (must be at least 4 bytes)
+  snprintf(buf, 4, "%0d%c", (sensor >> 1), (sensor % 2) ? 'O' : 'I');
+}
+
+bool get_sensor_value(uint8_t sensor)
+{
+  uint8_t byte;
+  uint8_t result;
+  uint8_t bit_position;
+
+  byte = sensor / 8;
+  result = sensors[byte] & gatemap[(sensor % 8)];
+  if (result) return(true);
+  return(false);
+}
+
+bool get_o_sensor_value(uint8_t sensor)
+{
+  uint8_t byte;
+  uint8_t result;
+  uint8_t bit_position;
+
+  byte = sensor / 8;
+  result = o_sensors[byte] & gatemap[(sensor % 8)];
+  if (result) return(true);
+  return(false);
+}
 
 void setup ()
 {
@@ -47,23 +108,20 @@ void setup ()
   pinMode (powerGates2, OUTPUT);
   digitalWrite(powerGates2, LOW);
   
+  memset(sensors, 0, 6);
+  memset(o_sensors, 0, 6);
 }  // end of setup
 
-byte switchBank1;
-byte oldSwitchBank1; 
-byte switchBank2;
-byte oldSwitchBank2; 
-byte switchBank3;
-byte oldSwitchBank3; 
-byte switchBank4;
-byte oldSwitchBank4; 
-byte switchBank5;
-byte oldSwitchBank5; 
-byte switchBank6;
-byte oldSwitchBank6; 
 
 void loop ()
 {
+  uint8_t result;
+  uint8_t sensor;
+  bool o_value;
+  bool value;
+  char name[4];
+  char output[60];
+
   digitalWrite(powerGates1, HIGH);
   digitalWrite(powerGates2, HIGH);
   delayMicroseconds(75); //first 24 gates only need 15us while gates closer to the end need ~40us-75us
@@ -78,106 +136,20 @@ void loop ()
   digitalWrite(powerGates1, LOW);
   digitalWrite(powerGates2, LOW);
 
-  switchBank1 = SPI.transfer (0); //8
-  switchBank2 = SPI.transfer (0); //16
-  switchBank3 = SPI.transfer (0); //24
-  switchBank4 = SPI.transfer (0); //32
-  switchBank5 = SPI.transfer (0); //40
-  switchBank6 = SPI.transfer (0); //48  
-  
-  
-  byte mask = 1;
-  int sensor = 1;
-  for (int i = 1; i <= 8; i++)
-  {
-    if ((switchBank1 & mask) != (oldSwitchBank1 & mask))
-      {
-      Serial.print ("Switch ");
-      Serial.print (sensor);
-      Serial.print (" ");
-      Serial.println ((switchBank1 & mask) ? "ir triggered" : "none");
-      }  // end of bit has changed
-    mask <<= 1; 
-    sensor++; 
-  }  // end of for each bit
-  mask = 1;
-  sensor = 9;
-  for (int i = 1; i <= 8; i++)
-  {
-    if ((switchBank2 & mask) != (oldSwitchBank2 & mask))
-      {
-      Serial.print ("Switch ");
-      Serial.print (sensor);
-      Serial.print (" ");
-      Serial.println ((switchBank2 & mask) ? "ir triggered" : "none");
-      
-      }  // end of bit has changed
-    mask <<= 1; 
-    sensor++; 
-  }  // end of for each bit
-  mask = 1;
-  sensor = 17;
-  for (int i = 1; i <= 8; i++)
-  {
-    if ((switchBank3 & mask) != (oldSwitchBank3 & mask))
-    {
-      Serial.print ("Switch ");
-      Serial.print (sensor);
-      Serial.print (" ");
-      Serial.println ((switchBank3 & mask) ? "ir triggered" : "none");
-    }  // end of bit has changed
-    mask <<= 1;
-    sensor++;  
-  }  // end of for each bit
-  mask = 1;
-  sensor = 25;
-  for (int i = 1; i <= 8; i++)
-  {
-    if ((switchBank4 & mask) != (oldSwitchBank4 & mask))
-    {
-      Serial.print ("Switch ");
-      Serial.print (sensor);
-      Serial.print (" ");
-      Serial.println ((switchBank4 & mask) ? "ir triggered" : "none");
-    }  // end of bit has changed
-    mask <<= 1; 
-    sensor++; 
-  }  // end of for each bit
-  mask = 1;
-  sensor = 33;
-  for (int i = 1; i <= 8; i++)
-  {
-    if ((switchBank5 & mask) != (oldSwitchBank5 & mask))
-    {
-      Serial.print ("Switch ");
-      Serial.print (sensor);
-      Serial.print (" ");
-      Serial.println ((switchBank5 & mask) ? "ir triggered" : "none");
-    }  // end of bit has changed
-    mask <<= 1; 
-    sensor++; 
-  }  // end of for each bit
-  mask = 1;
-  sensor = 41;
-  for (int i = 1; i <= 8; i++)
-  {
-    if ((switchBank6 & mask) != (oldSwitchBank6 & mask))
-    {
-      Serial.print ("Switch ");
-      Serial.print (sensor);
-      Serial.print (" ");
-      Serial.println ((switchBank6 & mask) ? "ir triggered" : "none");
-    }  // end of bit has changed
-    mask <<= 1;  
-    sensor++;
-  }  // end of for each bit
+  (void) SPI.transfer(sensors, 6); // Sends 6 octets currently in sensors out MOSI and replaces it with 6 octets read in from MISO  
 
-  oldSwitchBank1 = switchBank1;
-  oldSwitchBank2 = switchBank2;
-  oldSwitchBank3 = switchBank3;
-  oldSwitchBank4 = switchBank4;
-  oldSwitchBank5 = switchBank5;
-  oldSwitchBank6 = switchBank6;
-
+  // Work through sensors in order and display any that have changed.
+  for(sensor = 0; sensor < 48; sensor++)
+  {
+    value = get_sensor_value(sensor);
+    o_value = get_o_sensor_value(sensor);
+    sensor_to_name(sensor, name);
+    if (value != o_value)
+    {
+      snprintf(output, 60, "Sensor: %s %s\n", name, value ? "Triggered" : "not triggered");
+      Serial.print(output);
+    }
+  }
+  memcpy(o_sensors, sensors, 6);
   delay (20);   // must be greater than 7.5ms (see notes at top of code)
 }  // end of loop

--- a/arduino/test_shift_registers/test_shift_registers.ino
+++ b/arduino/test_shift_registers/test_shift_registers.ino
@@ -25,18 +25,33 @@
  *  
  */
 
+#define REV     1
 
+
+// Map of sensor number onto input pin on shift register (sensor number % 8 = pin number, int(sensor number / 8) = shift register number)
+#if REV >= 2
 uint8_t gatemap[] = {
-	0b00100000,	// Gate 0 (1I)
-	0b00010000,	// Gate 1 (1O)
-	0b10000000,	// Gate 2 (2I)
-	0b01000000,	// Gate 3 (2O)
-	0b00000100,	// Gate 4 (3I)
-	0b00001000,	// Gate 5 (3O)
-	0b00000001,	// Gate 6 (4I)
-	0b00000010,	// Gate 7 (4O)
+        0b00100000,     // Gate 0 (1I)
+        0b00010000,     // Gate 1 (1O)
+        0b10000000,     // Gate 2 (2I)
+        0b01000000,     // Gate 3 (2O)
+        0b00000100,     // Gate 4 (3I)
+        0b00001000,     // Gate 5 (3O)
+        0b00000001,     // Gate 6 (4I)
+        0b00000010,     // Gate 7 (4O)
 };
-
+#else
+uint8_t gatemap[] = {
+        0b00000001,     // Gate 0 (1I)
+        0b00000010,     // Gate 1 (1O)
+        0b00000100,     // Gate 2 (2I)
+        0b00001000,     // Gate 3 (2O)
+        0b00010000,     // Gate 4 (3I)
+        0b00100000,     // Gate 5 (3O)
+        0b01000000,     // Gate 6 (4I)
+        0b10000000,     // Gate 7 (4O)
+};
+#endif
 
 
 #include <SPI.h>

--- a/arduino/test_shift_registers/test_shift_registers.ino
+++ b/arduino/test_shift_registers/test_shift_registers.ino
@@ -1,16 +1,18 @@
 /*
  * For more help on reading shift registers: http://www.gammon.com.au/forum/?id=11979
  *  
- * Original design, preserved here for reference:
+ * Gate Map (sensor numbers):
  *   gate     0   ||  1  ||  2  ||  3  ||  4   ||   5  ||  6   ||  7   ||  8   ||  9   ||  10  ||  11  ||  12  ||  13  ||  14  ||  15  ||  16  ||  17  ||  18  ||  19  ||  20  ||  21  ||  22  ||  23
  *   inside   1   ||  3  ||  5  ||  7  ||  9   ||  11  ||  13  ||  15  ||  17  ||  19  ||  21  ||  23  ||  25  ||  27  ||  29  ||  31  ||  33  ||  35  ||  37  ||  39  ||  41  ||  43  ||  45  ||  47
  *   outside  2   ||  4  ||  6  ||  8  ||  10  ||  12  ||  14  ||  16  ||  18  ||  20  ||  22  ||  24  ||  26  ||  28  ||  30  ||  32  ||  34  ||  36  ||  38  ||  40  ||  42  ||  44  ||  46  ||  48
  *
- * New design, simpler PCB layout:
+ * Gate Map (bit numbers):
  *   gate    ||  00  ||  01  ||  02  ||  03  ||  04  ||  05  ||  06  ||  07  ||  08  ||  09  ||  10  ||  11  ||  12  ||  13  ||  14  ||  15  ||  16  ||  17  ||  18  ||  19  ||  20  ||  21  ||  22  ||  23  ||
  *   inside  ||   5  ||   7  ||   2  ||   0  ||  13  ||  15  ||  10  ||   8  ||  21  ||  23  ||  18  ||  16  ||  29  ||  31  ||  26  ||  24  ||  37  ||  39  ||  34  ||  32  ||  45  ||  47  ||  42  ||  40  ||
  *   outside ||   4  ||   6  ||   3  ||   1  ||  12  ||  14  ||  11  ||   9  ||  20  ||  22  ||  19  ||  17  ||  28  ||  30  ||  27  ||  25  ||  36  ||  38  ||  35  ||  33  ||  44  ||  46  ||  43  ||  41  ||
  *
+ * The bit numbers map is layed out such that bits 0-7 map to the bits with values 2^0 through 2^7 respectively in the first octet transferred.
+ * Bits 8-15 map similarly onto the second octet and so on.
  * 
  *  HOW long can we drive the LEDs ON without current limiting resistors?
  *  LED timed pulse (tp) allowance vs period (T)


### PR DESCRIPTION
This puts the sense pins on the 74*165 serial chips in an order closer to the position of the attached sensors and puts them in a rational order on the SIP resistors as well.

The layout out of the chips is:
```
16 15 14 13 12 11 10 9
      D  C  B  A
>
      E  F  G  H
1  2  3  4  5  6  7  8
```

This new schematic results in the SIP pack being connected as follows:
```
E F G H D C B A <COMMON>
```

This results in a left to right pin order on the resistor pack which is (e.g.)
1 Outside
1 Inside
2 Outside
2 Inside
3 Outside
3 Inside
4 Outside
4 Inside

(This is repeated for packs 5/6/7/8, 9/10/11/12, etc.)

Doing it this way made it possible to route the sense lines in a much more compact manner on the board which freed up space to place headers to connect servos.
